### PR TITLE
[Feat] Triage Issues implements and opens a pull request by default

### DIFF
--- a/.changeset/issue-fixer-auto-implement.md
+++ b/.changeset/issue-fixer-auto-implement.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': minor
+---
+
+Triage Issues now implements opened or reopened GitHub, GitLab, and Gitea issues and opens a pull request by default, instead of posting a plan and waiting for a mention. It still posts clarifying questions when the work is too unclear to ship.

--- a/apps/api/src/handlers/gitea/handleIssue.ts
+++ b/apps/api/src/handlers/gitea/handleIssue.ts
@@ -12,7 +12,7 @@ import type { GiteaIssueWebhook } from './types';
 const OPEN_ACTIONS = new Set(['opened', 'reopened']);
 
 /**
- * Launch plan-only issue triage when a plain Gitea issue is opened/reopened.
+ * Launch issue implementation when a plain Gitea issue is opened/reopened.
  */
 export async function handleGiteaIssue(
   payload: GiteaIssueWebhook,

--- a/apps/api/src/handlers/github/handleGitHubIssueFixer.ts
+++ b/apps/api/src/handlers/github/handleGitHubIssueFixer.ts
@@ -40,7 +40,7 @@ function issueLabels(labels: IssueFixerPayload['issue']['labels']): string[] {
 }
 
 /**
- * Launch one environment-backed plan-only triage task the moment a GitHub
+ * Launch one environment-backed implementation task the moment a GitHub
  * issue is opened or reopened (one task per issue event).
  */
 export async function handleGitHubIssueFixer(

--- a/apps/api/src/handlers/gitlab/handleIssue.ts
+++ b/apps/api/src/handlers/gitlab/handleIssue.ts
@@ -9,7 +9,7 @@ import type { GitLabIssueWebhook } from './types';
 const OPEN_ACTIONS = new Set(['open', 'reopen']);
 
 /**
- * Launch plan-only issue triage when a plain GitLab issue is opened/reopened.
+ * Launch issue implementation when a plain GitLab issue is opened/reopened.
  */
 export async function handleGitLabIssue(
   payload: GitLabIssueWebhook,

--- a/apps/api/src/handlers/shared/issue-fixer-launch.ts
+++ b/apps/api/src/handlers/shared/issue-fixer-launch.ts
@@ -29,7 +29,7 @@ type IssueFixerLaunchIssue = {
 };
 
 /**
- * Shared launch path for webhook-driven issue triage across supported SCMs.
+ * Shared launch path for webhook-driven issue implementation across supported SCMs.
  * Caller has already resolved the active Roomote repository row and normalized
  * the issue payload.
  */

--- a/apps/docs/automations.mdx
+++ b/apps/docs/automations.mdx
@@ -63,7 +63,7 @@ These automations react to pull requests, issues, and repository state.
 | Automation                 | What it does                                                      | Good first use                                                         |
 | -------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | **Review Code**            | Reviews pull requests automatically or on demand                  | Add an extra reviewer for regressions, risky changes, and missed tests |
-| **Triage Issues**          | Posts clarifying questions or an implementation plan when an issue is opened/reopened on GitHub, GitLab, or Gitea | Get a grounded plan on the issue without auto-opening a PR           |
+| **Triage Issues**          | Implements opened or reopened GitHub, GitLab, or Gitea issues and opens a pull request, or posts clarifying questions when the work is too unclear to ship | Get a pull request on the issue without waiting for a mention           |
 | **Resolve PR Conflicts**   | Looks for merge conflicts and helps fix them on open PRs          | Keep long-running branches from getting stuck                          |
 | **Merge announcer**        | Summarizes commits pushed to active repositories' default branches and names the pusher | Keep the team aware of changes that land outside pull requests |
 
@@ -80,11 +80,11 @@ installations that do not have that permission.
 For **Triage Issues**, turn the toggle on once a supported source-control
 provider is connected (GitHub, GitLab, or Gitea) and the repos you care about
 have configured Roomote environments. When an issue is opened or reopened,
-Roomote starts a task immediately, investigates the issue, and posts a concrete
-plan or clarifying questions as a comment on that issue. It does not need a
-Manager Channel, does not post Slack digests, does not implement the fix, and
-does not open a pull request automatically. Azure DevOps work items and
-Bitbucket issues are not covered yet.
+Roomote starts a task immediately, investigates the issue, and implements the
+fix. It opens a pull request and comments the pull request URL on the issue. If
+the work is too unclear to ship, it posts clarifying questions instead and
+waits for a reply. It does not need a Manager Channel and does not post Slack
+digests. Azure DevOps work items and Bitbucket issues are not covered yet.
 
 For **Resolve PR Conflicts**, pick a schedule, PR age cap, and label. The
 label is the team-controlled opt-in for scheduled scans. Make sure the label

--- a/apps/web/src/app/(sandbox)/task/[taskId]/startup/ProductTips.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/startup/ProductTips.tsx
@@ -51,7 +51,7 @@ export const PRODUCT_TIPS = [
   {
     title: 'Triage issues as they arrive',
     description:
-      'Roomote can investigate each newly opened issue and post a concrete implementation plan with the relevant code paths before anyone picks it up.',
+      'Roomote can investigate each newly opened issue, implement the fix, and open a pull request with the relevant code paths before anyone picks it up.',
   },
   {
     title: 'Keep old PRs mergeable',

--- a/apps/web/src/components/settings/automations/AutomationsSettings.tsx
+++ b/apps/web/src/components/settings/automations/AutomationsSettings.tsx
@@ -3047,7 +3047,7 @@ export function AutomationsSettings() {
                             )
                           }
                           rows={4}
-                          placeholder="Optional guidance for how to triage issues and write plans"
+                          placeholder="Optional guidance for how to implement issues"
                         />
                         {fieldErrors.issueFixerInstructions ? (
                           <p className="text-xs text-destructive">

--- a/apps/web/src/components/settings/automations/ScheduleOnlyAutomationContent.client.test.tsx
+++ b/apps/web/src/components/settings/automations/ScheduleOnlyAutomationContent.client.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react';
 
-import { ScheduleOnlyAutomationContent } from './ScheduleOnlyAutomationContent';
+import {
+  SCHEDULE_ONLY_AUTOMATION_UI_DEFINITIONS,
+  ScheduleOnlyAutomationContent,
+} from './ScheduleOnlyAutomationContent';
 
 describe('ScheduleOnlyAutomationContent', () => {
   it('renders the CI triage toggle for toggle-based automations', () => {
@@ -83,5 +86,21 @@ describe('ScheduleOnlyAutomationContent', () => {
 
     expect(screen.getByText(details[0])).toBeInTheDocument();
     expect(screen.getByText(details[1])).toBeInTheDocument();
+  });
+
+  it('describes Triage Issues as implementing and opening a pull request by default', () => {
+    const { description, details } =
+      SCHEDULE_ONLY_AUTOMATION_UI_DEFINITIONS.issueFixer;
+    const detailsText = details.join(' ');
+
+    expect(description).toContain('implement the fix, and open a pull request');
+    expect(description).not.toContain('implementation plan');
+    expect(detailsText).toContain(
+      'Implements the fix and opens a pull request by default.',
+    );
+    expect(detailsText).not.toMatch(/plan only/i);
+    expect(detailsText).not.toContain(
+      'It does not implement the fix or open a pull request automatically.',
+    );
   });
 });

--- a/apps/web/src/components/settings/automations/ScheduleOnlyAutomationContent.tsx
+++ b/apps/web/src/components/settings/automations/ScheduleOnlyAutomationContent.tsx
@@ -75,11 +75,11 @@ export const SCHEDULE_ONLY_AUTOMATION_UI_DEFINITIONS = {
   },
   issueFixer: {
     description:
-      'When an issue is opened or reopened on GitHub, GitLab, or Gitea, investigate it and post a concrete implementation plan on the issue.',
+      'When an issue is opened or reopened on GitHub, GitLab, or Gitea, investigate it, implement the fix, and open a pull request.',
     details: [
       'Runs immediately from the issue webhook — not on a daily or weekly batch schedule.',
       'Supports GitHub, GitLab, and Gitea issues. Azure DevOps work items and Bitbucket issues are not covered yet.',
-      'Posts a plan only. It does not implement the fix or open a pull request automatically.',
+      'Implements the fix and opens a pull request by default. Posts clarifying questions on the issue instead when the work is too unclear to ship.',
       'Only repositories covered by a configured Roomote environment are eligible.',
     ],
     icon: Wrench,

--- a/packages/cloud-agents/src/server/__tests__/issue-fixer-prompt.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/issue-fixer-prompt.test.ts
@@ -35,6 +35,28 @@ describe('buildIssueFixerFixPrompt', () => {
     expect(prompt).not.toContain('Comment formats');
   });
 
+  it('defaults to implementing the issue and opening a pull request', () => {
+    const prompt = buildIssueFixerFixPrompt({
+      repositoryFullName: 'acme/api',
+      environmentId: 'env-api',
+      trigger: 'webhook',
+      sourceControlProvider: 'github',
+      githubAppSlug: 'roomote',
+      issue: {
+        repositoryFullName: 'acme/api',
+        number: 12,
+        title: 'Broken checkout',
+        url: 'https://github.com/acme/api/issues/12',
+      },
+    });
+
+    expect(prompt).toContain('<run_mode>issue_implement</run_mode>');
+    expect(prompt).toContain('Implement GitHub issue #12');
+    expect(prompt).toContain('open a pull request');
+    expect(prompt).not.toContain('issue_plan_only');
+    expect(prompt).not.toContain('Do not implement code');
+  });
+
   it('uses the full GitHub app mention after opting out', () => {
     setGitHubRoomoteMentionSettingCache({
       value: false,
@@ -87,7 +109,7 @@ describe('buildIssueFixerFixPrompt', () => {
       '<source_control_provider>gitlab</source_control_provider>',
     );
     expect(prompt).toContain('<continue_mention>@roomote</continue_mention>');
-    expect(prompt).toContain('Triage GitLab issue #9');
+    expect(prompt).toContain('Implement GitLab issue #9');
     expect(prompt).toContain('source="gitlab_issue_body"');
     expect(prompt).not.toContain('GITLAB_TOKEN');
     expect(prompt).not.toContain('GitLab REST API');

--- a/packages/cloud-agents/src/server/issue-fixer-prompt.ts
+++ b/packages/cloud-agents/src/server/issue-fixer-prompt.ts
@@ -52,8 +52,8 @@ function resolveContinueMention({
 }
 
 /**
- * Builds the one-task Triage Issues prompt: investigate a named issue and post
- * either clarifying questions or a plan on that issue (provider-neutral).
+ * Builds the one-task Triage Issues prompt: investigate a named issue,
+ * implement the fix, and open a pull request (provider-neutral).
  */
 export function buildIssueFixerFixPrompt({
   repositoryFullName,
@@ -122,7 +122,7 @@ export function buildIssueFixerFixPrompt({
 
 <task_context>
   <source>issue_fixer</source>
-  <run_mode>issue_plan_only</run_mode>
+  <run_mode>issue_implement</run_mode>
   <trigger>${trigger}</trigger>
   <source_control_provider>${sourceControlProvider}</source_control_provider>
   <repository_scope>${repositoryFullName}</repository_scope>
@@ -137,7 +137,7 @@ export function buildIssueFixerFixPrompt({
   </issue>
 </task_context>
 
-Triage ${providerLabel} issue #${issue.number} in ${repositoryFullName}. Post either clarifying questions or a concrete implementation plan as a comment on that issue. Do not implement code and do not open a pull request.
+Implement ${providerLabel} issue #${issue.number} in ${repositoryFullName}. If the issue is too unclear to ship safely, post clarifying questions as a comment and stop. Otherwise implement the fix, open a pull request, and comment the pull request URL on the issue. Do not wait for a human to tag Roomote.
 
 Issue URL: ${issue.url}
 Title: ${escapedTitle}

--- a/packages/cloud-agents/src/server/workflows/__tests__/issueFixerSkill.test.ts
+++ b/packages/cloud-agents/src/server/workflows/__tests__/issueFixerSkill.test.ts
@@ -23,4 +23,17 @@ describe('issue-fixer skill', () => {
     expect(skill).not.toContain('GITEA_TOKEN');
     expect(skill).not.toContain('Post with provider-native tooling');
   });
+
+  it('implements the issue and opens a pull request by default', () => {
+    const skill = readIssueFixerSkill();
+
+    expect(skill).toContain('implement-changes');
+    expect(skill).toContain('open a pull request');
+    expect(skill).toContain('An existing plan comment is not a skip');
+    expect(skill).not.toContain(
+      'Do not implement the fix or open a pull request',
+    );
+    expect(skill).not.toContain('plan-only scope');
+    expect(skill).not.toContain("if you'd like me to implement");
+  });
 });

--- a/packages/cloud-agents/src/server/workflows/skills/standard/issue-fixer/SKILL.md
+++ b/packages/cloud-agents/src/server/workflows/skills/standard/issue-fixer/SKILL.md
@@ -1,34 +1,33 @@
 ---
 name: issue-fixer
-description: Investigate a specific open source-control issue and post either clarifying questions or a concrete implementation plan on the issue without implementing code or opening a PR.
+description: Investigate a specific open source-control issue, implement the fix, and open a pull request unless the issue is too unclear to ship.
 ---
 
 # Triage Issues
 
 <role>
-You are an issue triage specialist. When a concrete issue is supplied, investigate it and post either clarifying questions or a plan on the issue. Do not implement the fix or open a pull request in this task.
+You are an issue implementation specialist. When a concrete issue is supplied, investigate it. If it is too unclear to ship safely, post clarifying questions on the issue and stop. Otherwise implement the fix, open a pull request, and comment the pull request URL on the issue.
 </role>
 
 <workflow>
-  <overview>Work only the issue in task_context. Ground the response in the codebase, then post one clear issue comment — clarifying questions when needed, otherwise a proposed plan — and stop. Use continue_mention whenever humans should tag Roomote to continue.</overview>
+  <overview>Work only the issue in task_context. Ground the work in the codebase. Ask clarifying questions when product decisions are missing. Otherwise implement via implement-changes, open a pull request, and post the pull request URL on the issue. Do not wait for a human to tag Roomote.</overview>
 
   <phase name="setup">
     <steps>
       <step>Parse repository_scope, target_environment_id, trigger, source_control_provider, continue_mention, and the issue block.</step>
-      <step>If the task prompt includes "Additional team instructions", treat those as deployment-owned guidance for planning priorities, question style, and comment detail. Prefer them over default style when they do not conflict with plan-only scope.</step>
+      <step>If the task prompt includes "Additional team instructions", treat those as deployment-owned guidance for implementation priorities, question style, and comment detail. Prefer them over default style. They must not change this run to plan-only or skip opening a pull request.</step>
       <step>Re-fetch the live issue with Roomote MCP `manage_source_control` action `get_issue`, then read its comments with action `list_issue_comments`. Pass repository_scope as repositoryFullName and the issue number as issueNumber. Provider credentials remain server-side; do not use provider CLIs, raw REST calls, or token environment variables.</step>
-      <step>Skip when closed, a pull request, already fully planned, already has an active fix PR, or waiting on unanswered questions already asked.</step>
+      <step>Skip when closed, a pull request, already has an active fix PR, or waiting on unanswered clarifying questions already asked. An existing plan comment is not a skip; implement it.</step>
     </steps>
   </phase>
 
   <phase name="respond">
     <steps>
-      <step>Explore related code so any plan names real files and patterns.</step>
+      <step>Explore related code so the change names real files and patterns.</step>
       <step>If acceptance criteria, expected behavior, scope, or constraints are unclear, post clarifying questions on the issue and stop. Do not invent product decisions.</step>
-      <step>Otherwise post a proposed implementation plan that covers approach, files/components likely touched, tests/docs, and why the approach solves the issue.</step>
-      <step>Use the continue_mention value from task_context in follow-up instructions. Do not hard-code a different handle.</step>
-      <step>Post exactly one top-level issue comment with Roomote MCP `manage_source_control` action `create_issue_comment`, using repository_scope, the issue number, and the final body. Do not use provider-specific tooling.</step>
-      <step>Use one of these body shapes for the issue comment, substituting the continue mention for the app tag:</step>
+      <step>Otherwise load `implement-changes` and execute that workflow for this issue. Follow the task delivery policy for draft versus ready pull requests.</step>
+      <step>After the pull request exists, post exactly one top-level issue comment with Roomote MCP `manage_source_control` action `create_issue_comment`, using repository_scope, the issue number, and a body that links the pull request. Do not use provider-specific tooling.</step>
+      <step>Use the continue_mention value from task_context only in clarifying-question comments. Do not hard-code a different handle. Do not ask a human to tag Roomote before implementing.</step>
     </steps>
   </phase>
 </workflow>
@@ -41,25 +40,20 @@ I'd like to help with this issue, but I need some clarification to ensure I impl
 - Could you provide more details about [unclear aspect]?
 - Are there any specific constraints or requirements I should be aware of?
 
-Please tag {{continue_mention}} in your response with the answers, and I'll be happy to implement the fix once I have this information.
+Please tag {{continue_mention}} in your response with the answers, and I'll implement the fix once I have this information.
   </clarifying_questions>
 
-  <proposed_plan>
-I've analyzed this issue and here's my proposed implementation plan:
+  <implemented>
+I implemented this in [pull request]({{pull_request_url}}).
 
-1. Modify [file/component] to [change]
-2. Add [functionality] to handle [scenario]
-3. Update [tests/docs] accordingly
-
-This approach will [explain the benefits and how it solves the issue].
-
-Please tag {{continue_mention}} if you'd like me to implement this, or reply with feedback on the plan.
-  </proposed_plan>
+Please review the pull request.
+  </implemented>
 </comment_formats>
 
 <completion_criteria>
 <criterion>The named issue was re-verified or an explicit skip reason was reported.</criterion>
-<criterion>Exactly one clarifying or plan comment was posted when appropriate, or the run stopped without shipping code.</criterion>
+<criterion>The run either posted clarifying questions and stopped, or implemented the fix, opened a pull request, and commented that pull request URL on the issue.</criterion>
+<criterion>The run did not stop at a plan waiting for a human to tag Roomote.</criterion>
 <criterion>Any ask-to-continue mention uses the configured continue_mention from task_context rather than a hard-coded app handle.</criterion>
 <criterion>All live issue reads and writes used Roomote MCP `manage_source_control`; provider credentials were not accessed directly.</criterion>
 </completion_criteria>

--- a/packages/types/src/background-automation-registry.ts
+++ b/packages/types/src/background-automation-registry.ts
@@ -247,7 +247,7 @@ export const TRIGGERABLE_BACKGROUND_AUTOMATION_DESCRIPTORS = [
     slackIcon: 'wrench',
     scheduleModes: ISSUE_FIXER_SCHEDULE_MODES,
     // Webhook-driven on new issues only (no Run now / batch scan).
-    // Plans are posted on the issue itself, not as Slack suggestion cards.
+    // Fixes are implemented as pull requests; comments land on the issue.
     // GitHub/GitLab/Gitea issue open events launch issue_fixer triage.
     // ADO work-item @mentions start StandardTask (not issue_fixer); Bitbucket
     // issues are not yet supported.


### PR DESCRIPTION
## What changed

Triage Issues now implements opened or reopened GitHub, GitLab, and Gitea issues and opens a pull request by default. It still posts clarifying questions when the work is too unclear to ship.

Previously the automation posted a plan and asked a human to tag Roomote before any code changed.

## Why

An enabled Triage Issues automation should finish the work. Waiting for a mention left issues planned and unshipped.

## How

- Default `run_mode` is `issue_implement`.
- The issue-fixer skill loads `implement-changes`, opens a pull request, and comments the PR URL on the issue.
- Additional team instructions cannot revert the run to plan-only.
- An existing plan comment is not a skip.
- Settings, docs, and product-tip copy match the new default.

## Validation

- `@roomote/cloud-agents` issue-fixer prompt and skill tests
- `@roomote/web` Triage Issues settings copy test
- `@roomote/api` issue-fixer launch / GitLab / Gitea handleIssue tests
- `@roomote/cloud-agents` `check-types`

## Notes

This is a behavior change for deployments that already have Triage Issues enabled. The automation itself stays off until an admin turns it on.