### PR TITLE
fix: request_user_input tool schema rejected by OpenAI models

### DIFF
--- a/.changeset/fix-request-user-input-tool-schema.md
+++ b/.changeset/fix-request-user-input-tool-schema.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fixed Fast turns failing immediately on OpenAI models with "the inference provider returned an error". The `request_user_input` tool declared its arguments as a bare union, which produced a tool schema OpenAI rejected as invalid on every request.

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-bridge.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-bridge.test.ts
@@ -206,10 +206,16 @@ describe('Fast native OpenCode tool bridge', () => {
     expect(skillListSource).toContain(
       'exactly one of environmentId or repositoryId',
     );
-    expect(requestUserInputSource).toContain('args: z.union');
+    // OpenCode wraps `args` in z.object itself; a bare union there produces
+    // a schema OpenAI rejects, which takes every Fast turn down on its models.
+    expect(requestUserInputSource).toContain('args: {');
+    expect(requestUserInputSource).not.toContain('z.union');
     expect(requestUserInputSource).toContain('questions: z.array');
+    expect(requestUserInputSource).toContain('.max(4).optional()');
     expect(requestUserInputSource).toContain('preset: z.enum');
-    expect(requestUserInputSource).toContain('.strict()');
+    expect(requestUserInputSource).toContain(
+      'exactly one of questions or preset',
+    );
     expect(skillSource).toContain('Exact skill ID returned by list_skills');
     expect(skillSource).not.toContain('"explore-and-act"');
     expect(skillSource).toContain(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
@@ -487,8 +487,8 @@ import { z } from "zod"
 import { invoke } from "../roomote-fast-tool-bridge.js"
 
 export default {
-  description: "Ask structured questions, or use a trusted setup preset whose options Roomote supplies. Multiple-choice questions require explicit submission. The turn resumes from the persisted answer.",
-  args: z.union([z.object({
+  description: "Ask structured questions, or use a trusted setup preset whose options Roomote supplies. Pass exactly one of questions or preset. Multiple-choice questions require explicit submission. The turn resumes from the persisted answer.",
+  args: {
     questions: z.array(z.object({
       id: z.string().min(1).max(80),
       header: z.string().min(1).max(60),
@@ -500,10 +500,9 @@ export default {
         description: z.string().min(1).max(500),
       })).min(1).max(12).optional().describe("Present options as choices; omit for free-text"),
       multiple: z.boolean().optional().describe("Allow more than one option; defaults to false"),
-    })).min(1).max(4),
-  }).strict(), z.object({
-    preset: z.enum(["setup_starter_tasks"]).describe("Use the trusted starter-task preset instead of questions"),
-  }).strict()]),
+    })).min(1).max(4).optional().describe("Structured questions to ask; omit when using a preset"),
+    preset: z.enum(["setup_starter_tasks"]).optional().describe("Use the trusted starter-task preset instead of questions"),
+  },
   execute: (args, context) => invoke("request_user_input", args, context),
 }
 `,


### PR DESCRIPTION
## Summary

Every Fast turn on an OpenAI model has failed since v1.2.0 with "Could not complete the request because the inference provider returned an error." The provider response is:

```
Invalid schema for function 'request_user_input': 'union' is not valid under any of the given schemas.
param: tools[13].parameters, code: invalid_function_parameters
```

**Cause.** #1924 changed the `request_user_input` native tool's `args` to a top-level `z.union([...])`. OpenCode wraps a custom tool's `args` in `z.object(...)` itself, so the union *instance* became the object shape and the generated parameters carried its internal properties (`~standard`, `def`, `type: "union"`). OpenAI validates function schemas strictly and rejects the whole request; the failure is not retryable.

**Fix.** Declare `args` as a plain record with optional `questions` and optional `preset`, like every other native tool. The either/or is still enforced by `requestUserInputArgsSchema` on the service side; the tool description now says to pass exactly one.

**Verification.** Ran a local OpenCode 1.18 server with the old and new tool sources and read `/experimental/tool?provider=openai&model=gpt-5.6`: with the old source the endpoint cannot even serialize the tool (its parameters contain a `~standard.validate` function); with the new source it yields a normal object schema with `questions` and `preset` properties. Bridge test updated to guard against reintroducing a bare union.

Changeset included for the patch release.