### PR TITLE
Promote v1.2.1 to production

### DIFF
--- a/.changeset/fix-request-user-input-tool-schema.md
+++ b/.changeset/fix-request-user-input-tool-schema.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fixed Fast turns failing immediately on OpenAI models with "the inference provider returned an error". The `request_user_input` tool declared its arguments as a bare union, which produced a tool schema OpenAI rejected as invalid on every request.

--- a/.changeset/fix-request-user-input-tool-schema.md
+++ b/.changeset/fix-request-user-input-tool-schema.md
@@ -1,5 +1,0 @@
----
-'@roomote/web': patch
----
-
-Fixed Fast turns failing immediately on OpenAI models with "the inference provider returned an error". The `request_user_input` tool declared its arguments as a bare union, which produced a tool schema OpenAI rejected as invalid on every request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This file tracks product releases for Roomote (single monorepo version). Automated release entries are prepended by `pnpm run version`.
 
+## 1.2.1 (2026-09-02)
+
+Roomote 1.2.1 restores Fast turns on OpenAI models and keeps Slack replies and usage alerts accurate.
+
+### Highlights
+
+- Run Fast turns on OpenAI models without immediate inference-provider errors.
+- Keep streamed Fast replies in Slack complete and deduplicated when finalization fails.
+
+### Patch changes
+
+- Restore Fast turns on OpenAI models by sending a valid schema for user-input requests instead of failing immediately with an inference-provider error.
+- Keep streamed Fast replies in Slack complete and deduplicated when finalizing the stream fails.
+- Show concise inference-provider usage alerts in Slack without repeating synthetic percentage details.
+
 ## 1.2.0 (2026-09-02)
 
 Roomote 1.2 enables contextual Message Suggestions by default, streams Fast replies across web and Slack, guides first administrators in one resumable setup Session, and recommends Gemini 3.8 Flash.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roomote",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "FCL-1.0-ALv2",
   "packageManager": "pnpm@10.29.3",
   "engines": {

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-bridge.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-bridge.test.ts
@@ -206,10 +206,16 @@ describe('Fast native OpenCode tool bridge', () => {
     expect(skillListSource).toContain(
       'exactly one of environmentId or repositoryId',
     );
-    expect(requestUserInputSource).toContain('args: z.union');
+    // OpenCode wraps `args` in z.object itself; a bare union there produces
+    // a schema OpenAI rejects, which takes every Fast turn down on its models.
+    expect(requestUserInputSource).toContain('args: {');
+    expect(requestUserInputSource).not.toContain('z.union');
     expect(requestUserInputSource).toContain('questions: z.array');
+    expect(requestUserInputSource).toContain('.max(4).optional()');
     expect(requestUserInputSource).toContain('preset: z.enum');
-    expect(requestUserInputSource).toContain('.strict()');
+    expect(requestUserInputSource).toContain(
+      'exactly one of questions or preset',
+    );
     expect(skillSource).toContain('Exact skill ID returned by list_skills');
     expect(skillSource).not.toContain('"explore-and-act"');
     expect(skillSource).toContain(

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
@@ -487,8 +487,8 @@ import { z } from "zod"
 import { invoke } from "../roomote-fast-tool-bridge.js"
 
 export default {
-  description: "Ask structured questions, or use a trusted setup preset whose options Roomote supplies. Multiple-choice questions require explicit submission. The turn resumes from the persisted answer.",
-  args: z.union([z.object({
+  description: "Ask structured questions, or use a trusted setup preset whose options Roomote supplies. Pass exactly one of questions or preset. Multiple-choice questions require explicit submission. The turn resumes from the persisted answer.",
+  args: {
     questions: z.array(z.object({
       id: z.string().min(1).max(80),
       header: z.string().min(1).max(60),
@@ -500,10 +500,9 @@ export default {
         description: z.string().min(1).max(500),
       })).min(1).max(12).optional().describe("Present options as choices; omit for free-text"),
       multiple: z.boolean().optional().describe("Allow more than one option; defaults to false"),
-    })).min(1).max(4),
-  }).strict(), z.object({
-    preset: z.enum(["setup_starter_tasks"]).describe("Use the trusted starter-task preset instead of questions"),
-  }).strict()]),
+    })).min(1).max(4).optional().describe("Structured questions to ask; omit when using a preset"),
+    preset: z.enum(["setup_starter_tasks"]).optional().describe("Use the trusted starter-task preset instead of questions"),
+  },
   execute: (args, context) => invoke("request_user_input", args, context),
 }
 `,

--- a/packages/sdk/src/server/automations/__tests__/provider-usage-limit.test.ts
+++ b/packages/sdk/src/server/automations/__tests__/provider-usage-limit.test.ts
@@ -129,7 +129,7 @@ describe('provider usage limit automation', () => {
       title: { text: 'Inference Provider Usage Alert' },
       subtitle: {
         type: 'mrkdwn',
-        text: 'OpenRouter is at 90% ($90.00 of $100.00)',
+        text: 'OpenRouter is at 90%',
       },
       icon: {
         image_url: expect.stringContaining(
@@ -163,6 +163,28 @@ describe('provider usage limit automation', () => {
           ],
         },
       ],
+    });
+  });
+
+  it('keeps the alert concise when raw usage and limit are not reported', () => {
+    const message = buildProviderUsageLimitWarningMessage({
+      alerts: [
+        {
+          snapshot: snapshot({
+            providerName: 'ChatGPT (subscription)',
+            usedPercent: 89,
+            used: undefined,
+            limit: undefined,
+          }),
+          threshold: 85,
+        },
+      ],
+    });
+
+    expect(message.blocks[0]).toMatchObject({
+      subtitle: {
+        text: 'ChatGPT (subscription) is at 89%',
+      },
     });
   });
 
@@ -225,7 +247,7 @@ describe('provider usage limit automation', () => {
 
     expect(deps.postMessage).toHaveBeenCalledTimes(2);
     expect(JSON.stringify(deps.postMessage.mock.calls[1]?.[0])).toContain(
-      'OpenRouter is at 100% ($100.00 of $100.00)',
+      'OpenRouter is at 100%',
     );
   });
 

--- a/packages/sdk/src/server/automations/provider-usage-limit.ts
+++ b/packages/sdk/src/server/automations/provider-usage-limit.ts
@@ -241,13 +241,12 @@ function buildProviderUsageLimitAlertBlock(
   snapshot: ProviderUsageLimitSnapshot,
 ): SlackBlock {
   const percent = Math.round(snapshot.usedPercent * 10) / 10;
-  const usage = formatUsage(snapshot, percent);
 
   return buildAutomationResultBlocks({
     title: 'Inference Provider Usage Alert',
     subtitle: {
       type: 'mrkdwn',
-      text: `${snapshot.providerName} is at ${percent}% (${usage})`,
+      text: `${snapshot.providerName} is at ${percent}%`,
     },
     iconUrl: buildAutomationIconUrl('battery-warning'),
     configureUrl: buildManagerSlackSettingsUrl(

--- a/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.test.ts
@@ -30,6 +30,7 @@ function slackMock() {
     ),
     appendMessageStream: vi.fn(async () => true),
     stopMessageStream: vi.fn(async () => true),
+    deleteMessage: vi.fn(async () => true),
     updateMessage: vi.fn(async () => true),
     getMessageBlocks: vi.fn(async () => []),
   };
@@ -47,14 +48,13 @@ function build(slack: ReturnType<typeof slackMock>, quote: string | null) {
     recipientUserId: 'U1',
     sessionId: 'session-1',
     footerContext: {} as never,
-    takeQuote: () => {
-      const value = pendingQuote;
+    getQuote: () => pendingQuote,
+    onDelivered: () => {
       pendingQuote = null;
-      return value;
+      onDelivered();
     },
-    onDelivered,
   });
-  return { stream, onDelivered };
+  return { stream, onDelivered, getPendingQuote: () => pendingQuote };
 }
 
 describe('createSlackFastReplyStream', () => {
@@ -66,7 +66,7 @@ describe('createSlackFastReplyStream', () => {
 
   it('starts on the first append, appends after, and finishes into the canonical reply body', async () => {
     const slack = slackMock();
-    const { stream, onDelivered } = build(slack, '> Matt: hi');
+    const { stream, onDelivered, getPendingQuote } = build(slack, '> Matt: hi');
 
     await stream.append('Looking');
     await stream.append(' at the logs');
@@ -111,6 +111,7 @@ describe('createSlackFastReplyStream', () => {
       expect.objectContaining({ sessionId: 'session-1', messageId: '200.1' }),
     );
     expect(onDelivered).toHaveBeenCalledOnce();
+    expect(getPendingQuote()).toBeNull();
     // Finishing twice or aborting afterwards does nothing more.
     await expect(
       stream.finish({ purpose: 'closeout', message: 'again' }),
@@ -153,21 +154,65 @@ describe('createSlackFastReplyStream', () => {
     );
   });
 
-  it('yields no delivery when the final rewrite is rejected so the reply is posted instead', async () => {
+  it('removes the partial stream before falling back to a normal post', async () => {
     const slack = slackMock();
     mocks.updateWithFooter.mockResolvedValue(false);
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { stream, onDelivered } = build(slack, null);
+    const { stream, onDelivered, getPendingQuote } = build(slack, '> Matt: hi');
 
     await stream.append('Looking');
     await expect(
       stream.finish({ purpose: 'closeout', message: 'Looking.' }),
     ).resolves.toBeUndefined();
     expect(slack.stopMessageStream).toHaveBeenCalledTimes(1);
+    expect(slack.deleteMessage).toHaveBeenCalledWith({
+      channel: 'C1',
+      ts: '200.1',
+    });
     expect(mocks.recordMessage).not.toHaveBeenCalled();
     expect(onDelivered).not.toHaveBeenCalled();
+    expect(getPendingQuote()).toBe('> Matt: hi');
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('did not accept the final body'),
+    );
+  });
+
+  it('keeps the partial stream as the delivery when it cannot be removed', async () => {
+    const slack = slackMock();
+    mocks.updateWithFooter.mockResolvedValue(false);
+    slack.deleteMessage.mockResolvedValue(false);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { stream, onDelivered } = build(slack, null);
+
+    await stream.append('Looking');
+    await expect(
+      stream.finish({ purpose: 'closeout', message: 'Looking.' }),
+    ).resolves.toEqual({ messageId: '200.1' });
+    expect(mocks.recordMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'session-1', messageId: '200.1' }),
+    );
+    expect(onDelivered).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining('partial stream could not be removed'),
+    );
+  });
+
+  it('removes the partial stream when the final rewrite throws', async () => {
+    const slack = slackMock();
+    mocks.updateWithFooter.mockRejectedValue(new Error('lock timed out'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { stream } = build(slack, null);
+
+    await stream.append('Looking');
+    await expect(
+      stream.finish({ purpose: 'closeout', message: 'Looking.' }),
+    ).resolves.toBeUndefined();
+    expect(slack.deleteMessage).toHaveBeenCalledWith({
+      channel: 'C1',
+      ts: '200.1',
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to apply the final body'),
     );
   });
 

--- a/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.ts
+++ b/packages/sdk/src/server/lib/fast-agent-slack-reply-stream.ts
@@ -27,6 +27,7 @@ export function createSlackFastReplyStream(params: {
     | 'startMessageStream'
     | 'appendMessageStream'
     | 'stopMessageStream'
+    | 'deleteMessage'
     | 'updateMessage'
     | 'getMessageBlocks'
   >;
@@ -37,8 +38,8 @@ export function createSlackFastReplyStream(params: {
   recipientUserId: string;
   sessionId: string;
   footerContext: FastSessionReplyFooterContext;
-  /** The quote a first reply leads with, consumed when the stream finishes. */
-  takeQuote?: () => string | null;
+  /** The pending quote a first reply leads with, cleared after delivery. */
+  getQuote?: () => string | null;
   onDelivered?: () => void;
 }): FastAgentReplyStream {
   let messageTs: string | null = null;
@@ -75,38 +76,51 @@ export function createSlackFastReplyStream(params: {
       if (!ts) return undefined;
       messageTs = null;
       await params.slack.stopMessageStream({ channel: params.channelId, ts });
-      const quote = params.takeQuote?.() ?? null;
-      const updated = await updateSlackThreadMessageWithFooterText({
-        slack: params.slack,
-        channel: params.channelId,
-        threadTs: params.threadTs,
-        messageTs: ts,
-        text: quote ? `${quote}\n${reply.message}` : reply.message,
-        bodyBlocks: [
-          ...(quote
-            ? [
-                {
-                  type: 'section' as const,
-                  block_id: ROOMOTE_THREAD_REPLY_QUOTE_BLOCK_ID,
-                  text: { type: 'mrkdwn' as const, text: quote },
-                },
-              ]
-            : []),
-          { type: 'markdown' as const, text: reply.message },
-        ],
-        footerText: buildFastSessionReplyFooterText({
-          provider: 'slack',
-          sessionId: params.sessionId,
-          ...params.footerContext,
-        }),
-      });
-      if (!updated) {
-        // The streamed draft stays as it is; the caller posts the reply in
-        // full rather than treating the draft as the delivery.
+      const quote = params.getQuote?.() ?? null;
+      let updated = false;
+      try {
+        updated = await updateSlackThreadMessageWithFooterText({
+          slack: params.slack,
+          channel: params.channelId,
+          threadTs: params.threadTs,
+          messageTs: ts,
+          text: quote ? `${quote}\n${reply.message}` : reply.message,
+          bodyBlocks: [
+            ...(quote
+              ? [
+                  {
+                    type: 'section' as const,
+                    block_id: ROOMOTE_THREAD_REPLY_QUOTE_BLOCK_ID,
+                    text: { type: 'mrkdwn' as const, text: quote },
+                  },
+                ]
+              : []),
+            { type: 'markdown' as const, text: reply.message },
+          ],
+          footerText: buildFastSessionReplyFooterText({
+            provider: 'slack',
+            sessionId: params.sessionId,
+            ...params.footerContext,
+          }),
+        });
+      } catch (error) {
         console.warn(
-          `[Fast Agent] Slack did not accept the final body for streamed reply ${ts}; posting the reply instead.`,
+          `[Fast Agent] Failed to apply the final body to streamed Slack reply ${ts}: ${error instanceof Error ? error.message : String(error)}`,
         );
-        return undefined;
+      }
+      if (!updated) {
+        const deleted = await params.slack
+          .deleteMessage({ channel: params.channelId, ts })
+          .catch(() => false);
+        if (deleted) {
+          console.warn(
+            `[Fast Agent] Slack did not accept the final body for streamed reply ${ts}; removed the partial stream so the reply can post normally.`,
+          );
+          return undefined;
+        }
+        console.error(
+          `[Fast Agent] Slack did not accept the final body for streamed reply ${ts}, and the partial stream could not be removed; keeping it as the delivery.`,
+        );
       }
       await recordFastAgentConversationMessageBestEffort({
         sessionId: params.sessionId,

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
@@ -254,10 +254,9 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
                   recipientUserId: senderSubject.subjectSlackUserId,
                   sessionId: session.id,
                   footerContext,
-                  takeQuote: () => {
-                    const quote = pendingQuote;
+                  getQuote: () => pendingQuote,
+                  onDelivered: () => {
                     pendingQuote = null;
-                    return quote;
                   },
                 }),
             }


### PR DESCRIPTION
## Promote v1.2.1

Frozen at `cce9bdee61f41f2bccd122a89477aefefba63bb4` — the commit where `1.2.1` was versioned. Commits merged to `develop` afterward require an explicit candidate refresh or ship in the next release.

- Merge this PR with a **merge commit** (do not squash or rebase).
- If multiple promote PRs are open, merge them in version order (oldest first).
- Merging publishes a GitHub Release for `v1.2.1` and triggers the existing GHCR `v*` image publish (`latest` channel).
- The `release/v1.2.1` branch can be deleted after this PR merges.

### Changelog

## 1.2.1 (2026-09-02)

Roomote 1.2.1 restores Fast turns on OpenAI models and keeps Slack replies and usage alerts accurate.

### Highlights

- Run Fast turns on OpenAI models without immediate inference-provider errors.
- Keep streamed Fast replies in Slack complete and deduplicated when finalization fails.

### Patch changes

- Restore Fast turns on OpenAI models by sending a valid schema for user-input requests instead of failing immediately with an inference-provider error.
- Keep streamed Fast replies in Slack complete and deduplicated when finalizing the stream fails.
- Show concise inference-provider usage alerts in Slack without repeating synthetic percentage details.
