### PR TITLE
[Fix] Show outbound communication tool calls in task transcripts

### DIFF
--- a/apps/web/src/app/(sandbox)/task/[taskId]/message-visibility.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/message-visibility.client.test.ts
@@ -179,16 +179,31 @@ describe('message visibility helpers', () => {
     ).toBe(false);
   });
 
-  it('hides internal post_to_channel calls from the Roomote server', () => {
+  it('treats only effect-free Roomote lifecycle calls as internal debug rows', () => {
     expect(
       isInternalDebugToolCallMessage(
-        mcpToolCallMessage('post_to_channel', 'roomote'),
+        mcpToolCallMessage('ignore_event', 'roomote'),
       ),
     ).toBe(true);
     expect(
       isInternalDebugToolCallMessage(
-        mcpToolResultMessage('post_to_channel', 'roomote'),
+        mcpToolResultMessage('ignore_event', 'roomote'),
       ),
     ).toBe(true);
+    // Outbound communication is the task's visible output, not plumbing.
+    for (const toolName of [
+      'send_chat_reply',
+      'post_to_channel',
+      'send_chat_reaction_emoji',
+    ]) {
+      expect(
+        isInternalDebugToolCallMessage(mcpToolCallMessage(toolName, 'roomote')),
+      ).toBe(false);
+      expect(
+        isInternalDebugToolCallMessage(
+          mcpToolResultMessage(toolName, 'roomote'),
+        ),
+      ).toBe(false);
+    }
   });
 });

--- a/apps/web/src/app/(sandbox)/task/[taskId]/message-visibility.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/message-visibility.ts
@@ -15,17 +15,13 @@ const TOOL_CALLS_DENY_LIST_BY_SOURCE = new Map([
   ],
 ]);
 
