### PR TITLE
[Fix] Subagent activity disappears from task and session transcripts

### DIFF
--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/subagent-visibility.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/subagent-visibility.client.test.ts
@@ -74,15 +74,19 @@ describe('subagent spawn row visibility', () => {
     expect(ids).not.toContain('plumbing-1');
   });
 
-  it('keeps thread-bound subagent rows hidden without debug visibility', () => {
+  it('renders thread-bound spawn rows without debug visibility', () => {
     const message = rebuiltSpawnMessage({
       id: 'thread-bound-1',
-      payload: { receiverThreadIds: ['thread-child'] },
+      status: 'completed',
+      payload: {
+        senderThreadId: 'session-1',
+        receiverThreadIds: ['thread-child'],
+      },
     });
 
     const ids = renderedIds([message], { showInternalMessages: false });
 
-    expect(ids).not.toContain('thread-bound-1');
+    expect(ids).toContain('thread-bound-1');
   });
 
   it('still shows non-spawn subagent payloads with debug visibility on', () => {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/tool-call-grouping.client.test.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/tool-call-grouping.client.test.ts
@@ -1566,7 +1566,7 @@ describe('buildAcpRenderBlocks', () => {
     expect(entries[1].childBlocks).toBeUndefined();
   });
 
-  it('hides child-session output when debug-gated subagent rows are hidden', () => {
+  it('nests child-session output under the parent subagent row in the default transcript', () => {
     const entries = buildAcpRenderBlocks(
       [
         textMessage('assistant-1', 1),
@@ -1586,16 +1586,26 @@ describe('buildAcpRenderBlocks', () => {
       { showInternalMessages: false },
     );
 
-    expect(entries).toHaveLength(2);
-    expect(entries.map((entry) => entry.kind)).toEqual(['message', 'message']);
-    expect(
-      entries.some(
-        (entry) =>
-          entry.kind === 'message' &&
-          entry.msg.kind === 'text' &&
-          entry.msg.text === 'Child agent says hello.',
-      ),
-    ).toBe(false);
+    expect(entries).toHaveLength(3);
+    expect(entries.map((entry) => entry.kind)).toEqual([
+      'message',
+      'message',
+      'message',
+    ]);
+
+    if (entries[1]?.kind !== 'message') {
+      throw new Error('Expected completed subagent row');
+    }
+
+    expect(entries[1].msg.id).toBe('tool-subagent-finished');
+    expect(entries[1].childBlocks).toHaveLength(1);
+    expect(entries[1].childBlocks?.[0]).toEqual({
+      kind: 'message',
+      msg: expect.objectContaining({
+        id: 'assistant-child-1',
+        text: 'Child agent says hello.',
+      }),
+    });
   });
 
   it('keeps the in-progress subagent spawn row visible in the default transcript', () => {
@@ -1640,7 +1650,7 @@ describe('buildAcpRenderBlocks', () => {
     expect(entries[2].msg.data.title).toBe('Spawned subagent');
   });
 
-  it('keeps spawn rows but hides thread-bound subagent rows when internal transcript rows are disabled', () => {
+  it('keeps pending and thread-bound spawn rows when internal transcript rows are disabled', () => {
     const entries = buildAcpRenderBlocks(
       [
         textMessage('assistant-1', 1),
@@ -1659,18 +1669,20 @@ describe('buildAcpRenderBlocks', () => {
       { showInternalMessages: false },
     );
 
-    expect(entries).toHaveLength(3);
+    expect(entries).toHaveLength(4);
     expect(entries.map((entry) => entry.kind)).toEqual([
+      'message',
       'message',
       'message',
       'message',
     ]);
 
-    if (entries[1]?.kind !== 'message') {
-      throw new Error('Expected pending spawn row entry');
+    if (entries[1]?.kind !== 'message' || entries[2]?.kind !== 'message') {
+      throw new Error('Expected pending and thread-bound spawn row entries');
     }
 
     expect(entries[1].msg.id).toBe('tool-subagent-pending');
+    expect(entries[2].msg.id).toBe('tool-subagent-completed');
   });
 
   it('keeps Roomote chat reply rows visible when internal transcript rows are disabled', () => {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/subagent-tool.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/subagent-tool.ts
@@ -26,21 +26,16 @@ export function isSubagentToolMessage(
  * stable payload shape, not on the live-only `subagentActivity` field: that
  * field is streamed but never persisted, so any rule that depends on it
  * hides the row again after a transcript rebuild (page refresh) until the
- * next live update arrives. Subagent messages bound to receiver threads are
- * excluded — those surface through the active-subtasks list instead of an
- * inline row.
+ * next live update arrives. Thread-bound rows (`receiverThreadIds` set to the
+ * child session) stay visible too: the harness binds every spawn row once the
+ * child session is known, and the transcript nests that child's activity under
+ * the row, so hiding it would drop the whole subagent from the default view.
  */
 export function isSubagentSpawnRowMessage(
   msg: AcpUiMessage,
 ): msg is AcpToolCallUiMessage | AcpToolResultUiMessage {
-  if (
-    (msg.kind !== 'tool_call' && msg.kind !== 'tool_result') ||
-    msg.data.kind !== 'subagent'
-  ) {
-    return false;
-  }
-
-  const receiverThreadIds = msg.data.receiverThreadIds;
-
-  return !Array.isArray(receiverThreadIds) || receiverThreadIds.length === 0;
+  return (
+    (msg.kind === 'tool_call' || msg.kind === 'tool_result') &&
+    msg.data.kind === 'subagent'
+  );
 }


### PR DESCRIPTION
## What changed

- `isSubagentSpawnRowMessage` now treats every `kind: 'subagent'` tool row as a transcript-visible spawn row, regardless of whether `receiverThreadIds` is bound to a child session.
- Updated the render-block tests so thread-bound spawn rows stay visible in the default transcript and child-session output nests under them without debug visibility.

## Why this change was made

#2063 changed the OpenCode worker harness to stamp `senderThreadId` / `receiverThreadIds` onto task-tool spawn rows so linked child-session activity could be recovered in history. The web transcript still had a legacy rule that hid thread-bound spawn rows unless internal rows were enabled, on the assumption they surfaced through the active-subtasks list instead. That list only shows running subtasks, and the transcript nests child-session messages under the spawn row, so hiding the row dropped the entire subagent (spawn, result, and nested activity) from task transcripts and from nested task activity in Sessions once #2063 shipped.

## Impact

Subagent spawn rows and their nested child-session activity show up again in task transcripts and in Session views, both live and after a refresh. Debug-only gating still applies to non-spawn internal subagent plumbing rows.