### PR TITLE
[Fix] Show on-demand integration calls as the integration tool they invoked

### DIFF
--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/tool-presentation.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/tool-presentation.ts
@@ -307,6 +307,11 @@ function resolveReceiptLanguage(
       verb: byPhase('Saving', 'Saved', 'Failed to Save'),
       object: 'Memory',
     };
+  if (toolName === 'find_integration_tools')
+    return {
+      verb: byPhase('Searching', 'Searched', 'Failed to Search'),
+      object: 'Integration Tools',
+    };
   return null;
 }
 

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -3604,6 +3604,28 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         args: { query: 'fast agent' },
       },
     );
+    // The transcript sees the integration tool events, never a wrapper
+    // event for the call tool itself.
+    const toolCallTitles = mocks.upsertMessage.mock.calls
+      .map(
+        ([input]) =>
+          (
+            input as {
+              message: {
+                payload: { title?: string; eventType?: string };
+                eventType?: string;
+              };
+            }
+          ).message,
+      )
+      .filter((message) => message.eventType === 'roomote_runtime.tool_call')
+      .map((message) => message.payload.title);
+    expect(toolCallTitles).not.toContain('call_integration_tool');
+    // One integration tool event: the pre-acknowledgement call was refused
+    // before anything was recorded.
+    expect(
+      toolCallTitles.filter((title) => title === 'search_code'),
+    ).toHaveLength(1);
   });
 
   it.each(['github', 'gbrain'])(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -2845,6 +2845,12 @@ export async function answerFastAgentQuestion({
     ): Promise<unknown> => {
       activeToolExecutions += 1;
       try {
+        // The on-demand call is transport: the MCP executor it delegates to
+        // records the integration tool event, which is what the transcript
+        // should show, so no wrapper event is written for it.
+        if (call.name === FAST_AGENT_NATIVE_TOOL_NAMES.callIntegrationTool) {
+          return await executeNativeToolInner(call);
+        }
         const canonicalToolEvent = await beginCanonicalToolEvent({
           title: call.name,
           args: call.args,

--- a/packages/types/src/__tests__/acp.test.ts
+++ b/packages/types/src/__tests__/acp.test.ts
@@ -689,6 +689,43 @@ describe('normalizeTranscriptUserText', () => {
 });
 
 describe('extractAcpMcpInvocation', () => {
+  it('presents an on-demand integration call as the integration tool it invoked', () => {
+    // Fast native tool event: arguments nested under rawInput.arguments.
+    expect(
+      extractAcpMcpInvocation({
+        kind: 'mcp',
+        title: 'call_integration_tool',
+        toolName: 'call_integration_tool',
+        rawInput: {
+          arguments: {
+            integrationId: 'github',
+            toolName: 'search_code',
+            args: { query: 'fast' },
+          },
+        },
+      }),
+    ).toEqual({ mcpServerName: 'github', mcpToolName: 'search_code' });
+    // Sandbox ACP event: the member server's flattened tool name with the
+    // tool input carried directly.
+    expect(
+      extractAcpMcpInvocation({
+        kind: 'roomote_call_integration_tool',
+        title: 'roomote_call_integration_tool',
+        rawInput: { integrationId: 'linear', toolName: 'search_issues' },
+      }),
+    ).toEqual({ mcpServerName: 'linear', mcpToolName: 'search_issues' });
+    // Without a resolvable target, fall back to the ordinary resolution.
+    expect(
+      extractAcpMcpInvocation({
+        kind: 'roomote_call_integration_tool',
+        title: 'roomote_call_integration_tool',
+      }),
+    ).toEqual({
+      mcpServerName: 'roomote',
+      mcpToolName: 'call_integration_tool',
+    });
+  });
+
   it('keeps the legacy flattened MCP fallback for historical Roomote aliases', () => {
     expect(
       extractAcpMcpInvocation({

--- a/packages/types/src/acp.ts
+++ b/packages/types/src/acp.ts
@@ -1137,10 +1137,51 @@ export function normalizePlanPayload(
   return { entries };
 }
 
+// Name of the on-demand integration call tool (FAST_AGENT_NATIVE_TOOL_NAMES.callIntegrationTool;
+// the catalog module imports this one, so the literal lives here).
+const ON_DEMAND_INTEGRATION_CALL_TOOL_NAME = 'call_integration_tool';
+
+/**
+ * `call_integration_tool` is transport, not what the agent did. When a tool
+ * call is that wrapper, present the integration and tool it invoked, exactly
+ * as a directly mounted MCP call would have been shown.
+ */
+function unwrapOnDemandIntegrationCall(
+  update: Record<string, unknown>,
+): AcpMcpInvocation | null {
+  const candidates = [
+    asStringOrNull(update.mcpToolName),
+    asStringOrNull(update.toolName),
+    asStringOrNull(update.title),
+  ];
+  const isWrapper = candidates.some(
+    (name) =>
+      name === ON_DEMAND_INTEGRATION_CALL_TOOL_NAME ||
+      name?.endsWith(`_${ON_DEMAND_INTEGRATION_CALL_TOOL_NAME}`),
+  );
+  if (!isWrapper) {
+    return null;
+  }
+  const rawInput = asRecordOrNull(update.rawInput);
+  // Fast records native tool arguments under `arguments`; sandbox ACP events
+  // carry the tool input directly.
+  const args = asRecordOrNull(rawInput?.arguments) ?? rawInput;
+  const integrationId = asStringOrNull(args?.integrationId);
+  const toolName = asStringOrNull(args?.toolName);
+  if (!integrationId || !toolName) {
+    return null;
+  }
+  return { mcpServerName: integrationId, mcpToolName: toolName };
+}
+
 export function extractAcpMcpInvocation(
   update: Record<string, unknown>,
   options: ExtractAcpMcpInvocationOptions = {},
 ): AcpMcpInvocation | null {
+  const unwrapped = unwrapOnDemandIntegrationCall(update);
+  if (unwrapped) {
+    return unwrapped;
+  }
   const kind = asStringOrNull(update.kind);
   const mcpServerName = asStringOrNull(update.mcpServerName);
   const mcpToolName = asStringOrNull(update.mcpToolName);


### PR DESCRIPTION
## Problem

Since #2031 (Fast) and #2033 (tasks), an on-demand integration call renders in the transcript as "Used Call Integration Tool" instead of the integration and tool that actually ran (for example "Used GitHub: Search Code"). Fast also recorded the wrapper as its own tool event next to the real integration event, so each call showed twice.

## Change

- **Shared extractor** (`extractAcpMcpInvocation` in `@roomote/types`): when a tool call is `call_integration_tool` or the member server's `roomote_call_integration_tool`, present the `integrationId` and `toolName` from its input as the MCP server and tool. Fast nests native tool arguments under `rawInput.arguments`; sandbox ACP events carry the input directly; both are handled. Without a resolvable target it falls back to the ordinary resolution. The Fast transcript reuses the task ACP renderer, so this covers both surfaces.
- **Fast**: no wrapper tool event is written for `call_integration_tool`; the MCP executor's event (server, tool, arguments, result) is what the transcript shows, matching the pre-#2031 look.
- **Receipt** for `find_integration_tools`: "Searching / Searched / Failed to Search Integration Tools" rather than "Used Find Integration Tools".

## Verification

- Extractor tests for the Fast shape, the sandbox shape, and the fallback.
- Fast service test asserts no `call_integration_tool` tool event is recorded and exactly one integration tool event is.
- `@roomote/types` ACP suite, Fast suite (361), and the web client suite (2016) pass; typecheck and lint clean.