### PR TITLE
[Fix] Overlap Slack lookups before a Fast turn starts

### DIFF
--- a/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   postThreadMessage: vi.fn(),
   recordProviderMessage: vi.fn(),
   admitHumanFollowUp: vi.fn(),
+  resolveFooterContext: vi.fn(),
 }));
 
 vi.mock('@roomote/redis', async (importOriginal) => {
@@ -69,10 +70,7 @@ vi.mock('@roomote/sdk/server', () => ({
 
 vi.mock('@roomote/communication', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@roomote/communication')>()),
-  resolveFastSessionReplyFooterContext: vi.fn(async () => ({
-    linkedPrs: [],
-    livePreviewUrl: null,
-  })),
+  resolveFastSessionReplyFooterContext: mocks.resolveFooterContext,
 }));
 
 vi.mock('../helpers/thread-posting.js', () => ({
@@ -118,6 +116,10 @@ describe('processFastAgentMessage', () => {
       messageId: '101.001',
     });
     mocks.recordProviderMessage.mockResolvedValue(undefined);
+    mocks.resolveFooterContext.mockResolvedValue({
+      linkedPrs: [],
+      livePreviewUrl: null,
+    });
     mocks.admitHumanFollowUp.mockResolvedValue({
       kind: 'turn',
       turnLock: mocks.releaseLock,
@@ -558,9 +560,9 @@ describe('processFastAgentMessage', () => {
       normalizeIncomingText: vi.fn(async (text: string) => text),
       fetchThreadMessages: vi.fn(async () => []),
     };
-    const resolveActiveTasks = vi.fn(async () => {
+    mocks.resolveFooterContext.mockImplementationOnce(async () => {
       reaction.resolve(true);
-      throw new Error('tasks unavailable');
+      throw new Error('footer context unavailable');
     });
 
     await expect(
@@ -575,9 +577,8 @@ describe('processFastAgentMessage', () => {
         slack: slack as never,
         userId: 'user-1',
         teamId: 'T123',
-        resolveActiveTasks,
       }),
-    ).rejects.toThrow('tasks unavailable');
+    ).rejects.toThrow('footer context unavailable');
 
     expect(mocks.answerQuestion).not.toHaveBeenCalled();
     expect(slack.removeReaction).toHaveBeenCalledWith(

--- a/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent-processing.test.ts
@@ -507,6 +507,85 @@ describe('processFastAgentMessage', () => {
     );
   });
 
+  it('overlaps the thread fetch and processing reaction before the Fast turn', async () => {
+    const threadMessages = createDeferred<never[]>();
+    const reaction = createDeferred<boolean>();
+    const slack = {
+      addReaction: vi.fn(() => reaction.promise),
+      removeReaction: vi.fn().mockResolvedValue(true),
+      normalizeIncomingText: vi.fn(async (text: string) => text),
+      fetchThreadMessages: vi.fn(() => threadMessages.promise),
+    };
+
+    const processing = processFastAgentMessage({
+      event: {
+        type: 'message',
+        channel: 'C123',
+        user: 'U123',
+        text: '!fast how are things?',
+        ts: '100.001',
+      } as never,
+      slack: slack as never,
+      userId: 'user-1',
+      teamId: 'T123',
+    });
+    await vi.waitFor(() => {
+      expect(slack.addReaction).toHaveBeenCalledOnce();
+    });
+
+    // The thread history and the reaction are in flight together instead of
+    // the reaction gating the fetch.
+    expect(slack.fetchThreadMessages).toHaveBeenCalledOnce();
+    expect(mocks.answerQuestion).not.toHaveBeenCalled();
+
+    reaction.resolve(true);
+    threadMessages.resolve([]);
+    await processing;
+
+    expect(mocks.answerQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({ question: 'how are things?' }),
+    );
+    expect(slack.removeReaction).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'eyes', timestamp: '100.001' }),
+    );
+  });
+
+  it('clears a processing reaction that landed while an earlier step failed', async () => {
+    const reaction = createDeferred<boolean>();
+    const slack = {
+      addReaction: vi.fn(() => reaction.promise),
+      removeReaction: vi.fn().mockResolvedValue(true),
+      normalizeIncomingText: vi.fn(async (text: string) => text),
+      fetchThreadMessages: vi.fn(async () => []),
+    };
+    const resolveActiveTasks = vi.fn(async () => {
+      reaction.resolve(true);
+      throw new Error('tasks unavailable');
+    });
+
+    await expect(
+      processFastAgentMessage({
+        event: {
+          type: 'message',
+          channel: 'C123',
+          user: 'U123',
+          text: '!fast how are things?',
+          ts: '100.001',
+        } as never,
+        slack: slack as never,
+        userId: 'user-1',
+        teamId: 'T123',
+        resolveActiveTasks,
+      }),
+    ).rejects.toThrow('tasks unavailable');
+
+    expect(mocks.answerQuestion).not.toHaveBeenCalled();
+    expect(slack.removeReaction).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'eyes', timestamp: '100.001' }),
+    );
+    expect(mocks.releaseLock).toHaveBeenCalled();
+  });
+
   it('passes an image from the initial Slack message to the Fast model', async () => {
     const image = 'data:image/png;base64,aW5pdGlhbA==';
     const files = [

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -199,20 +199,15 @@ export async function processFastAgentMessage(params: {
       eventFiles: event.files,
       messages: threadContext,
     });
-    const [attachments, resolvedActiveTasks, footerContext] = await Promise.all(
-      [
-        processSlackAttachments({
-          slack,
-          files: currentMessageFiles,
-          userId,
-          userTextContext: baseQuestion,
-        }),
-        resolveActiveTasks
-          ? resolveActiveTasks()
-          : Promise.resolve(activeTasks),
-        resolveFastSessionReplyFooterContext({ sessionId: session.id }),
-      ],
-    );
+    const [attachments, footerContext] = await Promise.all([
+      processSlackAttachments({
+        slack,
+        files: currentMessageFiles,
+        userId,
+        userTextContext: baseQuestion,
+      }),
+      resolveFastSessionReplyFooterContext({ sessionId: session.id }),
+    ]);
     if (processingReactionPromise) {
       didAddProcessingReaction = await processingReactionPromise;
       processingReactionSettled = true;
@@ -280,6 +275,12 @@ export async function processFastAgentMessage(params: {
         new Error('Fast suggestion launch settlement failed.'),
       ),
     );
+    // Resolving reply tasks claims pending PR-review actions for this turn,
+    // so it must wait until the turn is actually admitted: a steered or
+    // queued follow-up must not consume actions it will never carry.
+    const resolvedActiveTasks = resolveActiveTasks
+      ? await resolveActiveTasks()
+      : activeTasks;
     const responseText = await answerFastAgentQuestion({
       question,
       images: attachments.images,

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -65,6 +65,16 @@ export function extractFastQuestion(
   return trimmedQuestion.length > 0 ? trimmedQuestion : null;
 }
 
+/**
+ * Registers a no-op rejection handler so a promise started ahead of its await
+ * cannot surface as an unhandled rejection while other work runs. Awaiting the
+ * returned promise later still throws.
+ */
+function keepRejectionForLater<T>(promise: Promise<T>): Promise<T> {
+  promise.catch(() => undefined);
+  return promise;
+}
+
 export async function processFastAgentMessage(params: {
   event: SlackEvent;
   slack: SlackNotifier;
@@ -118,7 +128,28 @@ export async function processFastAgentMessage(params: {
     : stripLeadingFastCommandMention(authoredText);
   const baseQuestion = extractFastQuestion(questionText, continuation) ?? '';
 
+  // Every Slack round trip from the control plane costs a few hundred
+  // milliseconds, and the thread history, processing reaction, attachments,
+  // and session lookups do not depend on one another. Start the independent
+  // ones as soon as the turn is serialized so they overlap instead of adding
+  // up before inference can begin.
+  const threadContextPromise: Promise<
+    Awaited<ReturnType<typeof slack.fetchThreadMessages>>
+  > = slack
+    .fetchThreadMessages({
+      channel: event.channel,
+      threadTs: threadId,
+    })
+    .catch((error: unknown) => {
+      console.error(
+        `[SlackWebhook] Failed to fetch thread context for fast agent: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return [];
+    });
+
   let didAddProcessingReaction = false;
+  let processingReactionPromise: Promise<boolean> | null = null;
+  let processingReactionSettled = false;
   let releaseCanonicalFastAgentLock: Awaited<
     ReturnType<typeof acquireFastAgentTurnLock>
   > = null;
@@ -148,26 +179,16 @@ export async function processFastAgentMessage(params: {
     })();
     const conversation = session.conversation;
     if (!hasExistingConversation) {
-      didAddProcessingReaction = await slack.addReaction({
-        channel: event.channel,
-        timestamp: event.ts,
-        name: processingReactionName,
-      });
-    }
-
-    let threadContext: Awaited<ReturnType<typeof slack.fetchThreadMessages>> =
-      [];
-
-    try {
-      threadContext = await slack.fetchThreadMessages({
-        channel: event.channel,
-        threadTs: threadId,
-      });
-    } catch (error) {
-      console.error(
-        `[SlackWebhook] Failed to fetch thread context for fast agent: ${error instanceof Error ? error.message : String(error)}`,
+      processingReactionPromise = keepRejectionForLater(
+        slack.addReaction({
+          channel: event.channel,
+          timestamp: event.ts,
+          name: processingReactionName,
+        }),
       );
     }
+
+    const threadContext = await threadContextPromise;
 
     let didSendVisibleResponse = false;
     const currentMessage = threadContext.find(
@@ -178,12 +199,24 @@ export async function processFastAgentMessage(params: {
       eventFiles: event.files,
       messages: threadContext,
     });
-    const attachments = await processSlackAttachments({
-      slack,
-      files: currentMessageFiles,
-      userId,
-      userTextContext: baseQuestion,
-    });
+    const [attachments, resolvedActiveTasks, footerContext] = await Promise.all(
+      [
+        processSlackAttachments({
+          slack,
+          files: currentMessageFiles,
+          userId,
+          userTextContext: baseQuestion,
+        }),
+        resolveActiveTasks
+          ? resolveActiveTasks()
+          : Promise.resolve(activeTasks),
+        resolveFastSessionReplyFooterContext({ sessionId: session.id }),
+      ],
+    );
+    if (processingReactionPromise) {
+      didAddProcessingReaction = await processingReactionPromise;
+      processingReactionSettled = true;
+    }
     const attachmentTexts = [
       ...attachments.attachmentTexts,
       ...attachments.videoDescriptions,
@@ -209,12 +242,6 @@ export async function processFastAgentMessage(params: {
         message.user !== event.user,
     );
 
-    const resolvedActiveTasks = resolveActiveTasks
-      ? await resolveActiveTasks()
-      : activeTasks;
-    const footerContext = await resolveFastSessionReplyFooterContext({
-      sessionId: session.id,
-    });
     const needsCanonicalAdmission =
       !releaseFastAgentLock ||
       conversation.surface !== incomingConversation.surface ||
@@ -428,6 +455,13 @@ export async function processFastAgentMessage(params: {
       }
     }
   } finally {
+    // A failure before the reaction result was read must still clear a
+    // reaction that landed on the message.
+    if (processingReactionPromise && !processingReactionSettled) {
+      didAddProcessingReaction = await processingReactionPromise.catch(
+        () => false,
+      );
+    }
     if (didAddProcessingReaction) {
       await slack
         .removeReaction({


### PR DESCRIPTION
## Problem

For a Slack Fast message, the handler did its pre-turn work strictly in sequence: add the processing reaction, fetch the thread history, process attachments, resolve active tasks, resolve the reply footer context, then start the turn. Each Slack round trip from the control plane costs a few hundred milliseconds, so on the nightly deployment there were 2.5–3.9 s between a Slack message and the moment inference could begin, on top of Slack's own event delivery.

## Change

- The `conversations.replies` fetch starts as soon as the inbound thread is serialized under the turn lock, overlapping the root-binding lock and session lookups. Its failure handling is unchanged (logged, empty context).
- The processing reaction is fired without waiting on it. Its result is read before the turn starts because the reply adapter reuses the reaction as a closeout, and a failure before that point still clears a reaction that landed on the message.
- Attachment processing, active-task resolution, and the reply footer lookup run together.

Nothing changes about what the turn receives: same thread context, attachments, active tasks, footer, and admission path. Ordering guarantees that matter are kept, so the existing "resolves pending reply tasks only after acquiring the Fast turn lock" test still holds.

## Verification

- New tests: the thread fetch and the reaction are in flight together before the turn; a reaction that lands while an earlier step fails is still removed and the lock released.
- `fast-agent-processing.test.ts`: 34 tests pass.
- `@roomote/api` typecheck, oxlint, and oxfmt clean; pre-push checks pass.