### PR TITLE
[Fix] End a Fast turn's inference once its closeout is delivered

### DIFF
--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-context-telemetry.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-context-telemetry.test.ts
@@ -209,6 +209,7 @@ describe('captureFastAgentInferenceContext', () => {
         completed_model_request_count: null,
         first_model_response_duration_ms: null,
         post_reply_inference_duration_ms: null,
+        aborted_after_closeout: null,
         input_tokens: null,
         cache_read_tokens: null,
         cache_write_tokens: null,

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -472,6 +472,67 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     );
   });
 
+  it('cuts the trailing model request once the closeout is delivered', async () => {
+    const adapter = callbacks();
+    const abortedAtSecondRequest = vi.fn();
+    mocks.generateText.mockImplementation(
+      async (_params, _session, options) => {
+        options.onModelResolved?.('openrouter/openai/gpt-5.4');
+        await options.onSessionReady('opencode-session-1');
+        options.onPromptStarted?.();
+        await options.onAssistantMessageStarted?.({
+          id: 'assistant-1',
+          sessionId: 'opencode-session-1',
+          parentId: 'user-1',
+          createdAtMs: 100,
+        });
+        await invokeTool(
+          nativeToolNames.sendChatReply,
+          { purpose: 'closeout', message: 'Done.' },
+          undefined,
+          'assistant-1',
+        );
+        const abortedBeforeNextRequest = options.signal?.aborted ?? false;
+        // OpenCode starts the next model request after the tool result.
+        await options.onAssistantMessageStarted?.({
+          id: 'assistant-2',
+          sessionId: 'opencode-session-1',
+          parentId: 'user-1',
+          createdAtMs: 200,
+        });
+        abortedAtSecondRequest(
+          abortedBeforeNextRequest,
+          options.signal?.aborted ?? false,
+        );
+        // The prompt runner surfaces the abort reason as the request error.
+        throw options.signal?.reason ?? new Error('not aborted');
+      },
+    );
+
+    const result = await answerFastAgentQuestion({
+      ...baseParams,
+      adapter,
+    });
+
+    expect(result).toBe('Done.');
+    expect(abortedAtSecondRequest).toHaveBeenCalledWith(false, true);
+    expect(adapter.postReply).toHaveBeenCalledOnce();
+    expect(adapter.postReply).toHaveBeenCalledWith({
+      purpose: 'closeout',
+      message: 'Done.',
+    });
+    expect(mocks.classifyInferenceError).not.toHaveBeenCalled();
+    expect(mocks.captureInferenceAttemptOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'success', attemptNumber: 1 }),
+    );
+    expect(mocks.captureTurnSettled).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: 'success',
+        abortedAfterCloseout: true,
+      }),
+    );
+  });
+
   it('posts an immediate answer through a native chat tool', async () => {
     const adapter = callbacks();
 

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-turn-diagnostics.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-turn-diagnostics.test.ts
@@ -147,10 +147,12 @@ describe('FastAgentTurnDiagnostics', () => {
       completedAtMs: 15_000,
       tokens: firstMessage.tokens,
     });
+    diagnostics.recordCloseoutAbort();
     diagnostics.markInferenceFinished();
     diagnostics.finish();
 
     const logMessage = logger.info.mock.calls[0]?.[0] as string;
+    expect(logMessage).toContain('abortedAfterCloseout=true');
     expect(logMessage).toContain('openCodeServerLeaseMs=400');
     expect(logMessage).toContain('openCodeSessionCreateMs=60');
     expect(logMessage).toContain('openCodeEventSubscribeMs=15');

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-context-telemetry.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-context-telemetry.ts
@@ -212,6 +212,7 @@ export function captureFastAgentTurnSettled(input: {
   completedModelRequestCount?: number;
   firstModelResponseDurationMs?: number;
   postReplyInferenceDurationMs?: number;
+  abortedAfterCloseout?: boolean;
   inputTokens?: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
@@ -256,6 +257,7 @@ export function captureFastAgentTurnSettled(input: {
         input.firstModelResponseDurationMs ?? null,
       post_reply_inference_duration_ms:
         input.postReplyInferenceDurationMs ?? null,
+      aborted_after_closeout: input.abortedAfterCloseout ?? null,
       input_tokens: input.inputTokens ?? null,
       cache_read_tokens: input.cacheReadTokens ?? null,
       cache_write_tokens: input.cacheWriteTokens ?? null,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -463,6 +463,18 @@ type FastAgentInferenceRetryOptions = {
   signal?: AbortSignal;
 };
 
+/**
+ * Abort reason for the OpenCode prompt once the turn has delivered its
+ * closeout. Any further model request would only produce post-closeout text
+ * that is never shown, while holding the conversation's turn lock.
+ */
+class FastAgentTurnClosedError extends Error {
+  constructor() {
+    super('The Fast turn delivered its closeout.');
+    this.name = 'FastAgentTurnClosedError';
+  }
+}
+
 class FastAgentInferenceError extends Error {
   constructor(
     public readonly failure: FastAgentInferenceFailure,
@@ -2858,9 +2870,12 @@ export async function answerFastAgentQuestion({
           const result = await runFastAgentInferenceWithRetries(
             async () => {
               const providerRetryAbortController = new AbortController();
-              const promptSignal = signal
-                ? AbortSignal.any([signal, providerRetryAbortController.signal])
-                : providerRetryAbortController.signal;
+              const closeoutAbortController = new AbortController();
+              const promptSignal = AbortSignal.any([
+                ...(signal ? [signal] : []),
+                providerRetryAbortController.signal,
+                closeoutAbortController.signal,
+              ]);
               let providerRetryTimeout:
                 | ReturnType<typeof setTimeout>
                 | undefined;
@@ -2946,13 +2961,30 @@ export async function answerFastAgentQuestion({
                         turnProgressMarker += 1;
                         noteInferenceRecoveryProgress();
                       },
-                      onAssistantMessageStarted: (
+                      onAssistantMessageStarted: async (
                         message: NonTaskOpenCodeAssistantMessage,
                       ) => {
                         diagnostics.recordAssistantMessageStarted();
                         assistantInstructionVersions.set(
                           message.id,
                           currentInstructionVersion,
+                        );
+                        if (!isInstructionClosed()) return;
+                        // A model request starting after the closeout is the
+                        // trailing request that only ever produces unseen
+                        // text. Let an in-flight steer drain land first: a
+                        // queued follow-up reopens the turn instead.
+                        await activeHumanSteerPoll.catch(() => undefined);
+                        if (
+                          !isInstructionClosed() ||
+                          activeToolExecutions > 0 ||
+                          closeoutAbortController.signal.aborted
+                        ) {
+                          return;
+                        }
+                        diagnostics.recordCloseoutAbort();
+                        closeoutAbortController.abort(
+                          new FastAgentTurnClosedError(),
                         );
                       },
                       onAssistantMessageCompleted: (message) => {
@@ -3041,6 +3073,25 @@ export async function answerFastAgentQuestion({
                 });
                 return result;
               } catch (error) {
+                if (closeoutAbortController.signal.aborted) {
+                  // The visible closeout already went out; the aborted
+                  // request was the trailing one. The turn is complete.
+                  captureFastAgentInferenceAttemptOutcome({
+                    userId,
+                    sessionId: session.id,
+                    turnId,
+                    surface: conversation.surface,
+                    sessionPath: attemptSessionPath,
+                    promptKind,
+                    attemptNumber: inferenceAttemptNumber,
+                    outcome: 'success',
+                    stage: 'model_generation',
+                    elapsedMs: Date.now() - attemptStartedAt,
+                    resolvedModel: resolvedInferenceModel,
+                    providerRetryEventCount,
+                  });
+                  return '';
+                }
                 const failure = classifyNonTaskInferenceError(error);
                 const attemptStage = !resolvedInferenceModel
                   ? 'model_resolution'

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-turn-diagnostics.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-turn-diagnostics.ts
@@ -103,6 +103,7 @@ export class FastAgentTurnDiagnostics {
   private firstModelResponseAt: number | undefined;
   private tokenTotals: TokenTotals | undefined;
   private maxContextTokens: number | undefined;
+  private abortedAfterCloseout = false;
   private openCodeProviderRetryEventCount = 0;
   private firstOpenCodeProviderRetryElapsedMs: number | undefined;
   private lastOpenCodeProviderRetryElapsedMs: number | undefined;
@@ -156,6 +157,11 @@ export class FastAgentTurnDiagnostics {
 
   recordPromptContext(context: FastAgentPromptContextStats): void {
     this.promptContext = context;
+  }
+
+  /** The trailing model request after the closeout was cut short. */
+  recordCloseoutAbort(): void {
+    this.abortedAfterCloseout = true;
   }
 
   /** One model request per assistant message OpenCode starts in the turn. */
@@ -411,6 +417,7 @@ export class FastAgentTurnDiagnostics {
       completedModelRequestCount: this.completedModelMessageIds.size,
       firstModelResponseDurationMs,
       postReplyInferenceDurationMs,
+      abortedAfterCloseout: this.abortedAfterCloseout,
       inputTokens: this.tokenTotals?.input,
       cacheReadTokens: this.tokenTotals?.cacheRead,
       cacheWriteTokens: this.tokenTotals?.cacheWrite,
@@ -470,6 +477,7 @@ export class FastAgentTurnDiagnostics {
       completedModelRequestCount: this.completedModelMessageIds.size,
       firstModelResponseDurationMs,
       postReplyInferenceDurationMs,
+      abortedAfterCloseout: this.abortedAfterCloseout,
       inputTokens: this.tokenTotals?.input,
       cacheReadTokens: this.tokenTotals?.cacheRead,
       cacheWriteTokens: this.tokenTotals?.cacheWrite,


### PR DESCRIPTION
Stacked on #2029 (diagnostics); retarget to `develop` once that merges.

## Problem

After `send_chat_reply` posts a closeout (or a closeout reaction or `ignore_event` ends the turn), OpenCode still starts one more model request to consume the tool result. The prompt tells the model to do nothing after a closeout, but the request happens regardless: it re-sends the full context, produces text nobody sees, and holds the conversation's turn lock for as long as the provider takes. On the nightly this was 10–25 s per turn (`inferenceDurationMs` minus `firstResponseDurationMs`), during which any follow-up in the same conversation queues behind a turn that is already done.

## Change

- When a new assistant message starts while the current instruction is closed, the turn aborts the OpenCode prompt with a dedicated reason. The prompt runner's existing abort path issues `session.abort` server-side, so the model stops generating rather than just the HTTP request being dropped.
- Before aborting, the handler waits for any in-flight native steer drain. A queued follow-up that reopens the turn (new instruction version) wins and the abort is skipped; the existing "steer after closeout" test covers that race.
- The inference attempt treats this abort as success (the visible reply already went out) and returns an empty prompt text, which the closed turn ignores. No retry, no failure classification, no session invalidation, so the warm OpenCode session survives for the next turn.
- Diagnostics gain `abortedAfterCloseout` on the log line and `aborted_after_closeout` on the settled-turn telemetry, so the saving is measurable against `postReplyInferenceDurationMs` from #2029.

Follow-ups admitted while a turn runs are durable parent events delivered as fresh turns once the lock frees, so ending the turn earlier cannot strand one.

## Verification

- New test: closeout on the first assistant message, second assistant message starts, the prompt signal is aborted only then, the turn resolves to the closeout, `postReply` is called once, no failure is classified, and telemetry reports success with `abortedAfterCloseout: true`.
- `src/server/fast-agent`: 356 tests pass. Typecheck, oxlint, knip, and pre-push clean.