+// Only tools whose call carries no user-visible effect belong here. Outbound
+// communication (`send_chat_reply`, `post_to_channel`,
+// `send_chat_reaction_emoji`) is a consequential receipt like
+// `send_task_message`: for a delegated task reporting to its orchestrator it
+// is the entire result, so hiding it left the task transcript blank.
 const INTERNAL_DEBUG_TOOL_CALLS_BY_SOURCE = new Map([
-  [
-    'roomote',
-    new Set([
-      'find_integration_tools',
-      'ignore_event',
-      'post_to_channel',
-      'send_chat_reaction_emoji',
-      'send_chat_reply',
-    ]),
-  ],
+  ['roomote', new Set(['find_integration_tools', 'ignore_event'])],
 ]);
 
 function normalizeIdentifier(value: string | null | undefined): string | null {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpToolDetails.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpToolDetails.tsx
@@ -214,9 +214,13 @@ function getVisibleToolInput(
   const visibleField =
     serverName === 'gbrain' && (toolName === 'search' || toolName === 'query')
       ? 'query'
-      : toolName === 'send_task_message'
+      : toolName === 'send_task_message' || toolName === 'send_chat_reply'
         ? 'message'
-        : null;
+        : toolName === 'post_to_channel'
+          ? 'text'
+          : toolName === 'send_chat_reaction_emoji'
+            ? 'name'
+            : null;
   if (!visibleField) {
     return null;
   }

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpToolDetails.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpToolDetails.client.test.tsx
@@ -437,18 +437,80 @@ describe('AcpToolDetails', () => {
     );
   });
 
-  it('hides expanded details for Roomote Slack lifecycle tools', () => {
+  it('shows the sent message for Roomote chat replies', () => {
+    const result = { success: true, delivered: true };
+    render(
+      <AcpToolDetails
+        msg={{
+          ...buildMessage({
+            kind: 'mcp',
+            title: 'send_chat_reply',
+            isMcp: true,
+            mcpServerName: 'roomote',
+            mcpToolName: 'send_chat_reply',
+            serverName: 'roomote',
+            toolName: 'send_chat_reply',
+            rawInput: {
+              arguments: {
+                message: 'Brief Slack update.',
+                purpose: 'closeout',
+              },
+            },
+            output: JSON.stringify(result),
+          } as Partial<AcpToolResultUiMessage['data']>),
+          text: JSON.stringify(result),
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Input')).toBeInTheDocument();
+    expect(codeBlockSpy.mock.calls.map(([props]) => props.code)).toEqual([
+      'message: Brief Slack update.',
+      ['success: true', 'delivered: true'].join('\n'),
+    ]);
+  });
+
+  it('shows the posted text and reaction name for channel tools', () => {
+    for (const [toolName, args, expected] of [
+      ['post_to_channel', { text: 'Deploy done.' }, 'text: Deploy done.'],
+      ['send_chat_reaction_emoji', { name: 'eyes' }, 'name: eyes'],
+    ] as const) {
+      codeBlockSpy.mockClear();
+      const { unmount } = render(
+        <AcpToolDetails
+          msg={{
+            ...buildMessage({
+              kind: 'mcp',
+              title: toolName,
+              isMcp: true,
+              mcpServerName: 'roomote',
+              mcpToolName: toolName,
+              serverName: 'roomote',
+              toolName,
+              rawInput: { arguments: args },
+              output: '{"success":true}',
+            } as Partial<AcpToolResultUiMessage['data']>),
+            text: '{"success":true}',
+          }}
+        />,
+      );
+      expect(codeBlockSpy.mock.calls[0]?.[0].code).toBe(expected);
+      unmount();
+    }
+  });
+
+  it('hides expanded details for effect-free Roomote lifecycle tools', () => {
     const { container } = render(
       <AcpToolDetails
         msg={buildMessage({
           kind: 'mcp',
-          title: 'send_chat_reply',
+          title: 'ignore_event',
           isMcp: true,
           mcpServerName: 'roomote',
-          mcpToolName: 'send_chat_reply',
+          mcpToolName: 'ignore_event',
           serverName: 'roomote',
-          toolName: 'send_chat_reply',
-          output: '{"success":true,"summary":"Brief Slack update."}',
+          toolName: 'ignore_event',
+          output: '{"success":true,"ignored":true}',
         })}
       />,
     );

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpToolMessage.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpToolMessage.client.test.tsx
@@ -380,7 +380,7 @@ describe('AcpToolMessage', () => {
     );
   });
 
-  it('renders Roomote Slack lifecycle tools as compact title-only rows', () => {
+  it('renders Roomote chat replies as expandable receipts like task messages', () => {
     render(
       <AcpToolMessage
         msg={buildResultMessage('mcp', {
@@ -390,7 +390,32 @@ describe('AcpToolMessage', () => {
           mcpToolName: 'send_chat_reply',
           serverName: 'roomote',
           toolName: 'send_chat_reply',
+          rawInput: { arguments: { message: 'Brief Slack update.' } },
           output: '{"success":true,"summary":"Brief Slack update."}',
+        } as Partial<AcpToolResultUiMessage['data']>)}
+      />,
+    );
+
+    expect(toolHeaderSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'Sent',
+        object: 'Chat Reply',
+        collapsible: true,
+      }),
+    );
+  });
+
+  it('renders effect-free Roomote lifecycle tools as compact title-only rows', () => {
+    render(
+      <AcpToolMessage
+        msg={buildResultMessage('mcp', {
+          title: 'ignore_event',
+          isMcp: true,
+          mcpServerName: 'roomote',
+          mcpToolName: 'ignore_event',
+          serverName: 'roomote',
+          toolName: 'ignore_event',
+          output: '{"success":true,"ignored":true}',
         })}
       />,
     );
@@ -398,7 +423,7 @@ describe('AcpToolMessage', () => {
     expect(toolHeaderSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'Used',
-        object: 'Send Chat Reply',
+        object: 'Ignore Event',
         suffix: 'Roomote',
         collapsible: false,
       }),

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/tool-call-grouping.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/tool-call-grouping.client.test.ts
@@ -1673,7 +1673,7 @@ describe('buildAcpRenderBlocks', () => {
     expect(entries[1].msg.id).toBe('tool-subagent-pending');
   });
 
-  it('hides Roomote Slack reply tool rows when internal transcript rows are disabled', () => {
+  it('keeps Roomote chat reply rows visible when internal transcript rows are disabled', () => {
     const entries = buildAcpRenderBlocks(
       [
         explorationToolMessage({
@@ -1692,14 +1692,40 @@ describe('buildAcpRenderBlocks', () => {
     expect(entries).toEqual([
       {
         kind: 'message',
-        msg: expect.objectContaining({
-          id: 'assistant-2',
-        }),
+        msg: expect.objectContaining({ id: 'tool-send-chat' }),
+      },
+      {
+        kind: 'message',
+        msg: expect.objectContaining({ id: 'assistant-2' }),
       },
     ]);
   });
 
-  it('hides Roomote Slack reply tool results in narration mode', () => {
+  it('hides effect-free Roomote lifecycle rows when internal transcript rows are disabled', () => {
+    const entries = buildAcpRenderBlocks(
+      [
+        explorationToolMessage({
+          id: 'tool-ignore',
+          ts: 1,
+          title: 'ignore_event',
+          text: '{"success":true,"ignored":true}',
+          kind: 'mcp',
+          toolName: 'ignore_event',
+        }),
+        textMessage('assistant-2', 2),
+      ],
+      { showInternalMessages: false },
+    );
+
+    expect(entries).toEqual([
+      {
+        kind: 'message',
+        msg: expect.objectContaining({ id: 'assistant-2' }),
+      },
+    ]);
+  });
+
+  it('keeps Roomote chat reply receipts standalone in narration mode', () => {
     const entries = buildAcpRenderBlocks(
       [
         explorationToolMessage({
@@ -1742,10 +1768,21 @@ describe('buildAcpRenderBlocks', () => {
       { displayMode: 'narration' },
     );
 
-    expect(entries).toEqual([]);
+    // Like send_task_message: a consequential receipt, never folded into an
+    // exploration group and never dropped by narration mode.
+    expect(entries).toEqual([
+      {
+        kind: 'message',
+        msg: expect.objectContaining({ id: 'tool-send-chat' }),
+      },
+      {
+        kind: 'message',
+        msg: expect.objectContaining({ id: 'tool-send-chat-closeout' }),
+      },
+    ]);
   });
 
-  it('keeps Roomote Slack reply tool results visible in narration mode when debug UI is enabled', () => {
+  it('keeps Roomote chat reply results visible in narration mode when debug UI is enabled', () => {
     const entries = buildAcpRenderBlocks(
       [
         explorationToolMessage({

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/tool-presentation-policy.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/tool-presentation-policy.ts
@@ -37,6 +37,9 @@ const CONSEQUENTIAL_RECEIPTS = new Set([
   'cancel_task',
   'retry_task_start',
   'send_task_message',
+  'send_chat_reply',
+  'post_to_channel',
+  'send_chat_reaction_emoji',
   'save_memory',
 ]);
 

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/tool-presentation.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/tool-presentation.ts
@@ -302,6 +302,21 @@ function resolveReceiptLanguage(
       verb: byPhase('Sending', 'Sent', 'Failed to Send'),
       object: 'Task Message',
     };
+  if (toolName === 'send_chat_reply')
+    return {
+      verb: byPhase('Sending', 'Sent', 'Failed to Send'),
+      object: 'Chat Reply',
+    };
+  if (toolName === 'post_to_channel')
+    return {
+      verb: byPhase('Posting', 'Posted', 'Failed to Post'),
+      object: 'Channel Message',
+    };
+  if (toolName === 'send_chat_reaction_emoji')
+    return {
+      verb: byPhase('Adding', 'Added', 'Failed to Add'),
+      object: 'Chat Reaction',
+    };
   if (toolName === 'save_memory')
     return {
       verb: byPhase('Saving', 'Saved', 'Failed to Save'),


### PR DESCRIPTION
## Problem

`send_chat_reply`, `post_to_channel`, and `send_chat_reaction_emoji` were classified as internal debug rows in the web task transcript, so they rendered only with debug rows enabled. That made sense when they sat next to a visible answer. For a task delegated from a session, where the task reports through its orchestrator, the `send_chat_reply` *is* the result. The task page ended up showing the prompt and nothing else, which reads as stuck.

## Change

Treat the three outbound communication tools the way `send_task_message` is already treated:

- Removed from the internal-debug list (`message-visibility.ts`). `ignore_event` and `find_integration_tools` stay there since they have no user-visible effect.
- Added to the consequential-receipts set (`tool-presentation-policy.ts`), so they stay visible in narration mode, keep their own row instead of folding into an exploration group, and expand.
- Receipt language: "Sent Chat Reply", "Posted Channel Message", "Added Chat Reaction", with running and failed phases.
- Expanded details show the sent `message`, the posted `text`, or the reaction `name` from the call input, alongside the result, with the same sanitizing as `send_task_message`.

## Validation

- Updated the tests that pinned the old hiding behavior and added coverage for the new receipts, narration-mode visibility, expanded details for all three tools, and the remaining debug-only handling of `ignore_event`.
- `vitest` for the task transcript suites and `fast-sessions`, `check-types` for web, `oxlint`, and `oxfmt` all pass.
