### PR TITLE
[Feat] Expose deployment MCP tools to Fast on demand instead of mounting every schema

### DIFF
--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-bridge.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-bridge.test.ts
@@ -650,7 +650,7 @@ describe('Fast native OpenCode tool bridge', () => {
     };
     const runtime = await getFastAgentNativeToolRuntime('native-mcp', [
       {
-        id: 'github',
+        id: 'roomote',
         name: 'GitHub',
         description: 'Repository access',
         tools: [
@@ -665,16 +665,16 @@ describe('Fast native OpenCode tool bridge', () => {
       mcp: Record<string, { url: string; headers: Record<string, string> }>;
     };
     const executor = vi.fn(async ({ args }) => ({ matches: [args.query] }));
-    expect(config.mcp.github!.headers.Authorization).toBe(
+    expect(config.mcp.roomote!.headers.Authorization).toBe(
       `Bearer ${runtime.mcpCapability}`,
     );
-    expect(config.mcp.github!.headers.Authorization).not.toContain(
+    expect(config.mcp.roomote!.headers.Authorization).not.toContain(
       runtime.env.ROOMOTE_FAST_TOOL_BRIDGE_TOKEN,
     );
     expect(config.agent.build.tools).toMatchObject({
       '*': false,
       task: true,
-      'github_*': true,
+      'roomote_*': true,
     });
     const serverConfig = JSON.parse(
       buildOpenCodeCliEnv(runtime.env, {
@@ -698,28 +698,76 @@ describe('Fast native OpenCode tool bridge', () => {
     try {
       await expect(
         listMcpTools({
-          url: config.mcp.github!.url,
-          headers: config.mcp.github!.headers,
+          url: config.mcp.roomote!.url,
+          headers: config.mcp.roomote!.headers,
         }),
       ).resolves.toEqual([
         { name: 'search_code', description: 'Search code', inputSchema },
       ]);
       await expect(
         callMcpTool({
-          url: config.mcp.github!.url,
-          headers: config.mcp.github!.headers,
+          url: config.mcp.roomote!.url,
+          headers: config.mcp.roomote!.headers,
           toolName: 'search_code',
           args: { query: 'Fast', filters: null },
         }),
       ).resolves.toEqual({ matches: ['Fast'] });
       expect(executor).toHaveBeenCalledWith({
-        integrationId: 'github',
+        integrationId: 'roomote',
         toolName: 'search_code',
         args: { query: 'Fast', filters: null },
       });
     } finally {
       unbind();
     }
+  });
+
+  it('registers only native servers with OpenCode and keeps on-demand servers off the request', async () => {
+    const runtime = await getFastAgentNativeToolRuntime('lazy-mcp', [
+      {
+        id: 'roomote',
+        name: 'Roomote',
+        description: 'Deployment access',
+        tools: [{ name: 'manage_tasks', inputSchema: { type: 'object' } }],
+      },
+      {
+        id: 'gbrain',
+        name: 'Brain',
+        description: 'Deployment memory',
+        tools: [{ name: 'query', inputSchema: { type: 'object' } }],
+      },
+      {
+        id: 'github',
+        name: 'GitHub',
+        description: 'Repository access',
+        tools: Array.from({ length: 40 }, (_, index) => ({
+          name: `tool_${index}`,
+          inputSchema: { type: 'object' },
+        })),
+      },
+    ]);
+    const config = JSON.parse(
+      await readFile(join(runtime.directory, 'opencode.json'), 'utf8'),
+    ) as {
+      agent: { build: { tools: Record<string, boolean> } };
+      mcp: Record<string, unknown>;
+    };
+
+    expect(Object.keys(config.mcp).sort()).toEqual(['gbrain', 'roomote']);
+    expect(config.agent.build.tools).toMatchObject({
+      'roomote_*': true,
+      'gbrain_*': true,
+      [FAST_AGENT_NATIVE_TOOL_NAMES.findIntegrationTools]: true,
+      [FAST_AGENT_NATIVE_TOOL_NAMES.callIntegrationTool]: true,
+    });
+    expect(config.agent.build.tools).not.toHaveProperty('github_*');
+    const toolsDirectory = join(runtime.env.OPENCODE_CONFIG_DIR!, 'tools');
+    expect(await readdir(toolsDirectory)).toEqual(
+      expect.arrayContaining([
+        'find_integration_tools.js',
+        'call_integration_tool.js',
+      ]),
+    );
   });
 
   it('keeps member task inspection namespaced from native task mutations', async () => {
@@ -756,7 +804,7 @@ describe('Fast native OpenCode tool bridge', () => {
     const parentSessionId = 'mcp-spill-parent-session';
     const runtime = await getFastAgentNativeToolRuntime(conversationId, [
       {
-        id: 'github',
+        id: 'roomote',
         name: 'GitHub',
         description: 'Repository access',
         tools: [{ name: 'search_code' }],
@@ -780,8 +828,8 @@ describe('Fast native OpenCode tool bridge', () => {
 
     try {
       const descriptor = (await callMcpTool({
-        url: config.mcp.github!.url,
-        headers: config.mcp.github!.headers,
+        url: config.mcp.roomote!.url,
+        headers: config.mcp.roomote!.headers,
         toolName: 'search_code',
         args: {},
       })) as {
@@ -831,7 +879,7 @@ describe('Fast native OpenCode tool bridge', () => {
     )}${marker}`;
     const runtime = await getFastAgentNativeToolRuntime(conversationId, [
       {
-        id: 'github',
+        id: 'roomote',
         name: 'GitHub',
         description: 'Repository access',
         tools: [{ name: 'search_code' }],
@@ -856,8 +904,8 @@ describe('Fast native OpenCode tool bridge', () => {
 
     try {
       const descriptor = (await callMcpTool({
-        url: config.mcp.github!.url,
-        headers: config.mcp.github!.headers,
+        url: config.mcp.roomote!.url,
+        headers: config.mcp.roomote!.headers,
         toolName: 'search_code',
         args: {},
       })) as { spill: { byteLength: number; handle: string } };
@@ -904,7 +952,7 @@ describe('Fast native OpenCode tool bridge', () => {
   it('revokes an in-flight MCP completion before it can recreate spill state', async () => {
     const conversationId = 'mcp-revocation-conversation';
     const integration = {
-      id: 'github',
+      id: 'roomote',
       name: 'GitHub',
       description: 'Repository access',
       tools: [{ name: 'search_code' }],
@@ -936,8 +984,8 @@ describe('Fast native OpenCode tool bridge', () => {
 
     try {
       const staleCall = callMcpTool({
-        url: config.mcp.github!.url,
-        headers: config.mcp.github!.headers,
+        url: config.mcp.roomote!.url,
+        headers: config.mcp.roomote!.headers,
         toolName: 'search_code',
         args: {},
       });
@@ -970,8 +1018,8 @@ describe('Fast native OpenCode tool bridge', () => {
       );
       try {
         const descriptor = (await callMcpTool({
-          url: config.mcp.github!.url,
-          headers: config.mcp.github!.headers,
+          url: config.mcp.roomote!.url,
+          headers: config.mcp.roomote!.headers,
           toolName: 'search_code',
           args: {},
         })) as { spill: { handle: string }; truncated: boolean };

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-prompt.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-prompt.test.ts
@@ -275,6 +275,34 @@ describe('buildFastAgentSystemPrompt', () => {
     );
   });
 
+  it('lists on-demand servers by name with their tool names instead of mounting them', () => {
+    const prompt = buildFastAgentSystemPrompt({
+      availableEnvironments: [],
+      availableIntegrations: [
+        {
+          id: 'roomote',
+          name: 'Roomote',
+          description: 'Deployment access',
+          tools: [{ name: 'manage_tasks' }],
+        },
+        {
+          id: 'github',
+          name: 'GitHub',
+          description: 'Repository access',
+          tools: [{ name: 'search_code' }, { name: 'list_issues' }],
+        },
+      ],
+    });
+
+    expect(prompt).toContain('Roomote [tool prefix: roomote_]');
+    expect(prompt).toContain('### On-demand servers');
+    expect(prompt).toContain('#### GitHub [id: github]');
+    expect(prompt).toContain('Tools: search_code, list_issues');
+    expect(prompt).not.toContain('GitHub [tool prefix: github_]');
+    expect(prompt).toContain('`find_integration_tools`');
+    expect(prompt).toContain('`call_integration_tool`');
+  });
+
   it('includes shared memory guidance when a memory MCP is available', () => {
     const prompt = buildFastAgentSystemPrompt({
       availableEnvironments: [],

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -59,7 +59,9 @@ const mocks = vi.hoisted(() => ({
 const nativeToolNames = vi.hoisted(
   () =>
     ({
+      callIntegrationTool: 'call_integration_tool',
       cancelTask: 'cancel_task',
+      findIntegrationTools: 'find_integration_tools',
       ignoreEvent: 'ignore_event',
       launchTask: 'launch_task',
       retryTaskStart: 'retry_task_start',
@@ -2687,6 +2689,37 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
           success: true,
           result: { matches: ['fast-agent.ts'] },
         });
+        // On-demand servers stay reachable to subagents through the two
+        // shared lookup and call tools.
+        await expect(
+          subagentExecutor({
+            agent: 'advisor',
+            name: nativeToolNames.findIntegrationTools,
+            args: { integrationId: 'github', toolName: 'search_code' },
+          }),
+        ).resolves.toEqual({
+          success: true,
+          tools: [
+            expect.objectContaining({
+              integrationId: 'github',
+              name: 'search_code',
+            }),
+          ],
+        });
+        await expect(
+          subagentExecutor({
+            agent: 'advisor',
+            name: nativeToolNames.callIntegrationTool,
+            args: {
+              integrationId: 'github',
+              toolName: 'search_code',
+              args: { query: 'Fast Agent advisor lazy' },
+            },
+          }),
+        ).resolves.toEqual({
+          success: true,
+          result: { matches: ['fast-agent.ts'] },
+        });
         await parentExecutor({
           name: nativeToolNames.sendChatReply,
           args: {
@@ -2701,7 +2734,7 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     await expect(
       answerFastAgentQuestion({ ...baseParams, adapter }),
     ).resolves.toBe('Subagent review completed.');
-    expect(mocks.callIntegration).toHaveBeenCalledTimes(2);
+    expect(mocks.callIntegration).toHaveBeenCalledTimes(3);
     expect(mocks.getNativeRuntime).toHaveBeenCalledWith(
       'conversation-1',
       expect.arrayContaining([
@@ -3372,6 +3405,103 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
           nativeMessageId: 'native-message-1',
         }),
       }),
+    );
+  });
+
+  it('exposes on-demand integrations through find_integration_tools and call_integration_tool', async () => {
+    const inputSchema = {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+    };
+    mocks.listIntegrations.mockResolvedValue([
+      {
+        id: 'github',
+        name: 'GitHub',
+        description: 'Repository access',
+        tools: [
+          { name: 'search_code', description: 'Search code', inputSchema },
+          { name: 'list_issues', description: 'List issues', inputSchema },
+        ],
+      },
+    ]);
+    const toolResults: unknown[] = [];
+    mocks.generateText.mockImplementation(
+      async (_params, _session, options) => {
+        await options.onSessionReady('opencode-session-1');
+        toolResults.push(
+          await invokeTool(nativeToolNames.findIntegrationTools, {
+            integrationId: 'github',
+            query: 'search',
+          }),
+        );
+        toolResults.push(
+          await invokeTool(nativeToolNames.findIntegrationTools, {
+            integrationId: 'missing',
+          }),
+        );
+        toolResults.push(
+          await invokeTool(nativeToolNames.callIntegrationTool, {
+            integrationId: 'github',
+            toolName: 'search_code',
+            args: { query: 'fast agent' },
+          }),
+        );
+        await invokeTool(nativeToolNames.sendChatReply, {
+          purpose: 'ack',
+          message: 'Looking.',
+        });
+        toolResults.push(
+          await invokeTool(nativeToolNames.callIntegrationTool, {
+            integrationId: 'github',
+            toolName: 'search_code',
+            args: { query: 'fast agent' },
+          }),
+        );
+        await invokeTool(nativeToolNames.sendChatReply, {
+          purpose: 'closeout',
+          message: 'Found it.',
+        });
+        return '';
+      },
+    );
+
+    await answerFastAgentQuestion({ ...baseParams, adapter: callbacks() });
+
+    // Lookups need no acknowledgement and return the schema to call with.
+    expect(toolResults[0]).toEqual({
+      success: true,
+      tools: [
+        {
+          integrationId: 'github',
+          name: 'search_code',
+          description: 'Search code',
+          inputSchema,
+        },
+      ],
+    });
+    expect(toolResults[1]).toEqual({
+      success: false,
+      error: expect.stringContaining('"missing"'),
+    });
+    // Calls follow the same gate as natively mounted MCP tools.
+    expect(toolResults[2]).toEqual({
+      success: false,
+      error: expect.stringContaining('acknowledgement'),
+    });
+    expect(toolResults[3]).toEqual({
+      success: true,
+      result: { matches: ['fast-agent.ts'] },
+    });
+    expect(mocks.callIntegration).toHaveBeenCalledTimes(1);
+    expect(mocks.callIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'conversation-1' }),
+      expect.any(Array),
+      {
+        integrationId: 'github',
+        toolName: 'search_code',
+        args: { query: 'fast agent' },
+      },
     );
   });
 

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -2720,6 +2720,22 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
           success: true,
           result: { matches: ['fast-agent.ts'] },
         });
+        // The shared call path must not hand subagents parent-only member
+        // tools that the subagent tool filter denies.
+        await expect(
+          subagentExecutor({
+            agent: 'judge',
+            name: nativeToolNames.callIntegrationTool,
+            args: {
+              integrationId: 'roomote',
+              toolName: 'manage_custom_automations',
+              args: { action: 'list' },
+            },
+          }),
+        ).resolves.toEqual({
+          success: false,
+          error: expect.stringContaining('mounted natively'),
+        });
         await parentExecutor({
           name: nativeToolNames.sendChatReply,
           args: {
@@ -3424,6 +3440,12 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
           { name: 'list_issues', description: 'List issues', inputSchema },
         ],
       },
+      {
+        id: 'roomote',
+        name: 'Roomote',
+        description: 'Deployment access',
+        tools: [{ name: 'manage_custom_automations', inputSchema }],
+      },
     ]);
     const toolResults: unknown[] = [];
     mocks.generateText.mockImplementation(
@@ -3440,6 +3462,12 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
             integrationId: 'missing',
           }),
         );
+        // Natively mounted servers are neither searchable nor callable here.
+        toolResults.push(
+          await invokeTool(nativeToolNames.findIntegrationTools, {
+            query: 'automations',
+          }),
+        );
         toolResults.push(
           await invokeTool(nativeToolNames.callIntegrationTool, {
             integrationId: 'github',
@@ -3451,6 +3479,13 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
           purpose: 'ack',
           message: 'Looking.',
         });
+        toolResults.push(
+          await invokeTool(nativeToolNames.callIntegrationTool, {
+            integrationId: 'roomote',
+            toolName: 'manage_custom_automations',
+            args: { action: 'list' },
+          }),
+        );
         toolResults.push(
           await invokeTool(nativeToolNames.callIntegrationTool, {
             integrationId: 'github',
@@ -3484,12 +3519,17 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       success: false,
       error: expect.stringContaining('"missing"'),
     });
+    expect(toolResults[2]).toEqual({ success: true, tools: [] });
     // Calls follow the same gate as natively mounted MCP tools.
-    expect(toolResults[2]).toEqual({
+    expect(toolResults[3]).toEqual({
       success: false,
       error: expect.stringContaining('acknowledgement'),
     });
-    expect(toolResults[3]).toEqual({
+    expect(toolResults[4]).toEqual({
+      success: false,
+      error: expect.stringContaining('mounted natively'),
+    });
+    expect(toolResults[5]).toEqual({
       success: true,
       result: { matches: ['fast-agent.ts'] },
     });

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
@@ -52,7 +52,10 @@ import {
   isRoomoteTaskSandboxHost,
   shouldOverrideFastProjectConfigForTaskSandbox,
 } from './fast-agent-runtime-context';
-import { buildFastAgentToolFilter } from './fast-agent-tool-policy';
+import {
+  buildFastAgentToolFilter,
+  isFastAgentNativeIntegration,
+} from './fast-agent-tool-policy';
 
 export {
   FAST_AGENT_NATIVE_TOOL_FILTER,
@@ -368,6 +371,37 @@ export default {
     memory: z.string().min(1).describe("One self-contained fact a future conversation can act on without this conversation's context"),
   },
   execute: (args, context) => invoke("save_memory", args, context),
+}
+`,
+
+    [FAST_AGENT_NATIVE_TOOL_NAMES.findIntegrationTools]: String.raw`
+import { z } from "zod"
+import { invoke } from "../roomote-fast-tool-bridge.js"
+
+export default {
+  description: "Look up on-demand deployment MCP tools by server, name, or keywords. Returns each match's server id, name, description, and input schema so it can be called with call_integration_tool.",
+  args: {
+    integrationId: z.string().min(1).optional().describe("Exact server id from Deployment MCP Servers to list that server's tools"),
+    toolName: z.string().min(1).optional().describe("Exact tool name to fetch one tool's schema"),
+    query: z.string().min(1).optional().describe("Keywords matched against tool names and descriptions"),
+    limit: z.number().int().positive().max(25).optional(),
+  },
+  execute: (args, context) => invoke("find_integration_tools", args, context),
+}
+`,
+
+    [FAST_AGENT_NATIVE_TOOL_NAMES.callIntegrationTool]: String.raw`
+import { z } from "zod"
+import { invoke } from "../roomote-fast-tool-bridge.js"
+
+export default {
+  description: "Call an on-demand deployment MCP tool by server id and tool name with arguments matching the schema returned by find_integration_tools.",
+  args: {
+    integrationId: z.string().min(1).describe("Exact server id from Deployment MCP Servers"),
+    toolName: z.string().min(1).describe("Exact tool name on that server"),
+    args: z.record(z.string(), z.unknown()).optional().describe("Tool arguments matching the tool's input schema"),
+  },
+  execute: (args, context) => invoke("call_integration_tool", args, context),
 }
 `,
 
@@ -1269,6 +1303,13 @@ export async function getFastAgentNativeToolRuntime(
     revoked: false,
   });
   pruneSessionRuntimes();
+  // Only native servers are registered with OpenCode. On-demand servers stay
+  // reachable through the capability (find_integration_tools and
+  // call_integration_tool route to the same executor) without their schemas
+  // being sent on every model request.
+  const nativeIntegrations = integrations.filter((integration) =>
+    isFastAgentNativeIntegration(integration.id),
+  );
   writeFileSync(
     join(runtime.directory, 'opencode.json'),
     JSON.stringify({
@@ -1279,12 +1320,12 @@ export async function getFastAgentNativeToolRuntime(
       agent: {
         build: {
           tools: buildFastAgentToolFilter(
-            integrations.map((integration) => integration.id),
+            nativeIntegrations.map((integration) => integration.id),
           ),
         },
       },
       mcp: Object.fromEntries(
-        integrations.map((integration) => [
+        nativeIntegrations.map((integration) => [
           integration.id,
           {
             type: 'remote',

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
@@ -16,6 +16,7 @@ import {
   type FastAgentTurnSource,
 } from './fast-agent-conversation';
 import type { FastAgentActiveTask } from './fast-agent-session';
+import { isFastAgentNativeIntegration } from './fast-agent-tool-policy';
 import { buildRoomoteStyleGuidanceSection } from '../../style-guidance';
 
 function formatRepositoriesForPrompt(
@@ -82,12 +83,26 @@ function formatIntegrationsForPrompt(
     return '- No deployment MCP servers are available in fast mode.';
   }
 
-  return integrations
-    .map(
-      (integration) =>
-        `### ${integration.name} [tool prefix: ${integration.id}_]\n${integration.description}${integration.instructions ? `\n\n${integration.instructions}` : ''}`,
-    )
-    .join('\n\n');
+  const native = integrations.filter((integration) =>
+    isFastAgentNativeIntegration(integration.id),
+  );
+  const onDemand = integrations.filter(
+    (integration) => !isFastAgentNativeIntegration(integration.id),
+  );
+  const sections = native.map(
+    (integration) =>
+      `### ${integration.name} [tool prefix: ${integration.id}_]\n${integration.description}${integration.instructions ? `\n\n${integration.instructions}` : ''}`,
+  );
+  if (onDemand.length > 0) {
+    sections.push(
+      `### On-demand servers\nThe servers below are not mounted as individual tools. Call \`find_integration_tools\` with the server id (and a tool name or keywords) to get a tool's input schema, then \`call_integration_tool\` with that server id, tool name, and arguments. Tool names are listed so you can pick the right server without searching.`,
+      ...onDemand.map(
+        (integration) =>
+          `#### ${integration.name} [id: ${integration.id}]\n${integration.description}${integration.instructions ? `\n\n${integration.instructions}` : ''}\nTools: ${integration.tools.map((tool) => tool.name).join(', ')}`,
+      ),
+    );
+  }
+  return sections.join('\n\n');
 }
 
 export function buildFastAgentSystemPrompt({
@@ -264,7 +279,7 @@ ${reactionGuidance}
 - Use \`roomote_get_chat_message_context\` or \`roomote_get_chat_channel_messages\` for additional chat context. Pass the target channel or message reference required by the native tool schema. Slack channel history defaults to the previous 24 hours when \`oldest\` is omitted.
 - Never send conversational acknowledgements to a task. "Okay", "cool", "thanks", status questions, and similar conversation are addressed to you. Use a user-visible chat tool.
 - Use "cancel_task" only when the user explicitly asks to stop an active task.
-- Call a listed deployment MCP tool directly when it can answer the request. Fast receives the same actor-authorized remote and deployment-proxied MCP tool catalog as delegated tasks, with each tool exposed individually under its server prefix and native JSON schema; local stdio servers remain sandbox-only.
+- Call a deployment MCP tool when it can answer the request. Fast receives the same actor-authorized remote and deployment-proxied MCP tool catalog as delegated tasks; local stdio servers remain sandbox-only. Servers listed with a tool prefix expose each tool individually with its native JSON schema. On-demand servers are reached through \`find_integration_tools\` (fetch the schema by server id and tool name, or search by keywords) followed by \`call_integration_tool\`; the same acknowledgement, duplicate, and audit rules apply to both paths.
 - Use \`roomote_manage_custom_automations\` for custom automation lifecycle requests. It uses the current user's deployment authorization, is admin-only, and is unavailable to advisor and judge subagents. List before modifying an existing automation, use "list_models" before setting a model override, use update with "enabled" to enable or disable, and use "run_now" rather than "launch_task" to test an automation. Communicate first on a human-authored turn; platform events remain exempt. Delete only when the user explicitly requests it, and after creating an automation ask whether they want to run it now.
 
 ${recurringAutomationGuidance}

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -380,6 +380,85 @@ const taskIdArgsSchema = z.object({
   taskId: z.string().trim().min(1).nullable().optional(),
 });
 const ignoreEventArgsSchema = z.object({ reason: z.string().trim().min(1) });
+const findIntegrationToolsArgsSchema = z.object({
+  integrationId: z.string().trim().min(1).optional(),
+  toolName: z.string().trim().min(1).optional(),
+  query: z.string().trim().min(1).optional(),
+  limit: z.number().int().positive().max(25).optional(),
+});
+const callIntegrationToolArgsSchema = z.object({
+  integrationId: z.string().trim().min(1),
+  toolName: z.string().trim().min(1),
+  args: z.record(z.unknown()).optional(),
+});
+const FIND_INTEGRATION_TOOLS_DEFAULT_LIMIT = 10;
+
+/**
+ * Resolve on-demand integration tools for `find_integration_tools`. Exact
+ * server and tool names win; otherwise every query term must appear in the
+ * tool's name or description. Results carry the input schema the model needs
+ * to call the tool, bounded so a broad query cannot inline a whole catalog.
+ */
+function findFastAgentIntegrationTools(
+  integrations: FastAgentIntegration[],
+  args: z.infer<typeof findIntegrationToolsArgsSchema>,
+): {
+  tools: Array<{
+    integrationId: string;
+    name: string;
+    description?: string;
+    inputSchema?: unknown;
+  }>;
+  truncated: boolean;
+  unknownIntegration: boolean;
+} {
+  const limit = args.limit ?? FIND_INTEGRATION_TOOLS_DEFAULT_LIMIT;
+  const scoped = args.integrationId
+    ? integrations.filter(
+        (integration) => integration.id === args.integrationId,
+      )
+    : integrations;
+  if (args.integrationId && scoped.length === 0) {
+    return { tools: [], truncated: false, unknownIntegration: true };
+  }
+  const terms = (args.query ?? '')
+    .toLowerCase()
+    .split(/\s+/u)
+    .filter((term) => term.length > 0);
+  const matches: Array<{
+    integrationId: string;
+    name: string;
+    description?: string;
+    inputSchema?: unknown;
+    exact: boolean;
+  }> = [];
+  for (const integration of scoped) {
+    for (const tool of integration.tools) {
+      if (args.toolName && tool.name !== args.toolName) continue;
+      const haystack = `${tool.name} ${tool.description ?? ''}`.toLowerCase();
+      if (terms.length > 0 && !terms.every((term) => haystack.includes(term))) {
+        continue;
+      }
+      matches.push({
+        integrationId: integration.id,
+        name: tool.name,
+        ...(tool.description ? { description: tool.description } : {}),
+        ...(tool.inputSchema !== undefined
+          ? { inputSchema: tool.inputSchema }
+          : {}),
+        exact:
+          Boolean(args.toolName) ||
+          terms.some((term) => tool.name.toLowerCase() === term),
+      });
+    }
+  }
+  matches.sort((left, right) => Number(right.exact) - Number(left.exact));
+  return {
+    tools: matches.slice(0, limit).map(({ exact: _exact, ...tool }) => tool),
+    truncated: matches.length > limit,
+    unknownIntegration: false,
+  };
+}
 const saveMemoryArgsSchema = z.object({
   memory: z.string().trim().min(1).max(FAST_AGENT_MEMORY_FACT_MAX_CHARS),
 });
@@ -2093,6 +2172,9 @@ export async function answerFastAgentQuestion({
       FAST_AGENT_NATIVE_TOOL_NAMES.sendChatReaction,
       FAST_AGENT_NATIVE_TOOL_NAMES.launchTask,
       FAST_AGENT_NATIVE_TOOL_NAMES.ignoreEvent,
+      // A catalog lookup reads nothing external; the call it prepares for is
+      // still gated on the acknowledgement.
+      FAST_AGENT_NATIVE_TOOL_NAMES.findIntegrationTools,
       `${ROOMOTE_MCP_ID}_${CHAT_REACTION_EMOJI_TOOL_NAME}`,
     ]);
     const authorizeToolStart = (toolId: string) =>
@@ -2277,6 +2359,55 @@ export async function answerFastAgentQuestion({
       }
     };
 
+    const describeIntegrationTools = (
+      args: z.infer<typeof findIntegrationToolsArgsSchema>,
+    ) => {
+      const found = findFastAgentIntegrationTools(availableIntegrations, args);
+      if (found.unknownIntegration) {
+        return {
+          success: false as const,
+          error: `No deployment MCP server with id "${args.integrationId}" is available in fast mode.`,
+        };
+      }
+      return {
+        success: true as const,
+        tools: found.tools,
+        ...(found.truncated
+          ? {
+              guidance:
+                'More tools matched than were returned. Narrow the query or pass integrationId or toolName.',
+            }
+          : {}),
+      };
+    };
+    // Subagents may look up and call on-demand deployment MCP tools; every
+    // other Fast tool stays with the parent. Calls run through the parent's
+    // MCP executor, so gating, duplicate detection, and auditing are shared.
+    const executeSubagentNativeTool = async (
+      call: FastAgentNativeToolCall,
+    ): Promise<unknown> => {
+      try {
+        if (call.name === FAST_AGENT_NATIVE_TOOL_NAMES.findIntegrationTools) {
+          return describeIntegrationTools(
+            findIntegrationToolsArgsSchema.parse(call.args),
+          );
+        }
+        if (call.name === FAST_AGENT_NATIVE_TOOL_NAMES.callIntegrationTool) {
+          const args = callIntegrationToolArgsSchema.parse(call.args);
+          return await executeMcpTool({
+            integrationId: args.integrationId,
+            toolName: args.toolName,
+            args: args.args ?? {},
+          });
+        }
+      } catch (error) {
+        return toolFailure(error);
+      }
+      return {
+        success: false,
+        error: 'That tool is reserved for the Fast parent agent.',
+      };
+    };
     const executeNativeToolInner = async (
       call: FastAgentNativeToolCall,
     ): Promise<unknown> => {
@@ -2669,6 +2800,19 @@ export async function answerFastAgentQuestion({
             };
           }
 
+          case FAST_AGENT_NATIVE_TOOL_NAMES.findIntegrationTools: {
+            return describeIntegrationTools(
+              findIntegrationToolsArgsSchema.parse(call.args),
+            );
+          }
+          case FAST_AGENT_NATIVE_TOOL_NAMES.callIntegrationTool: {
+            const args = callIntegrationToolArgsSchema.parse(call.args);
+            return executeMcpTool({
+              integrationId: args.integrationId,
+              toolName: args.toolName,
+              args: args.args ?? {},
+            });
+          }
           case FAST_AGENT_NATIVE_TOOL_NAMES.ignoreEvent: {
             ignoreEventArgsSchema.parse(call.args);
             if (platformEvent && platformEventVisibility === 'required') {
@@ -3002,12 +3146,7 @@ export async function answerFastAgentQuestion({
                           bindFastAgentNativeToolExecutor(
                             subagentSessionID,
                             session.id,
-                            () =>
-                              Promise.resolve({
-                                success: false,
-                                error:
-                                  'That tool is reserved for the Fast parent agent.',
-                              }),
+                            executeSubagentNativeTool,
                             {
                               allowSkillAccess: false,
                               allowSpillRecovery: false,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -111,7 +111,10 @@ import {
   type FastAgentMcpToolCall,
   type FastAgentNativeToolCall,
 } from './fast-agent-native-tool-bridge';
-import { getFastAgentNativeAcpKind } from './fast-agent-tool-policy';
+import {
+  getFastAgentNativeAcpKind,
+  isFastAgentNativeIntegration,
+} from './fast-agent-tool-policy';
 import {
   callFastAgentIntegration,
   listFastAgentIntegrations,
@@ -2359,14 +2362,31 @@ export async function answerFastAgentQuestion({
       }
     };
 
+    // Natively mounted servers are excluded from both the lookup and the
+    // call path: their tools are already exposed by name, and the subagent
+    // tool filter denies some of them, which the shared call path must not
+    // bypass.
+    const onDemandIntegrations = availableIntegrations.filter(
+      (integration) => !isFastAgentNativeIntegration(integration.id),
+    );
+    const nativeIntegrationError = (integrationId: string) => ({
+      success: false as const,
+      error: `The "${integrationId}" server is mounted natively; call its tools directly by their ${integrationId}_ prefixed names.`,
+    });
     const describeIntegrationTools = (
       args: z.infer<typeof findIntegrationToolsArgsSchema>,
     ) => {
-      const found = findFastAgentIntegrationTools(availableIntegrations, args);
+      if (
+        args.integrationId &&
+        isFastAgentNativeIntegration(args.integrationId)
+      ) {
+        return nativeIntegrationError(args.integrationId);
+      }
+      const found = findFastAgentIntegrationTools(onDemandIntegrations, args);
       if (found.unknownIntegration) {
         return {
           success: false as const,
-          error: `No deployment MCP server with id "${args.integrationId}" is available in fast mode.`,
+          error: `No on-demand deployment MCP server with id "${args.integrationId}" is available in fast mode.`,
         };
       }
       return {
@@ -2394,6 +2414,9 @@ export async function answerFastAgentQuestion({
         }
         if (call.name === FAST_AGENT_NATIVE_TOOL_NAMES.callIntegrationTool) {
           const args = callIntegrationToolArgsSchema.parse(call.args);
+          if (isFastAgentNativeIntegration(args.integrationId)) {
+            return nativeIntegrationError(args.integrationId);
+          }
           return await executeMcpTool({
             integrationId: args.integrationId,
             toolName: args.toolName,
@@ -2807,6 +2830,9 @@ export async function answerFastAgentQuestion({
           }
           case FAST_AGENT_NATIVE_TOOL_NAMES.callIntegrationTool: {
             const args = callIntegrationToolArgsSchema.parse(call.args);
+            if (isFastAgentNativeIntegration(args.integrationId)) {
+              return nativeIntegrationError(args.integrationId);
+            }
             return executeMcpTool({
               integrationId: args.integrationId,
               toolName: args.toolName,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-tool-policy.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-tool-policy.ts
@@ -1,6 +1,8 @@
 import {
   FAST_AGENT_NATIVE_TOOL_NAMES,
   getFastAgentNativeAcpKind,
+  isMemoryMcpServer,
+  ROOMOTE_MCP_ID,
   type FastAgentNativeToolName,
 } from '@roomote/types';
 
@@ -25,7 +27,24 @@ export const FAST_AGENT_SUBAGENT_TOOL_FILTER: Record<string, boolean> = {
   ...Object.fromEntries(
     Object.values(FAST_AGENT_NATIVE_TOOL_NAMES).map((name) => [name, false]),
   ),
+  // Subagents reach on-demand deployment MCP servers the same way the parent
+  // does; these two are the only Fast tools they share.
+  [FAST_AGENT_NATIVE_TOOL_NAMES.findIntegrationTools]: true,
+  [FAST_AGENT_NATIVE_TOOL_NAMES.callIntegrationTool]: true,
 };
+
+/**
+ * Deployment MCP servers whose tools are registered with OpenCode directly,
+ * so every tool schema rides along in each model request. The Roomote member
+ * tools are referenced by name throughout the system prompt and memory recall
+ * is a required first call, so both stay native. Every other server is
+ * exposed on demand through `find_integration_tools` and
+ * `call_integration_tool`, which keeps a deployment with hundreds of tools
+ * from inflating every request.
+ */
+export function isFastAgentNativeIntegration(integrationId: string): boolean {
+  return integrationId === ROOMOTE_MCP_ID || isMemoryMcpServer(integrationId);
+}
 
 export function buildFastAgentToolFilter(
   integrationIds: string[],

--- a/packages/types/src/fast-agent-tool-catalog.ts
+++ b/packages/types/src/fast-agent-tool-catalog.ts
@@ -5,7 +5,9 @@ import { ACP_TOOL_KINDS, type KnownAcpToolKind } from './acp';
  * contract so runtime policy and transcript fixtures describe the same set.
  */
 export const FAST_AGENT_NATIVE_TOOL_NAMES = {
+  callIntegrationTool: 'call_integration_tool',
   cancelTask: 'cancel_task',
+  findIntegrationTools: 'find_integration_tools',
   ignoreEvent: 'ignore_event',
   launchTask: 'launch_task',
   retryTaskStart: 'retry_task_start',
@@ -24,7 +26,15 @@ export type FastAgentNativeToolName =
   (typeof FAST_AGENT_NATIVE_TOOL_NAMES)[keyof typeof FAST_AGENT_NATIVE_TOOL_NAMES];
 
 export const FAST_AGENT_NATIVE_TOOL_CATALOG = [
+  {
+    name: FAST_AGENT_NATIVE_TOOL_NAMES.callIntegrationTool,
+    kind: ACP_TOOL_KINDS.mcp,
+  },
   { name: FAST_AGENT_NATIVE_TOOL_NAMES.cancelTask, kind: ACP_TOOL_KINDS.task },
+  {
+    name: FAST_AGENT_NATIVE_TOOL_NAMES.findIntegrationTools,
+    kind: ACP_TOOL_KINDS.search,
+  },
   {
     name: FAST_AGENT_NATIVE_TOOL_NAMES.ignoreEvent,
     kind: ACP_TOOL_KINDS.communication,


### PR DESCRIPTION
## Problem

Every Fast model request carried the JSON schema of every tool on every deployment MCP server. With the diagnostics from #2029 on the nightly (eight MCP servers), each request was ~64k tokens of context with 253 integration tool definitions, and the model took 13–17 s to reach its first tool call. The same model on a deployment with no MCP servers does it in 3–4 s on ~11k tokens.

## Change

- **Native servers stay native.** The Roomote member tools (`roomote_*`, referenced by name throughout the prompt) and memory servers (whose recall is a required first call) are still registered with OpenCode and exposed as individual tools. `isFastAgentNativeIntegration` in `fast-agent-tool-policy.ts` is the single rule.
- **Every other server is on demand.** It is no longer written to the conversation's `opencode.json`, so its schemas never enter a request. The system prompt lists it under "On-demand servers" with its id, description, instructions, and tool names, so the model can pick the right server without a search.
- **Two new native tools.** `find_integration_tools` returns matching tools (server id, name, description, input schema) by exact server/tool name or by keywords, bounded to 10 by default, and is exempt from the acknowledgement gate because it reads nothing external. `call_integration_tool` runs a tool through the existing `executeMcpTool`, so acknowledgement gating, duplicate-call detection, the automation-only restrictions, and the integration audit records are unchanged.
- **Subagents.** Advisor and judge previously reached MCP tools through OpenCode's session config; they now get the same two tools via the subagent executor, routed through the parent's MCP executor.
- The bridge's MCP endpoint still serves every integration in the capability, so anything that already calls through it keeps working.

## Verification

- Bridge: only native servers land in `opencode.json` and the agent tool filter; the two tool files are written to the shared tools directory.
- Prompt: on-demand servers render with id and tool names, not a tool prefix, alongside the find/call guidance.
- Service: lookup returns the schema without an acknowledgement; an unknown server id errors; a call before the acknowledgement is refused and after it routes to `callFastAgentIntegration` with the exact arguments; subagents can look up and call, and still cannot use parent-only tools.
- Live local turn: the model called `find_integration_tools` and replied normally; the tools load in OpenCode.
- `src/server/fast-agent` suite (360) and `@roomote/types` suite pass; typecheck, oxlint, knip, and pre-push clean.

## Expected effect

On the nightly, integration tool definitions drop from 253 to the member and memory tools (a few dozen), which should take most of the ~50k tokens of tool schemas out of every request. `maxContextTokens` and `firstModelResponseDurationMs` in the `Turn finished` line will show the before/after directly.