### PR TITLE
feat: stream Fast replies into Slack threads

### DIFF
--- a/.changeset/fast-slack-reply-streaming.md
+++ b/.changeset/fast-slack-reply-streaming.md
@@ -1,0 +1,8 @@
+---
+'@roomote/api': patch
+'@roomote/cloud-agents': patch
+'@roomote/sdk': patch
+'@roomote/slack': patch
+---
+
+Stream Fast replies into Slack threads with Slack's message streaming API while the model writes them; the finished message keeps the usual reply body and sticky footer.

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -28,6 +28,7 @@ import {
   wakeFastAgentParentEventAt,
   wakeFastAgentParentEventNow,
   type FastAgentDurableTurn,
+  createSlackFastReplyStream,
   recordFastAgentConversationMessageBestEffort,
   resolveUserMcpServerConfigs,
 } from '@roomote/sdk/server';
@@ -366,6 +367,24 @@ export async function processFastAgentMessage(params: {
             includeRoomoteMemberTools: true,
           }),
         launchTask,
+        ...(event.user
+          ? {
+              createReplyStream: () =>
+                createSlackFastReplyStream({
+                  slack,
+                  conversation,
+                  channelId: event.channel,
+                  threadTs: threadId,
+                  recipientTeamId: teamId,
+                  recipientUserId: event.user,
+                  sessionId: session.id,
+                  footerContext,
+                  onDelivered: () => {
+                    didSendVisibleResponse = true;
+                  },
+                }),
+            }
+          : {}),
         postReply: async ({ message, kickoff }) => {
           const posted = await postSlackThreadMarkdownMessage({
             slack,

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -34,7 +34,10 @@ import {
 } from '@roomote/sdk/server';
 
 import { LEADING_FAST_COMMAND_MENTION_PATTERN } from '../constants.js';
-import { postSlackThreadMarkdownMessage } from '../helpers/thread-posting.js';
+import {
+  postSlackThreadMarkdownMessage,
+  guardReplyStreamBySourceMessage,
+} from '../helpers/thread-posting.js';
 import { processSlackAttachments } from '../helpers/attachments.js';
 
 export function stripLeadingFastCommandMention(text: string): string {
@@ -370,19 +373,27 @@ export async function processFastAgentMessage(params: {
         ...(event.user
           ? {
               createReplyStream: () =>
-                createSlackFastReplyStream({
-                  slack,
-                  conversation,
-                  channelId: event.channel,
-                  threadTs: threadId,
-                  recipientTeamId: teamId,
-                  recipientUserId: event.user,
-                  sessionId: session.id,
-                  footerContext,
-                  onDelivered: () => {
-                    didSendVisibleResponse = true;
+                guardReplyStreamBySourceMessage(
+                  createSlackFastReplyStream({
+                    slack,
+                    conversation,
+                    channelId: event.channel,
+                    threadTs: threadId,
+                    recipientTeamId: teamId,
+                    recipientUserId: event.user,
+                    sessionId: session.id,
+                    footerContext,
+                    onDelivered: () => {
+                      didSendVisibleResponse = true;
+                    },
+                  }),
+                  {
+                    slack,
+                    channel: event.channel,
+                    threadTs: threadId,
+                    sourceMessageTs: event.ts,
                   },
-                }),
+                ),
             }
           : {}),
         postReply: async ({ message, kickoff }) => {

--- a/apps/api/src/handlers/slack/helpers/__tests__/thread-posting-stream-guard.test.ts
+++ b/apps/api/src/handlers/slack/helpers/__tests__/thread-posting-stream-guard.test.ts
@@ -1,0 +1,74 @@
+vi.mock('../../../../logging.js', () => ({
+  apiLogger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { guardReplyStreamBySourceMessage } from '../thread-posting';
+
+function fakeStream() {
+  return {
+    append: vi.fn(async () => {}),
+    finish: vi.fn(async () => ({ messageId: 'reply-ts' })),
+    abort: vi.fn(async () => {}),
+  };
+}
+
+const params = { channel: 'C1', threadTs: '100.1', sourceMessageTs: '100.2' };
+
+describe('guardReplyStreamBySourceMessage', () => {
+  it('streams and finishes while the source message is still in the thread', async () => {
+    const inner = fakeStream();
+    const slack = { hasMessageInThread: vi.fn(async () => true) };
+    const guarded = guardReplyStreamBySourceMessage(inner, {
+      slack,
+      ...params,
+    });
+
+    await guarded.append('Hel');
+    await guarded.append('lo');
+    expect(inner.append).toHaveBeenCalledTimes(2);
+    // The open-time check is made once; the finish re-checks.
+    expect(slack.hasMessageInThread).toHaveBeenCalledTimes(1);
+    await expect(
+      guarded.finish({ purpose: 'closeout', message: 'Hello' }),
+    ).resolves.toEqual({ messageId: 'reply-ts' });
+    expect(slack.hasMessageInThread).toHaveBeenCalledTimes(2);
+  });
+
+  it('never opens a stream for a deleted source and yields no delivery', async () => {
+    const inner = fakeStream();
+    const slack = { hasMessageInThread: vi.fn(async () => false) };
+    const guarded = guardReplyStreamBySourceMessage(inner, {
+      slack,
+      ...params,
+    });
+
+    await guarded.append('Hello');
+    expect(inner.append).not.toHaveBeenCalled();
+    await expect(
+      guarded.finish({ purpose: 'closeout', message: 'Hello' }),
+    ).resolves.toBeUndefined();
+    expect(inner.finish).not.toHaveBeenCalled();
+  });
+
+  it('ends a stream whose source was deleted mid-way and treats an unknown state as present', async () => {
+    const inner = fakeStream();
+    const slack = {
+      hasMessageInThread: vi
+        .fn<() => Promise<boolean | null>>()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(false),
+    };
+    const guarded = guardReplyStreamBySourceMessage(inner, {
+      slack,
+      ...params,
+    });
+
+    await guarded.append('Hello');
+    expect(inner.append).toHaveBeenCalledTimes(1);
+    await expect(
+      guarded.finish({ purpose: 'closeout', message: 'Hello' }),
+    ).resolves.toBeUndefined();
+    expect(inner.abort).toHaveBeenCalledTimes(1);
+    expect(inner.finish).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/handlers/slack/helpers/thread-posting.ts
+++ b/apps/api/src/handlers/slack/helpers/thread-posting.ts
@@ -1,4 +1,5 @@
 import { Env } from '@roomote/env';
+import type { FastAgentReplyStream } from '@roomote/cloud-agents/server';
 import { AGENT_DISPLAY_NAME, formatErrorForLog } from '@roomote/types';
 import {
   findSlackConversationSubjectByUserId,
@@ -174,4 +175,44 @@ export async function postTaskSuggestionStartedMessage(params: {
       `[SlackWebhook] Failed to post task suggestion started message for ${channelId}:${threadTs}: ${formatErrorForLog(error)}`,
     );
   }
+}
+
+/**
+ * Applies the deleted-source rule to a streamed reply: the stream opens only
+ * while the triggering message is still in the thread, and a source deleted
+ * mid-stream ends it without a delivery so the regular post path suppresses
+ * the reply exactly as it would have.
+ */
+export function guardReplyStreamBySourceMessage(
+  stream: FastAgentReplyStream,
+  params: {
+    slack: Pick<SlackNotifier, 'hasMessageInThread'>;
+    channel: string;
+    threadTs: string;
+    sourceMessageTs: string;
+  },
+): FastAgentReplyStream {
+  const sourceMessagePresent = async () =>
+    (await params.slack.hasMessageInThread({
+      channel: params.channel,
+      threadTs: params.threadTs,
+      messageTs: params.sourceMessageTs,
+    })) !== false;
+  let presentAtOpen: Promise<boolean> | undefined;
+
+  return {
+    append: async (text) => {
+      presentAtOpen ??= sourceMessagePresent();
+      if (await presentAtOpen) await stream.append(text);
+    },
+    finish: async (reply) => {
+      if (await sourceMessagePresent()) return stream.finish(reply);
+      apiLogger.debug(
+        `[SlackWebhook] Ending the streamed fast-agent reply because source message ${params.sourceMessageTs} is no longer in thread ${params.threadTs}`,
+      );
+      await stream.abort();
+      return undefined;
+    },
+    abort: () => stream.abort(),
+  };
 }

--- a/apps/docs/fast-sessions.mdx
+++ b/apps/docs/fast-sessions.mdx
@@ -94,7 +94,8 @@ posting a duplicate acknowledgement.
 Fast replies across Slack, Discord, Microsoft Teams, and Telegram link back to
 the Session view and can resume the same Session directly from chat. Roomote
 verifies the provider installation, conversation, and linked user before it
-accepts the follow-up.
+accepts the follow-up. On Slack, a longer reply streams into the thread as the
+model writes it and settles into the finished message.
 
 Follow-ups sent while Fast is responding are retained before Roomote reports
 that they were accepted. A correction from the same person can steer the active

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -222,6 +222,23 @@ vi.mock('../fast-agent-title', () => ({
   refreshFastAgentSessionTitle: mocks.refreshTitle,
 }));
 
+vi.mock('../fast-agent-surface-reply-stream', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../fast-agent-surface-reply-stream')>();
+  return {
+    ...actual,
+    // Tests drive the stream synchronously; no start delay or pacing.
+    createFastAgentSurfaceReplyStreamer: (
+      options: Parameters<typeof actual.createFastAgentSurfaceReplyStreamer>[0],
+    ) =>
+      actual.createFastAgentSurfaceReplyStreamer({
+        ...options,
+        startDelayMs: 0,
+        intervalMs: 0,
+      }),
+  };
+});
+
 vi.mock('@roomote/redis', () => ({
   getRedis: () => ({ publish: mocks.publishReplyStream }),
 }));
@@ -7878,6 +7895,95 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       const streamed = streamedReplies();
       expect(streamed).toEqual([[expect.any(String), 'Scratch that.']]);
       expect(persistedAssistantRows().at(-1)?.eventId).toBe(streamed[0]![0]);
+    });
+
+    it('streams a long reply into the surface and delivers through the stream', async () => {
+      const streamCalls: string[] = [];
+      const createReplyStream = vi.fn(() => ({
+        append: vi.fn(async (text: string) => {
+          streamCalls.push(`append:${text}`);
+        }),
+        finish: vi.fn(async (reply: { message: string }) => {
+          streamCalls.push(`finish:${reply.message}`);
+          return { messageId: 'slack-ts-1' };
+        }),
+        abort: vi.fn(async () => {
+          streamCalls.push('abort');
+        }),
+      }));
+      const postReply = vi.fn().mockResolvedValue({ messageId: 'posted' });
+      const tick = () => new Promise((resolve) => setTimeout(resolve, 5));
+      mocks.generateText.mockImplementation(
+        async (_params, _session, options) => {
+          await options.onSessionReady('opencode-session-1');
+          options.onAssistantTextUpdated?.({
+            messageId: 'assistant-message-1',
+            partId: 'text-1',
+            text: 'Looking at',
+            completed: false,
+          });
+          await tick();
+          options.onAssistantTextUpdated?.({
+            messageId: 'assistant-message-1',
+            partId: 'text-1',
+            text: 'Looking at the deploy history.',
+            completed: true,
+          });
+          await tick();
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'closeout',
+          });
+          return 'Looking at the deploy history.';
+        },
+      );
+
+      await answerFastAgentQuestion({
+        ...baseParams,
+        adapter: callbacks({ postReply, createReplyStream }),
+      });
+
+      expect(createReplyStream).toHaveBeenCalledTimes(1);
+      expect(streamCalls).toEqual([
+        'append:Looking at',
+        'append: the deploy history.',
+        'finish:Looking at the deploy history.',
+      ]);
+      expect(postReply).not.toHaveBeenCalled();
+      expect(persistedAssistantRows().at(-1)?.metadata).toMatchObject({
+        platformMessageId: 'slack-ts-1',
+      });
+    });
+
+    it('posts a reply that finished writing before the stream opened', async () => {
+      const createReplyStream = vi.fn();
+      const postReply = vi.fn().mockResolvedValue({ messageId: 'posted' });
+      mocks.generateText.mockImplementation(
+        async (_params, _session, options) => {
+          await options.onSessionReady('opencode-session-1');
+          options.onAssistantTextUpdated?.({
+            messageId: 'assistant-message-1',
+            partId: 'text-1',
+            text: 'Done.',
+            completed: true,
+          });
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'closeout',
+          });
+          return 'Done.';
+        },
+      );
+
+      await answerFastAgentQuestion({
+        ...baseParams,
+        adapter: callbacks({ postReply, createReplyStream }),
+      });
+
+      expect(createReplyStream).not.toHaveBeenCalled();
+      expect(postReply).toHaveBeenCalledWith({
+        purpose: 'closeout',
+        message: 'Done.',
+      });
     });
 
     it('stops streaming text that follows a closeout', async () => {

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-surface-reply-stream.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-surface-reply-stream.test.ts
@@ -1,0 +1,106 @@
+import type { FastAgentReplyStream } from '../fast-agent-conversation';
+import { createFastAgentSurfaceReplyStreamer } from '../fast-agent-surface-reply-stream';
+
+function fakeStream() {
+  const calls: string[] = [];
+  const stream: FastAgentReplyStream = {
+    append: vi.fn(async (text: string) => {
+      calls.push(`append:${text}`);
+    }),
+    finish: vi.fn(async (reply) => {
+      calls.push(`finish:${reply.message}`);
+      return { messageId: 'ts-1' };
+    }),
+    abort: vi.fn(async () => {
+      calls.push('abort');
+    }),
+  };
+  return { stream, calls };
+}
+
+describe('createFastAgentSurfaceReplyStreamer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('opens a stream only for text still being written after the start delay, paces appends, and finishes with the reply', async () => {
+    const { stream, calls } = fakeStream();
+    const createStream = vi.fn(() => stream);
+    const streamer = createFastAgentSurfaceReplyStreamer({
+      createStream,
+      startDelayMs: 100,
+      intervalMs: 50,
+    });
+
+    streamer.update('Looking', true);
+    await vi.advanceTimersByTimeAsync(99);
+    expect(createStream).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(createStream).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['append:Looking']);
+
+    streamer.update('Looking at', true);
+    streamer.update('Looking at the logs', true);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(calls).toEqual(['append:Looking', 'append: at the logs']);
+
+    await expect(
+      streamer.deliver({
+        purpose: 'closeout',
+        message: 'Looking at the logs.',
+      }),
+    ).resolves.toEqual({ messageId: 'ts-1' });
+    expect(calls.at(-1)).toBe('finish:Looking at the logs.');
+    expect(createStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('posts normally when the reply finished before the start delay or has no stream', async () => {
+    const { stream } = fakeStream();
+    const createStream = vi.fn(() => stream);
+    const streamer = createFastAgentSurfaceReplyStreamer({
+      createStream,
+      startDelayMs: 100,
+    });
+
+    streamer.update('Done.', false);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(createStream).not.toHaveBeenCalled();
+    await expect(
+      streamer.deliver({ purpose: 'closeout', message: 'Done.' }),
+    ).resolves.toBeUndefined();
+
+    const inert = createFastAgentSurfaceReplyStreamer({});
+    inert.update('Still writing', true);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await expect(
+      inert.deliver({ purpose: 'closeout', message: 'x' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('aborts an unfinished stream and survives surface failures', async () => {
+    const { stream, calls } = fakeStream();
+    vi.mocked(stream.append).mockRejectedValueOnce(new Error('rate limited'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const streamer = createFastAgentSurfaceReplyStreamer({
+      createStream: () => stream,
+      startDelayMs: 10,
+      intervalMs: 10,
+    });
+
+    streamer.update('Half', true);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Surface reply stream step failed'),
+    );
+    await streamer.abort();
+    expect(calls.at(-1)).toBe('abort');
+    // A second abort or deliver without an active stream is a no-op.
+    await streamer.abort();
+    await expect(
+      streamer.deliver({ purpose: 'closeout', message: 'x' }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation.ts
@@ -82,6 +82,19 @@ export type FastAgentReplyHandle = {
   messageId: string;
 };
 
+/**
+ * A reply rendered on its surface while the model is still writing it.
+ * `append` opens the stream on first use and extends it afterwards;
+ * `finish` ends it with the delivered reply and returns the message, or
+ * nothing when the stream never opened so the caller posts normally;
+ * `abort` ends it without a reply, leaving what was streamed.
+ */
+export type FastAgentReplyStream = {
+  append: (text: string) => Promise<void>;
+  finish: (reply: FastAgentReply) => Promise<FastAgentReplyHandle | undefined>;
+  abort: () => Promise<void>;
+};
+
 export type FastAgentReaction = {
   name: string;
   purpose: 'ack' | 'closeout';
@@ -160,6 +173,8 @@ export type FastAgentTurnAdapter = {
    */
   assertTaskLaunch?: () => Promise<void>;
   postReply: (reply: FastAgentReply) => Promise<FastAgentReplyHandle | void>;
+  /** Surfaces with a streaming API render the reply as it is written. */
+  createReplyStream?: () => FastAgentReplyStream;
   replaceReply?: (
     handle: FastAgentReplyHandle,
     reply: FastAgentReply,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -103,6 +103,7 @@ import {
   createFastAgentReplyStreamPublisher,
   createFastAgentReplyTextTracker,
 } from './fast-agent-reply-stream';
+import { createFastAgentSurfaceReplyStreamer } from './fast-agent-surface-reply-stream';
 import { RemoteFastAgentSettingsSkillSource } from './fast-agent-settings-skill-source';
 import { buildFastAgentExplicitSkillInvocationContext } from './fast-agent-skill-invocation';
 import {
@@ -1584,6 +1585,14 @@ export async function answerFastAgentQuestion({
   let streamedReply:
     | { eventId: string; turnSeq: number; sentText: string }
     | undefined;
+  // A chat surface with a streaming API renders the same undelivered text
+  // as it is written; the reply that delivers it takes over that message.
+  // Platform events (automation reports, task settlements) post whole.
+  const surfaceReplyStream = createFastAgentSurfaceReplyStreamer({
+    ...(adapter.createReplyStream && !platformEvent
+      ? { createStream: adapter.createReplyStream }
+      : {}),
+  });
   const onAssistantTextUpdated = (update: NonTaskOpenCodeAssistantText) => {
     replyTextTracker.apply(update);
     // Text after a closeout belongs to the trailing model request that the
@@ -1591,6 +1600,7 @@ export async function answerFastAgentQuestion({
     if (isInstructionClosed(getInstructionVersion(update.messageId))) return;
     const text = replyTextTracker.unconsumedText();
     if (!text.trim()) return;
+    surfaceReplyStream.update(text, replyTextTracker.hasIncompleteUnconsumed());
     streamedReply ??= {
       ...allocateCanonicalEvent(`assistant:${nextAssistantOrdinal++}`),
       sentText: '',
@@ -2542,7 +2552,9 @@ export async function answerFastAgentQuestion({
         diagnostics.recordVisibleReply(),
       );
       if (!replacedRetry) {
-        const posted = await adapter.postReply(reply);
+        const posted =
+          (await surfaceReplyStream.deliver(reply)) ??
+          (await adapter.postReply(reply));
         diagnostics.recordVisibleReply();
         turnVisibleMessages.push(buildAssistantTextMessage(reply.message));
         await persistAssistantReply({
@@ -2698,7 +2710,12 @@ export async function answerFastAgentQuestion({
       // Deliberately not the postReply closure: a system retry notice must
       // not satisfy the model's acknowledgement gate or close the turn.
       if (!(await replaceInferenceRetryReply(reply))) {
-        inferenceRetryReply = (await adapter.postReply(reply)) || undefined;
+        // A reply already streaming becomes the notice carrier rather than
+        // leaving a cut-off draft above it.
+        inferenceRetryReply =
+          (await surfaceReplyStream.deliver(reply)) ??
+          (await adapter.postReply(reply)) ??
+          undefined;
         inferenceRetryMessageIndex = turnVisibleMessages.length;
         turnVisibleMessages.push(buildAssistantTextMessage(message));
         await persistAssistantReply({
@@ -3140,6 +3157,7 @@ export async function answerFastAgentQuestion({
             if (completedChatReplySignatures.has(signature)) {
               replyTextTracker.consumeUnconsumed();
               dropStreamedReply();
+              await surfaceReplyStream.abort();
               return {
                 success: true,
                 delivered: true,
@@ -4283,7 +4301,9 @@ export async function answerFastAgentQuestion({
             message: RESTARTED_ACTIVE_TURN_MESSAGE,
           };
           try {
-            const posted = await adapter.postReply(reply);
+            const posted =
+              (await surfaceReplyStream.deliver(reply)) ??
+              (await adapter.postReply(reply));
             diagnostics.recordVisibleReply();
             const retryEvent = inferenceRetryCanonicalEvent;
             await persistAssistantReply({
@@ -4358,7 +4378,9 @@ export async function answerFastAgentQuestion({
             diagnostics.recordVisibleReply(),
           ))
         ) {
-          const posted = await adapter.postReply(reply);
+          const posted =
+            (await surfaceReplyStream.deliver(reply)) ??
+            (await adapter.postReply(reply));
           diagnostics.recordVisibleReply();
           turnVisibleMessages.push(buildAssistantTextMessage(message));
           await persistAssistantReply({
@@ -4432,6 +4454,9 @@ export async function answerFastAgentQuestion({
       }
     }
     dropStreamedReply();
+    // A stream no reply finished (a cancelled or parked turn) is closed so
+    // Slack stops showing it as still writing; its text stays.
+    await surfaceReplyStream.abort();
     await replyStream.dispose();
     await adapter.activity?.settle().catch((error) => {
       console.warn(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-surface-reply-stream.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-surface-reply-stream.ts
@@ -1,0 +1,142 @@
+import type {
+  FastAgentReply,
+  FastAgentReplyHandle,
+  FastAgentReplyStream,
+} from './fast-agent-conversation';
+
+/**
+ * A reply still being written this long after its text started streaming
+ * opens a surface stream; a reply that finishes sooner posts as one message,
+ * which keeps short answers from spending a stream on every turn.
+ */
+export const FAST_AGENT_SURFACE_STREAM_START_DELAY_MS = 750;
+/** Minimum spacing between appends to one surface stream. */
+export const FAST_AGENT_SURFACE_STREAM_INTERVAL_MS = 500;
+
+/**
+ * Drives one surface reply stream at a time from the turn's undelivered
+ * reply text. Appends are coalesced and rate-paced; the delivering reply
+ * finishes the stream and takes over its message. Every surface call is
+ * serialized and best effort: a failure leaves the persisted delivery path
+ * untouched.
+ */
+export function createFastAgentSurfaceReplyStreamer(options: {
+  createStream?: () => FastAgentReplyStream;
+  startDelayMs?: number;
+  intervalMs?: number;
+}) {
+  const startDelayMs =
+    options.startDelayMs ?? FAST_AGENT_SURFACE_STREAM_START_DELAY_MS;
+  const intervalMs =
+    options.intervalMs ?? FAST_AGENT_SURFACE_STREAM_INTERVAL_MS;
+  let stream: FastAgentReplyStream | undefined;
+  let sentText = '';
+  let latestText = '';
+  let latestIncomplete = false;
+  let startTimer: NodeJS.Timeout | undefined;
+  let appendTimer: NodeJS.Timeout | undefined;
+  let lastAppendAtMs = 0;
+  let chain: Promise<void> = Promise.resolve();
+
+  const run = (step: () => Promise<void>) => {
+    chain = chain.then(step).catch((error) => {
+      console.warn(
+        `[Fast Agent] Surface reply stream step failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    });
+  };
+  const clearTimers = () => {
+    if (startTimer) clearTimeout(startTimer);
+    if (appendTimer) clearTimeout(appendTimer);
+    startTimer = undefined;
+    appendTimer = undefined;
+  };
+  const appendPending = () => {
+    appendTimer = undefined;
+    const active = stream;
+    if (!active) return;
+    // Only appends stream; a rewrite of earlier text is left to the finish.
+    if (!latestText.startsWith(sentText)) return;
+    const delta = latestText.slice(sentText.length);
+    if (!delta) return;
+    sentText = latestText;
+    lastAppendAtMs = Date.now();
+    run(() => active.append(delta));
+  };
+  const scheduleAppend = () => {
+    if (appendTimer || !stream) return;
+    const wait = Math.max(0, lastAppendAtMs + intervalMs - Date.now());
+    appendTimer = setTimeout(appendPending, wait);
+    appendTimer.unref?.();
+  };
+  const reset = () => {
+    clearTimers();
+    const active = stream;
+    stream = undefined;
+    sentText = '';
+    latestText = '';
+    latestIncomplete = false;
+    return active;
+  };
+
+  return {
+    /** The undelivered reply text so far and whether it is still growing. */
+    update(text: string, incomplete: boolean): void {
+      const createStream = options.createStream;
+      if (!createStream) return;
+      latestText = text;
+      latestIncomplete = incomplete;
+      if (stream) {
+        scheduleAppend();
+        return;
+      }
+      if (startTimer) return;
+      startTimer = setTimeout(() => {
+        startTimer = undefined;
+        if (stream || !latestIncomplete || !latestText.trim()) return;
+        const opened = createStream();
+        stream = opened;
+        sentText = latestText;
+        lastAppendAtMs = Date.now();
+        const text = latestText;
+        run(() => opened.append(text));
+      }, startDelayMs);
+      startTimer.unref?.();
+    },
+    /**
+     * Finishes the active stream with the reply that delivers it. Returns
+     * the message the reply now lives in, or nothing when no stream carried
+     * it so the caller posts the reply itself.
+     */
+    async deliver(
+      reply: FastAgentReply,
+    ): Promise<FastAgentReplyHandle | undefined> {
+      const active = reset();
+      if (!active) return undefined;
+      await chain;
+      try {
+        return await active.finish(reply);
+      } catch (error) {
+        console.warn(
+          `[Fast Agent] Failed to finish a surface reply stream: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        return undefined;
+      }
+    },
+    /** Ends the active stream without a reply, leaving its text as is. */
+    async abort(): Promise<void> {
+      const active = reset();
+      if (!active) return;
+      await chain;
+      await active.abort().catch((error) => {
+        console.warn(
+          `[Fast Agent] Failed to end a surface reply stream: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+    },
+  };
+}
+
+export type FastAgentSurfaceReplyStreamer = ReturnType<
+  typeof createFastAgentSurfaceReplyStreamer
+>;

--- a/packages/cloud-agents/src/server/fast-agent/index.ts
+++ b/packages/cloud-agents/src/server/fast-agent/index.ts
@@ -3,6 +3,7 @@ export * from './fast-agent-conversation';
 export * from './fast-agent-conversation-repository';
 export * from './fast-agent-prompt';
 export * from './fast-agent-reply-stream';
+export * from './fast-agent-surface-reply-stream';
 export * from './fast-agent-service';
 export * from './fast-agent-turn-lock';
 export * from './fast-agent-session';

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -314,6 +314,7 @@ export {
 export * from './lib/task-runs/pr-review-action';
 export * from './lib/task-runs/pr-review-follow-up-dispatch';
 export * from './lib/fast-agent-surface-reply';
+export * from './lib/fast-agent-slack-reply-stream';
 export * from './lib/fast-agent-provider-message';
 export * from './lib/task-runs/notify-fast-agent-parent-on-pr-feedback';
 export * from './lib/task-runs/notify-fast-agent-parent-on-pull-request-conflict';

--- a/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.test.ts
@@ -153,6 +153,24 @@ describe('createSlackFastReplyStream', () => {
     );
   });
 
+  it('yields no delivery when the final rewrite is rejected so the reply is posted instead', async () => {
+    const slack = slackMock();
+    mocks.updateWithFooter.mockResolvedValue(false);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { stream, onDelivered } = build(slack, null);
+
+    await stream.append('Looking');
+    await expect(
+      stream.finish({ purpose: 'closeout', message: 'Looking.' }),
+    ).resolves.toBeUndefined();
+    expect(slack.stopMessageStream).toHaveBeenCalledTimes(1);
+    expect(mocks.recordMessage).not.toHaveBeenCalled();
+    expect(onDelivered).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('did not accept the final body'),
+    );
+  });
+
   it('aborts by stopping the stream and leaving its text', async () => {
     const slack = slackMock();
     const { stream } = build(slack, null);

--- a/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.test.ts
@@ -1,0 +1,167 @@
+const mocks = vi.hoisted(() => ({
+  updateWithFooter: vi.fn(),
+  recordMessage: vi.fn(),
+}));
+
+vi.mock('@roomote/slack', () => ({
+  ROOMOTE_THREAD_REPLY_QUOTE_BLOCK_ID: 'quote',
+  updateSlackThreadMessageWithFooterText: mocks.updateWithFooter,
+}));
+vi.mock('@roomote/communication', () => ({
+  buildFastSessionReplyFooterText: () => 'footer',
+}));
+vi.mock('./fast-agent-provider-message', () => ({
+  recordFastAgentConversationMessageBestEffort: mocks.recordMessage,
+}));
+
+import { createSlackFastReplyStream } from './fast-agent-slack-reply-stream';
+
+const conversation = {
+  surface: 'slack' as const,
+  workspaceId: 'T1',
+  conversationId: '100.1',
+  replyTarget: { channelId: 'C1', threadId: '100.1' },
+};
+
+function slackMock() {
+  return {
+    startMessageStream: vi.fn<() => Promise<string | null>>(
+      async () => '200.1',
+    ),
+    appendMessageStream: vi.fn(async () => true),
+    stopMessageStream: vi.fn(async () => true),
+    updateMessage: vi.fn(async () => true),
+    getMessageBlocks: vi.fn(async () => []),
+  };
+}
+
+function build(slack: ReturnType<typeof slackMock>, quote: string | null) {
+  let pendingQuote = quote;
+  const onDelivered = vi.fn();
+  const stream = createSlackFastReplyStream({
+    slack,
+    conversation: conversation as never,
+    channelId: 'C1',
+    threadTs: '100.1',
+    recipientTeamId: 'T1',
+    recipientUserId: 'U1',
+    sessionId: 'session-1',
+    footerContext: {} as never,
+    takeQuote: () => {
+      const value = pendingQuote;
+      pendingQuote = null;
+      return value;
+    },
+    onDelivered,
+  });
+  return { stream, onDelivered };
+}
+
+describe('createSlackFastReplyStream', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateWithFooter.mockResolvedValue(true);
+    mocks.recordMessage.mockResolvedValue(undefined);
+  });
+
+  it('starts on the first append, appends after, and finishes into the canonical reply body', async () => {
+    const slack = slackMock();
+    const { stream, onDelivered } = build(slack, '> Matt: hi');
+
+    await stream.append('Looking');
+    await stream.append(' at the logs');
+    expect(slack.startMessageStream).toHaveBeenCalledWith({
+      channel: 'C1',
+      threadTs: '100.1',
+      recipientTeamId: 'T1',
+      recipientUserId: 'U1',
+      markdownText: 'Looking',
+    });
+    expect(slack.appendMessageStream).toHaveBeenCalledWith({
+      channel: 'C1',
+      ts: '200.1',
+      markdownText: ' at the logs',
+    });
+
+    await expect(
+      stream.finish({ purpose: 'closeout', message: 'Looking at the logs.' }),
+    ).resolves.toEqual({ messageId: '200.1' });
+    expect(slack.stopMessageStream).toHaveBeenCalledWith({
+      channel: 'C1',
+      ts: '200.1',
+    });
+    expect(mocks.updateWithFooter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'C1',
+        threadTs: '100.1',
+        messageTs: '200.1',
+        text: '> Matt: hi\nLooking at the logs.',
+        bodyBlocks: [
+          {
+            type: 'section',
+            block_id: 'quote',
+            text: { type: 'mrkdwn', text: '> Matt: hi' },
+          },
+          { type: 'markdown', text: 'Looking at the logs.' },
+        ],
+        footerText: 'footer',
+      }),
+    );
+    expect(mocks.recordMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-1', messageId: '200.1' }),
+    );
+    expect(onDelivered).toHaveBeenCalledOnce();
+    // Finishing twice or aborting afterwards does nothing more.
+    await expect(
+      stream.finish({ purpose: 'closeout', message: 'again' }),
+    ).resolves.toBeUndefined();
+    await stream.abort();
+    expect(slack.stopMessageStream).toHaveBeenCalledTimes(1);
+  });
+
+  it('yields nothing when the stream never opened so the caller posts normally', async () => {
+    const slack = slackMock();
+    slack.startMessageStream.mockResolvedValue(null);
+    const { stream, onDelivered } = build(slack, null);
+
+    await stream.append('Looking');
+    await stream.append(' more');
+    expect(slack.startMessageStream).toHaveBeenCalledTimes(1);
+    expect(slack.appendMessageStream).not.toHaveBeenCalled();
+    await expect(
+      stream.finish({ purpose: 'closeout', message: 'Done.' }),
+    ).resolves.toBeUndefined();
+    expect(mocks.updateWithFooter).not.toHaveBeenCalled();
+    expect(onDelivered).not.toHaveBeenCalled();
+  });
+
+  it('stops appending after a failed append but still finishes with the full reply', async () => {
+    const slack = slackMock();
+    slack.appendMessageStream.mockResolvedValueOnce(false);
+    const { stream } = build(slack, null);
+
+    await stream.append('One');
+    await stream.append(' two');
+    await stream.append(' three');
+    expect(slack.appendMessageStream).toHaveBeenCalledTimes(1);
+
+    await expect(
+      stream.finish({ purpose: 'closeout', message: 'One two three.' }),
+    ).resolves.toEqual({ messageId: '200.1' });
+    expect(mocks.updateWithFooter).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'One two three.' }),
+    );
+  });
+
+  it('aborts by stopping the stream and leaving its text', async () => {
+    const slack = slackMock();
+    const { stream } = build(slack, null);
+    await stream.append('Half');
+    await stream.abort();
+    expect(slack.stopMessageStream).toHaveBeenCalledWith({
+      channel: 'C1',
+      ts: '200.1',
+    });
+    expect(mocks.updateWithFooter).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.ts
+++ b/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.ts
@@ -101,9 +101,12 @@ export function createSlackFastReplyStream(params: {
         }),
       });
       if (!updated) {
+        // The streamed draft stays as it is; the caller posts the reply in
+        // full rather than treating the draft as the delivery.
         console.warn(
-          `[Fast Agent] Slack kept the streamed text for reply ${ts}; the final body could not be written.`,
+          `[Fast Agent] Slack did not accept the final body for streamed reply ${ts}; posting the reply instead.`,
         );
+        return undefined;
       }
       await recordFastAgentConversationMessageBestEffort({
         sessionId: params.sessionId,

--- a/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.ts
+++ b/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.ts
@@ -1,0 +1,123 @@
+import type {
+  FastAgentConversation,
+  FastAgentReplyStream,
+} from '@roomote/cloud-agents/server';
+import {
+  buildFastSessionReplyFooterText,
+  type FastSessionReplyFooterContext,
+} from '@roomote/communication';
+import {
+  ROOMOTE_THREAD_REPLY_QUOTE_BLOCK_ID,
+  updateSlackThreadMessageWithFooterText,
+  type SlackNotifier,
+} from '@roomote/slack';
+
+import { recordFastAgentConversationMessageBestEffort } from './fast-agent-provider-message';
+
+/**
+ * Streams a Fast reply into a Slack thread with Slack's message streaming
+ * API, then rewrites the finished message into the same body the reply
+ * would have been posted with (quote, markdown block, sticky footer).
+ * Streaming outside a DM needs the recipient; callers without a Slack user
+ * for the sender do not offer a stream.
+ */
+export function createSlackFastReplyStream(params: {
+  slack: Pick<
+    SlackNotifier,
+    | 'startMessageStream'
+    | 'appendMessageStream'
+    | 'stopMessageStream'
+    | 'updateMessage'
+    | 'getMessageBlocks'
+  >;
+  conversation: FastAgentConversation;
+  channelId: string;
+  threadTs: string;
+  recipientTeamId: string;
+  recipientUserId: string;
+  sessionId: string;
+  footerContext: FastSessionReplyFooterContext;
+  /** The quote a first reply leads with, consumed when the stream finishes. */
+  takeQuote?: () => string | null;
+  onDelivered?: () => void;
+}): FastAgentReplyStream {
+  let messageTs: string | null = null;
+  let opened = false;
+  let failed = false;
+
+  return {
+    append: async (text) => {
+      if (failed || !text) return;
+      if (!messageTs) {
+        if (opened) return;
+        opened = true;
+        messageTs = await params.slack.startMessageStream({
+          channel: params.channelId,
+          threadTs: params.threadTs,
+          recipientTeamId: params.recipientTeamId,
+          recipientUserId: params.recipientUserId,
+          markdownText: text,
+        });
+        if (!messageTs) failed = true;
+        return;
+      }
+      const appended = await params.slack.appendMessageStream({
+        channel: params.channelId,
+        ts: messageTs,
+        markdownText: text,
+      });
+      // The finish rewrites the whole message, so a lost append only costs
+      // liveness, never content.
+      if (!appended) failed = true;
+    },
+    finish: async (reply) => {
+      const ts = messageTs;
+      if (!ts) return undefined;
+      messageTs = null;
+      await params.slack.stopMessageStream({ channel: params.channelId, ts });
+      const quote = params.takeQuote?.() ?? null;
+      const updated = await updateSlackThreadMessageWithFooterText({
+        slack: params.slack,
+        channel: params.channelId,
+        threadTs: params.threadTs,
+        messageTs: ts,
+        text: quote ? `${quote}\n${reply.message}` : reply.message,
+        bodyBlocks: [
+          ...(quote
+            ? [
+                {
+                  type: 'section' as const,
+                  block_id: ROOMOTE_THREAD_REPLY_QUOTE_BLOCK_ID,
+                  text: { type: 'mrkdwn' as const, text: quote },
+                },
+              ]
+            : []),
+          { type: 'markdown' as const, text: reply.message },
+        ],
+        footerText: buildFastSessionReplyFooterText({
+          provider: 'slack',
+          sessionId: params.sessionId,
+          ...params.footerContext,
+        }),
+      });
+      if (!updated) {
+        console.warn(
+          `[Fast Agent] Slack kept the streamed text for reply ${ts}; the final body could not be written.`,
+        );
+      }
+      await recordFastAgentConversationMessageBestEffort({
+        sessionId: params.sessionId,
+        conversation: params.conversation,
+        messageId: ts,
+      });
+      params.onDelivered?.();
+      return { messageId: ts };
+    },
+    abort: async () => {
+      const ts = messageTs;
+      if (!ts) return;
+      messageTs = null;
+      await params.slack.stopMessageStream({ channel: params.channelId, ts });
+    },
+  };
+}

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
@@ -26,6 +26,8 @@ import {
 } from '@roomote/slack';
 
 import { createDiscordCommunicationProviderFromRuntimeCredentials } from './discord-communication';
+import { createSlackFastReplyStream } from './fast-agent-slack-reply-stream';
+import { findSlackConversationSubjectByUserId } from './slack-conversation-log';
 import {
   createFastAgentCommunicationTaskLauncher,
   createFastAgentDiscordTaskLauncher,
@@ -230,10 +232,36 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
           senderDisplayName: params.senderDisplayName,
           text: params.question,
         });
+    // Streaming a reply outside a DM needs the Slack user it is addressed
+    // to; a sender without a linked Slack account gets whole replies.
+    const senderSubject = await findSlackConversationSubjectByUserId({
+      userId: params.userId,
+      slackTeamId: conversation.workspaceId,
+    }).catch(() => null);
 
     return {
       conversation,
       adapter: {
+        ...(senderSubject
+          ? {
+              createReplyStream: () =>
+                createSlackFastReplyStream({
+                  slack,
+                  conversation,
+                  channelId: conversation.replyTarget.channelId,
+                  threadTs: threadId,
+                  recipientTeamId: conversation.workspaceId,
+                  recipientUserId: senderSubject.subjectSlackUserId,
+                  sessionId: session.id,
+                  footerContext,
+                  takeQuote: () => {
+                    const quote = pendingQuote;
+                    pendingQuote = null;
+                    return quote;
+                  },
+                }),
+            }
+          : {}),
         activity: createFastAgentSlackSessionActivity({
           slack,
           workspaceId: conversation.workspaceId,

--- a/packages/slack/src/__tests__/mock-slack-server.test.ts
+++ b/packages/slack/src/__tests__/mock-slack-server.test.ts
@@ -889,4 +889,80 @@ describe('MockSlackServer', () => {
       await server.stop();
     }
   });
+
+  it('streams a message through chat.startStream, appendStream, and stopStream', async () => {
+    const server = new MockSlackServer({
+      state: {
+        team: { id: 'T1', domain: 'mock-roomote' },
+        acceptedBotTokens: ['xoxb-mock-token'],
+        botUserId: 'BROOMOTE',
+        channels: [{ id: 'C1', name: 'product-debug', isMember: true }],
+        users: [{ id: 'U1', name: 'alex', displayName: 'Alex' }],
+        messages: [],
+      },
+    });
+
+    try {
+      await server.start();
+      const call = async (method: string, body: Record<string, unknown>) => {
+        const response = await fetch(`${server.baseUrl}/api/${method}`, {
+          method: 'POST',
+          headers: {
+            authorization: 'Bearer xoxb-mock-token',
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        });
+        return (await response.json()) as {
+          ok: boolean;
+          ts?: string;
+          error?: string;
+        };
+      };
+
+      const started = await call('chat.startStream', {
+        channel: 'C1',
+        thread_ts: '1710000000.000100',
+        recipient_team_id: 'T1',
+        recipient_user_id: 'U1',
+        markdown_text: 'Looking',
+      });
+      expect(started.ok).toBe(true);
+      const ts = started.ts!;
+
+      expect(
+        await call('chat.appendStream', {
+          channel: 'C1',
+          ts,
+          markdown_text: ' at the logs',
+        }),
+      ).toMatchObject({ ok: true, ts });
+      expect(
+        await call('chat.stopStream', {
+          channel: 'C1',
+          ts,
+          markdown_text: '.',
+          blocks: [{ type: 'context', elements: [] }],
+        }),
+      ).toMatchObject({ ok: true, ts });
+      expect(
+        await call('chat.appendStream', {
+          channel: 'C1',
+          ts: '0.0',
+          markdown_text: 'x',
+        }),
+      ).toMatchObject({ ok: false, error: 'message_not_found' });
+
+      const state = server.getState();
+      const streamed = state.messages?.find((message) => message.ts === ts);
+      expect(streamed).toMatchObject({
+        channel: 'C1',
+        thread_ts: '1710000000.000100',
+        text: 'Looking at the logs.',
+        blocks: [{ type: 'context', elements: [] }],
+      });
+    } finally {
+      await server.stop();
+    }
+  });
 });

--- a/packages/slack/src/__tests__/thread-reply-footer-ops.test.ts
+++ b/packages/slack/src/__tests__/thread-reply-footer-ops.test.ts
@@ -41,6 +41,7 @@ import {
   isSlackThreadReplyFooterBlock,
   postSlackThreadMessageWithStickyFooter,
   removeSlackThreadReplyFooter,
+  updateSlackThreadMessageWithFooterText,
 } from '../thread-reply-footer-ops';
 
 describe('thread-reply-footer-ops', () => {
@@ -160,6 +161,92 @@ describe('thread-reply-footer-ops', () => {
         linkedPrs: [],
         livePreviewUrl: null,
       }),
+    );
+  });
+
+  it('rewrites an existing message into the footer carrier and strips the previous one', async () => {
+    const slack = {
+      getMessageBlocks: vi.fn().mockResolvedValue([
+        { type: 'section', text: { type: 'mrkdwn', text: 'old body' } },
+        {
+          type: 'context',
+          block_id: 'roomote_thread_reply_footer',
+          elements: [{ type: 'mrkdwn', text: 'old footer' }],
+        },
+      ]),
+      updateMessage: vi.fn().mockResolvedValue(true),
+    };
+
+    await expect(
+      updateSlackThreadMessageWithFooterText({
+        slack,
+        channel: 'C1',
+        threadTs: '100.000',
+        messageTs: '333.000',
+        text: 'final reply',
+        bodyBlocks: [{ type: 'markdown', text: 'final reply' }],
+        footerText: 'footer',
+      }),
+    ).resolves.toBe(true);
+
+    expect(slack.updateMessage).toHaveBeenNthCalledWith(1, {
+      channel: 'C1',
+      ts: '333.000',
+      message: {
+        text: 'final reply',
+        blocks: [
+          { type: 'markdown', text: 'final reply' },
+          expect.objectContaining({
+            type: 'context',
+            block_id: 'roomote_thread_reply_footer',
+          }),
+        ],
+      },
+    });
+    // The prior carrier loses its footer and the pointer moves.
+    expect(slack.updateMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ ts: '111.000' }),
+    );
+    expect(mockSetFooterTs).toHaveBeenCalledWith('C1', '100.000', '333.000');
+  });
+
+  it('takes the footer back off a rewritten message when the pointer cannot be saved', async () => {
+    mockGetFooterTs.mockResolvedValue(null);
+    mockSetFooterTs.mockRejectedValue(new Error('redis down'));
+    const slack = {
+      getMessageBlocks: vi.fn().mockResolvedValue([
+        { type: 'markdown', text: 'final reply' },
+        {
+          type: 'context',
+          block_id: 'roomote_thread_reply_footer',
+          elements: [{ type: 'mrkdwn', text: 'footer' }],
+        },
+      ]),
+      updateMessage: vi.fn().mockResolvedValue(true),
+    };
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      updateSlackThreadMessageWithFooterText({
+        slack,
+        channel: 'C1',
+        threadTs: '100.000',
+        messageTs: '333.000',
+        text: 'final reply',
+        bodyBlocks: [{ type: 'markdown', text: 'final reply' }],
+        footerText: 'footer',
+      }),
+    ).resolves.toBe(true);
+
+    expect(slack.updateMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        ts: '333.000',
+        message: { blocks: [{ type: 'markdown', text: 'final reply' }] },
+      }),
+    );
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to persist latest footer message ts'),
     );
   });
 

--- a/packages/slack/src/mock-slack-server.ts
+++ b/packages/slack/src/mock-slack-server.ts
@@ -908,6 +908,42 @@ export class MockSlackServer {
         return;
       }
 
+      case 'POST chat.startStream': {
+        const ts = this.nextTs();
+        const message = this.storeOutgoingMessage({
+          ts,
+          payload: {
+            channel: jsonBody.channel,
+            thread_ts: jsonBody.thread_ts,
+            text: String(jsonBody.markdown_text ?? ''),
+          },
+          ephemeral: false,
+        });
+        json(response, 200, { ok: true, channel: message.channel, ts });
+        return;
+      }
+
+      case 'POST chat.appendStream':
+      case 'POST chat.stopStream': {
+        const channel = String(jsonBody.channel ?? '');
+        const ts = String(jsonBody.ts ?? '');
+        const message = (this.state.messages ?? []).find(
+          (entry) => entry.channel === channel && entry.ts === ts,
+        );
+
+        if (!message) {
+          json(response, 200, { ok: false, error: 'message_not_found' });
+          return;
+        }
+
+        message.text += String(jsonBody.markdown_text ?? '');
+        if (Array.isArray(jsonBody.blocks)) {
+          message.blocks = [...(message.blocks ?? []), ...jsonBody.blocks];
+        }
+        json(response, 200, { ok: true, channel, ts });
+        return;
+      }
+
       case 'POST chat.update': {
         const channel = String(jsonBody.channel ?? '');
         const ts = String(jsonBody.ts ?? '');

--- a/packages/slack/src/slack-notifier.ts
+++ b/packages/slack/src/slack-notifier.ts
@@ -1300,6 +1300,77 @@ export class SlackNotifier {
    * Uses conversations.replies to find thread replies (the started message
    * is always posted as a thread reply with thread_ts).
    */
+  /**
+   * Message streaming (`chat.startStream` / `appendStream` / `stopStream`):
+   * one reply that renders as it is written. Every method reports failure
+   * instead of throwing so a caller can fall back to a normal post.
+   */
+  public async startMessageStream(params: {
+    channel: string;
+    threadTs: string;
+    recipientTeamId: string;
+    recipientUserId: string;
+    markdownText: string;
+  }): Promise<string | null> {
+    try {
+      const response = await this.getClient().chat.startStream({
+        channel: params.channel,
+        thread_ts: params.threadTs,
+        recipient_team_id: params.recipientTeamId,
+        recipient_user_id: params.recipientUserId,
+        markdown_text: params.markdownText,
+      });
+      return response.ok && typeof response.ts === 'string'
+        ? response.ts
+        : null;
+    } catch (error) {
+      console.error(
+        `[startMessageStream] Slack chat.startStream failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return null;
+    }
+  }
+
+  public async appendMessageStream(params: {
+    channel: string;
+    ts: string;
+    markdownText: string;
+  }): Promise<boolean> {
+    try {
+      const response = await this.getClient().chat.appendStream({
+        channel: params.channel,
+        ts: params.ts,
+        markdown_text: params.markdownText,
+      });
+      return response.ok === true;
+    } catch (error) {
+      console.error(
+        `[appendMessageStream] Slack chat.appendStream failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return false;
+    }
+  }
+
+  public async stopMessageStream(params: {
+    channel: string;
+    ts: string;
+    markdownText?: string;
+  }): Promise<boolean> {
+    try {
+      const response = await this.getClient().chat.stopStream({
+        channel: params.channel,
+        ts: params.ts,
+        ...(params.markdownText ? { markdown_text: params.markdownText } : {}),
+      });
+      return response.ok === true;
+    } catch (error) {
+      console.error(
+        `[stopMessageStream] Slack chat.stopStream failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return false;
+    }
+  }
+
   public async getMessageBlocks({
     channel,
     messageTs,

--- a/packages/slack/src/thread-reply-footer-ops.ts
+++ b/packages/slack/src/thread-reply-footer-ops.ts
@@ -278,6 +278,84 @@ export async function postSlackThreadMessageWithFooterText(params: {
 }
 
 /**
+ * Rewrites an existing thread message (for example one that was streamed)
+ * into its final body and makes it the sticky footer carrier, the same way a
+ * freshly posted reply would be.
+ */
+export async function updateSlackThreadMessageWithFooterText(params: {
+  slack: Pick<SlackNotifier, 'getMessageBlocks' | 'updateMessage'>;
+  channel: string;
+  threadTs: string;
+  messageTs: string;
+  text: string;
+  /** Body blocks without the footer context block. */
+  bodyBlocks: unknown[];
+  footerText: string;
+}): Promise<boolean> {
+  const footerBlock = buildSlackThreadReplyFooterBlock({
+    footerText: params.footerText,
+  });
+
+  return withSlackThreadReplyFooterLock({
+    channel: params.channel,
+    threadTs: params.threadTs,
+    fn: async () => {
+      const previousFooterMessageTs = await getSlackThreadReplyFooterMessageTs(
+        params.channel,
+        params.threadTs,
+      );
+      const updated = await params.slack.updateMessage({
+        channel: params.channel,
+        ts: params.messageTs,
+        message: {
+          text: params.text,
+          blocks: [...params.bodyBlocks, footerBlock],
+        },
+      });
+      if (!updated) {
+        return false;
+      }
+
+      if (
+        previousFooterMessageTs &&
+        previousFooterMessageTs !== params.messageTs
+      ) {
+        try {
+          await removeSlackThreadReplyFooter({
+            slack: params.slack,
+            channel: params.channel,
+            threadTs: params.threadTs,
+            messageTs: previousFooterMessageTs,
+          });
+        } catch (error) {
+          console.error(
+            `[slackThreadFooter] Failed to remove footer from prior Slack message ${previousFooterMessageTs}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+
+      try {
+        await setSlackThreadReplyFooterMessageTs(
+          params.channel,
+          params.threadTs,
+          params.messageTs,
+        );
+      } catch (error) {
+        console.error(
+          `[slackThreadFooter] Failed to persist latest footer message ts ${params.messageTs}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+
+      return true;
+    },
+  });
+}
+
+/**
  * Posts a Slack thread reply that becomes the sticky "Working on..." footer
  * message for the thread: attaches the current footer, then removes it from
  * whatever prior reply still carries the tracked footer.

--- a/packages/slack/src/thread-reply-footer-ops.ts
+++ b/packages/slack/src/thread-reply-footer-ops.ts
@@ -348,6 +348,24 @@ export async function updateSlackThreadMessageWithFooterText(params: {
             error instanceof Error ? error.message : String(error)
           }`,
         );
+        // Without the pointer no later reply could strip this footer, so
+        // take it back off rather than let the thread collect duplicates.
+        try {
+          await removeSlackThreadReplyFooter({
+            slack: params.slack,
+            channel: params.channel,
+            threadTs: params.threadTs,
+            messageTs: params.messageTs,
+          });
+        } catch (removeError) {
+          console.error(
+            `[slackThreadFooter] Failed to remove footer from Slack message ${params.messageTs} after persistence failure: ${
+              removeError instanceof Error
+                ? removeError.message
+                : String(removeError)
+            }`,
+          );
+        }
       }
 
       return true;


### PR DESCRIPTION
## Summary

Follow-up to #2082 (web streaming). Fast replies on Slack now stream into the thread while the model writes them, using Slack's message streaming API rather than repeated edits.

- **Slack native streaming.** `SlackNotifier` gains `startMessageStream` / `appendMessageStream` / `stopMessageStream` (`chat.startStream`, `chat.appendStream`, `chat.stopStream`). These need only `chat:write`, so existing installations qualify. `startStream`/`stopStream` are Tier 2 and `appendStream` is Tier 4, which keeps streaming off the Tier 3 `chat.update` budget shared by every conversation in a workspace.
- **One optional adapter hook.** `FastAgentTurnAdapter.createReplyStream` returns a stream with `append` / `finish` / `abort`. The Fast service feeds it the same undelivered reply text that already streams to the web transcript, through a throttled streamer: a stream opens only if the reply is still being written 750 ms after its text started (short replies post as before), appends are paced at 500 ms, and the reply that delivers the text (`send_chat_reply` or the terminal closeout) finishes the stream and takes over its message. Retry notices and error closeouts also finish an open stream instead of leaving a cut-off draft above them. Platform-event turns (automation reports, task settlements) never stream.
- **Finished message is canonical.** `finish` stops the stream, then rewrites the message into the usual reply body (quote block when applicable, `markdown` block, sticky thread footer moved onto it) via a new `updateSlackThreadMessageWithFooterText`, and records the message id like a posted reply.
- **Fallbacks.** If `startStream` fails the reply posts normally; if an append fails, appends stop and the finish still writes the full text. A turn that ends without delivering (cancelled or parked) stops the stream and leaves its text.
- Wired into both Slack adapters that run human-authored turns: the mention handler in `apps/api` and web-initiated follow-ups in `packages/sdk` (the latter requires a linked Slack user for the sender, since streaming outside a DM needs a recipient).
- The mock Slack server implements the three streaming endpoints.

Discord, Telegram, and Teams have no streaming API and keep whole replies.

## Testing

- `check-types` for slack, cloud-agents, sdk, api; `pnpm lint:fast`; `pnpm knip`
- New tests: surface streamer (start delay, pacing, delivery, abort, failure), Slack stream factory (start/append/finish body, never-opened fallback, failed append, abort), mock server streaming endpoints, Fast service streaming delivery and the short-reply fallback
- Existing slack, sdk, api, and cloud-agents suites pass
- Not yet exercised against a real Slack workspace; worth a manual check on a thread before merge