### PR TITLE
[Fix] Keep the Fast transcript's working indicator up until the turn ends

### DIFF
--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.client.test.tsx
@@ -720,6 +720,85 @@ describe('FastSessionTranscript', () => {
     expect(screen.getByText('Follow-up answer')).toBeInTheDocument();
   });
 
+  it('keeps a working indicator up after a tool call until the turn ends', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(2);
+    replyMutate.mockResolvedValue({ success: true });
+    render(
+      <FastSessionTranscript
+        sessionId="session-1"
+        initialMessages={[
+          textMessage({ id: 'user-1', role: 'user', text: 'Question', ts: 1 }),
+          textMessage({
+            id: 'assistant-1',
+            role: 'assistant',
+            text: 'Answer',
+            ts: 2,
+          }),
+        ]}
+        canReply
+      />,
+    );
+    const input = screen.getByPlaceholderText('Message agent');
+    fireEvent.change(input, { target: { value: 'Look it up' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', charCode: 13 });
+    expect(await screen.findByText('Thinking')).toBeInTheDocument();
+
+    // The model's first action is a tool call. That is visible output, so
+    // "Thinking" ends, but the turn is still running.
+    act(() => {
+      FakeEventSource.instances[0]!.emit('messages', {
+        conversationResponding: true,
+        messages: [
+          {
+            ...textMessage({
+              id: 'tool-1',
+              role: 'assistant',
+              text: '',
+              ts: Date.now() + 1,
+            }),
+            role: 'tool' as const,
+            eventType: ACP_ENVELOPE_EVENT_TYPES.ToolCall,
+            contentBlocks: [],
+            payload: {
+              toolCallId: 'tool-1',
+              title: 'search_code',
+              kind: 'mcp',
+              status: 'completed',
+              isExecute: false,
+              isRead: false,
+              isMcp: true,
+              isRoomoteNativeTool: false,
+              mcpServerName: 'github',
+              mcpToolName: 'search_code',
+              serverName: 'github',
+              toolName: 'search_code',
+              command: null,
+              rawInput: { arguments: { query: 'fast' } },
+            },
+          },
+        ],
+      });
+    });
+    expect(screen.queryByText('Thinking')).not.toBeInTheDocument();
+    expect(screen.getByText('Working')).toBeInTheDocument();
+
+    act(() => {
+      FakeEventSource.instances[0]!.emit('messages', {
+        conversationResponding: false,
+        messages: [
+          textMessage({
+            id: 'assistant-2',
+            role: 'assistant',
+            text: 'Found it',
+            ts: Date.now() + 2,
+          }),
+        ],
+      });
+    });
+    expect(screen.queryByText('Working')).not.toBeInTheDocument();
+    expect(screen.getByText('Found it')).toBeInTheDocument();
+  });
+
   it('clears Thinking when a follow-up send fails', async () => {
     replyMutate.mockRejectedValue(new Error('turn is busy'));
     render(

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.tsx
@@ -192,12 +192,12 @@ export function pendingResponseReducer(
   };
 }
 
-function ThinkingMessage() {
+function ThinkingMessage({ label = 'Thinking' }: { label?: string }) {
   return (
     <Message from="assistant" className="chat-reasoning-message">
       <MessageContent>
         <Shimmer className="text-sm font-light" direction="rl" duration={1}>
-          Thinking
+          {label}
         </Shimmer>
       </MessageContent>
     </Message>
@@ -602,10 +602,12 @@ export function FastSessionTranscript({
           />
           {pendingResponseState.pendingAfter !== null ? (
             <ThinkingMessage />
-          ) : !isSending &&
-            conversationResponding !== true &&
-            runningTaskCount > 0 &&
-            openTasksPanel ? (
+          ) : conversationResponding === true ? (
+            // Visible output (a tool call, an acknowledgement) has arrived
+            // but the turn is still running: the responding lease is the
+            // authority, and it clears the moment the closeout lands.
+            <ThinkingMessage label="Working" />
+          ) : !isSending && runningTaskCount > 0 && openTasksPanel ? (
             <RunningTasksMessage
               count={runningTaskCount}
               onOpenTasks={openTasksPanel}


### PR DESCRIPTION
## Problem

After the model makes a tool call, the Fast transcript looks idle even though the turn is still running. The "Thinking" indicator is driven by "no visible non-user message since the user's message," and a tool event counts as visible, so it cleared on the first tool call. Until #2031 the first event was almost always the acknowledgement (integration calls were gated behind it), which hid this; now `find_integration_tools` can run first, and the transcript goes quiet with nothing said. It also always went quiet after any mid-turn tool call, and the trailing post-closeout request that #2030 removed used to blur the end of the turn.

## Change

The session's responding lease is already the authority for "the turn is running" (set at turn start, cleared at turn end, which #2030 moved to the closeout). When it is active after visible output, the transcript shows a "Working" indicator in the same slot; "Thinking" is unchanged for the no-output-yet case. The existing stale-lease guard still applies: the client only trusts `responding: true` when it arrives with new output, so a reconnect with a leftover lease does not show a false indicator.

## Verification

New transcript test: follow-up shows Thinking, a streamed tool event with the lease active switches it to Working, and the closeout with the lease released clears it. Transcript client suite (30) passes; typecheck and lint clean.