### PR TITLE
fix: wait for pending database migrations before bullmq and controller start

### DIFF
--- a/.changeset/wait-for-migrations-at-boot.md
+++ b/.changeset/wait-for-migrations-at-boot.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fixed the bullmq and controller services crashing during upgrades when they started before the database migration finished. On platforms that roll every service at once, a boot that reads a column the pending migration adds could exhaust the restart budget within seconds and stay down until someone redeployed it; both services now wait for the migration to land and then start normally.

--- a/apps/bullmq/src/index.ts
+++ b/apps/bullmq/src/index.ts
@@ -8,7 +8,9 @@ import { HonoAdapter } from '@bull-board/hono';
 
 import {
   bootstrapGeneratedAuthKeypairs,
+  db,
   ensureAutomationRows,
+  waitForMigrations,
 } from '@roomote/db/server';
 import {
   DISCORD_SUGGESTED_TASKS_ONBOARDING_FOLLOWUP_QUEUE_NAME,
@@ -51,6 +53,25 @@ import { startPullRequestMergeabilityCheckQueue } from './pull-request-mergeabil
 import { startTaskSleepQueue } from './task-sleep-queue';
 import { startAutomationRecommendationsQueue } from './automation-recommendations-queue';
 import { startFastAgentParentEventQueue } from './fast-agent-parent-event-queue';
+
+// Deployments roll every service at once while migrations run only ahead
+// of the api service. A boot that reads a column the pending migration adds
+// would crash-loop past the platform's restart budget and stay down after
+// the migration lands, so wait for the schema instead.
+try {
+  const readiness = await waitForMigrations({
+    database: db,
+    log: (message) => console.info(message),
+  });
+  if (readiness.state === 'unmanaged') {
+    console.info(
+      'Database has no migration bookkeeping; assuming its schema is managed directly.',
+    );
+  }
+} catch (error) {
+  console.error('Database migrations did not become ready', error);
+  process.exit(1);
+}
 
 // Resolve auto-generated auth keypairs before any queue worker starts so
 // scheduled jobs that sign tokens observe the resolved keys.

--- a/apps/controller/src/index.ts
+++ b/apps/controller/src/index.ts
@@ -1,4 +1,8 @@
-import { bootstrapGeneratedAuthKeypairs } from '@roomote/db/server';
+import {
+  bootstrapGeneratedAuthKeypairs,
+  db,
+  waitForMigrations,
+} from '@roomote/db/server';
 import { assertSecureBootBinding, Env } from '@roomote/env';
 import {
   buildRoomoteDeployMarker,
@@ -80,6 +84,17 @@ process.on('uncaughtException', (error) => {
 });
 
 async function main() {
+  // Migrations run only ahead of the api service while every service rolls
+  // at once; wait for the schema rather than crash-loop on a pending column.
+  const readiness = await waitForMigrations({
+    database: db,
+    log: (message) => console.info(message),
+  });
+  if (readiness.state === 'unmanaged') {
+    console.info(
+      'Database has no migration bookkeeping; assuming its schema is managed directly.',
+    );
+  }
   await bootstrapGeneratedAuthKeypairs();
   assertSecureBootBinding();
 

--- a/packages/db/src/__tests__/migration-readiness.live.test.ts
+++ b/packages/db/src/__tests__/migration-readiness.live.test.ts
@@ -1,0 +1,12 @@
+import { db } from '../db';
+import { checkMigrationReadiness } from '../lib/migration-readiness';
+
+// Runs against the real test database, which drizzle-kit pushes directly:
+// it has tables but no migration bookkeeping.
+describe('migration readiness against the test database', () => {
+  it('reports a push-managed schema as unmanaged', async () => {
+    await expect(checkMigrationReadiness(db)).resolves.toEqual({
+      state: 'unmanaged',
+    });
+  });
+});

--- a/packages/db/src/__tests__/migration-readiness.test.ts
+++ b/packages/db/src/__tests__/migration-readiness.test.ts
@@ -15,15 +15,23 @@ const journalPath = path.resolve(
   '../../drizzle/meta/_journal.json',
 );
 
-function databaseReturning(applied: unknown) {
+function databaseReturning(applied: unknown, publicTables = 0) {
   return {
-    execute: vi.fn(async () => [{ applied }]),
+    execute: vi.fn(async (query: unknown) =>
+      JSON.stringify(query).includes('information_schema')
+        ? [{ count: publicTables }]
+        : [{ applied }],
+    ),
   } as unknown as Parameters<typeof checkMigrationReadiness>[0];
 }
 
-function databaseThrowing(code: string) {
+function databaseThrowing(code: string, publicTables = 0) {
   return {
-    execute: vi.fn(async () => {
+    execute: vi.fn(async (query: { queryChunks?: unknown[] }) => {
+      // The bookkeeping read fails; the fallback table count answers.
+      if (JSON.stringify(query).includes('information_schema')) {
+        return [{ count: publicTables }];
+      }
       throw Object.assign(new Error('relation missing'), { code });
     }),
   } as unknown as Parameters<typeof checkMigrationReadiness>[0];
@@ -53,7 +61,7 @@ describe('migration readiness', () => {
     ).resolves.toMatchObject({ state: 'ready' });
   });
 
-  it('reports pending behind the expected migration or with no rows', async () => {
+  it('reports pending behind the expected migration or with no rows on an empty schema', async () => {
     await expect(
       checkMigrationReadiness(databaseReturning(LATEST_MIGRATION_MILLIS - 1)),
     ).resolves.toEqual({
@@ -61,20 +69,42 @@ describe('migration readiness', () => {
       appliedMillis: LATEST_MIGRATION_MILLIS - 1,
     });
     await expect(
-      checkMigrationReadiness(databaseReturning(null)),
+      checkMigrationReadiness(databaseReturning(null, 0)),
     ).resolves.toEqual({ state: 'pending', appliedMillis: null });
   });
 
-  it('treats a database without drizzle bookkeeping as unmanaged and rethrows other errors', async () => {
+  it('treats an empty bookkeeping table over a populated schema as unmanaged', async () => {
+    // drizzle-kit push leaves the table behind with no rows in dev and tests.
     await expect(
-      checkMigrationReadiness(databaseThrowing('42P01')),
+      checkMigrationReadiness(databaseReturning(null, 92)),
+    ).resolves.toEqual({ state: 'unmanaged' });
+  });
+
+  it('treats a populated database without drizzle bookkeeping as unmanaged and rethrows other errors', async () => {
+    await expect(
+      checkMigrationReadiness(databaseThrowing('42P01', 12)),
     ).resolves.toEqual({ state: 'unmanaged' });
     await expect(
-      checkMigrationReadiness(databaseThrowing('3F000')),
+      checkMigrationReadiness(databaseThrowing('3F000', 12)),
     ).resolves.toEqual({ state: 'unmanaged' });
     await expect(
       checkMigrationReadiness(databaseThrowing('57P01')),
     ).rejects.toThrow('relation missing');
+  });
+
+  it('waits on a brand-new database whose first migration has not run', async () => {
+    // Fresh Railway/Render databases have neither the drizzle schema nor
+    // any application table until the api pre-deploy migration starts.
+    await expect(
+      checkMigrationReadiness(databaseThrowing('3F000', 0)),
+    ).resolves.toEqual({ state: 'pending', appliedMillis: null });
+    await expect(
+      waitForMigrations({
+        database: databaseThrowing('42P01', 0),
+        intervalMs: 1,
+        timeoutMs: 5,
+      }),
+    ).rejects.toBeInstanceOf(MigrationsNotReadyError);
   });
 
   it('waits until the migration lands, logging while it does', async () => {

--- a/packages/db/src/__tests__/migration-readiness.test.ts
+++ b/packages/db/src/__tests__/migration-readiness.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  checkMigrationReadiness,
+  LATEST_MIGRATION_MILLIS,
+  LATEST_MIGRATION_TAG,
+  MigrationsNotReadyError,
+  waitForMigrations,
+} from '../lib/migration-readiness';
+
+const journalPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../drizzle/meta/_journal.json',
+);
+
+function databaseReturning(applied: unknown) {
+  return {
+    execute: vi.fn(async () => [{ applied }]),
+  } as unknown as Parameters<typeof checkMigrationReadiness>[0];
+}
+
+function databaseThrowing(code: string) {
+  return {
+    execute: vi.fn(async () => {
+      throw Object.assign(new Error('relation missing'), { code });
+    }),
+  } as unknown as Parameters<typeof checkMigrationReadiness>[0];
+}
+
+describe('migration readiness', () => {
+  it('expects the newest journal entry', () => {
+    const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as {
+      entries: Array<{ when: number; tag: string }>;
+    };
+    const newest = journal.entries.at(-1)!;
+    expect(LATEST_MIGRATION_MILLIS).toBe(newest.when);
+    expect(LATEST_MIGRATION_TAG).toBe(newest.tag);
+  });
+
+  it('reports ready once the applied migration reaches the expected one', async () => {
+    await expect(
+      checkMigrationReadiness(
+        databaseReturning(String(LATEST_MIGRATION_MILLIS)),
+      ),
+    ).resolves.toEqual({
+      state: 'ready',
+      appliedMillis: LATEST_MIGRATION_MILLIS,
+    });
+    await expect(
+      checkMigrationReadiness(databaseReturning(LATEST_MIGRATION_MILLIS + 1)),
+    ).resolves.toMatchObject({ state: 'ready' });
+  });
+
+  it('reports pending behind the expected migration or with no rows', async () => {
+    await expect(
+      checkMigrationReadiness(databaseReturning(LATEST_MIGRATION_MILLIS - 1)),
+    ).resolves.toEqual({
+      state: 'pending',
+      appliedMillis: LATEST_MIGRATION_MILLIS - 1,
+    });
+    await expect(
+      checkMigrationReadiness(databaseReturning(null)),
+    ).resolves.toEqual({ state: 'pending', appliedMillis: null });
+  });
+
+  it('treats a database without drizzle bookkeeping as unmanaged and rethrows other errors', async () => {
+    await expect(
+      checkMigrationReadiness(databaseThrowing('42P01')),
+    ).resolves.toEqual({ state: 'unmanaged' });
+    await expect(
+      checkMigrationReadiness(databaseThrowing('3F000')),
+    ).resolves.toEqual({ state: 'unmanaged' });
+    await expect(
+      checkMigrationReadiness(databaseThrowing('57P01')),
+    ).rejects.toThrow('relation missing');
+  });
+
+  it('waits until the migration lands, logging while it does', async () => {
+    let applied = LATEST_MIGRATION_MILLIS - 10;
+    const database = {
+      execute: vi.fn(async () => {
+        applied += 5;
+        return [{ applied }];
+      }),
+    } as unknown as Parameters<typeof checkMigrationReadiness>[0];
+    const log = vi.fn();
+
+    await expect(
+      waitForMigrations({ database, intervalMs: 1, logEveryMs: 0, log }),
+    ).resolves.toEqual({
+      state: 'ready',
+      appliedMillis: LATEST_MIGRATION_MILLIS,
+    });
+    expect(database.execute).toHaveBeenCalledTimes(2);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('Waiting for database migrations'),
+    );
+  });
+
+  it('gives up after the timeout', async () => {
+    await expect(
+      waitForMigrations({
+        database: databaseReturning(null),
+        intervalMs: 1,
+        timeoutMs: 5,
+      }),
+    ).rejects.toBeInstanceOf(MigrationsNotReadyError);
+  });
+});

--- a/packages/db/src/lib/migration-readiness.ts
+++ b/packages/db/src/lib/migration-readiness.ts
@@ -1,0 +1,104 @@
+import { sql } from 'drizzle-orm';
+
+import journal from '../../drizzle/meta/_journal.json';
+import type { DatabaseOrTransaction } from '../db';
+
+/**
+ * The newest migration this build expects, as drizzle records it: the
+ * migrator writes each entry's journal `when` into
+ * `drizzle.__drizzle_migrations.created_at`.
+ */
+export const LATEST_MIGRATION_MILLIS = journal.entries.reduce(
+  (latest, entry) => Math.max(latest, entry.when),
+  0,
+);
+export const LATEST_MIGRATION_TAG =
+  journal.entries.find((entry) => entry.when === LATEST_MIGRATION_MILLIS)
+    ?.tag ?? null;
+
+export type MigrationReadiness =
+  | { state: 'ready'; appliedMillis: number }
+  | { state: 'pending'; appliedMillis: number | null }
+  /** No drizzle bookkeeping at all: the schema is pushed directly (dev, tests). */
+  | { state: 'unmanaged' };
+
+const MISSING_RELATION_CODES = new Set(['42P01', '3F000']);
+
+function isMissingRelationError(error: unknown): boolean {
+  const code =
+    (error as { code?: unknown })?.code ??
+    (error as { cause?: { code?: unknown } })?.cause?.code;
+  return typeof code === 'string' && MISSING_RELATION_CODES.has(code);
+}
+
+export async function checkMigrationReadiness(
+  database: DatabaseOrTransaction,
+): Promise<MigrationReadiness> {
+  let rows: Array<{ applied: unknown }>;
+  try {
+    rows = (await database.execute(
+      sql`select max(created_at) as applied from drizzle.__drizzle_migrations`,
+    )) as unknown as Array<{ applied: unknown }>;
+  } catch (error) {
+    if (isMissingRelationError(error)) return { state: 'unmanaged' };
+    throw error;
+  }
+  const raw = rows[0]?.applied;
+  const appliedMillis = raw === null || raw === undefined ? null : Number(raw);
+  if (appliedMillis !== null && appliedMillis >= LATEST_MIGRATION_MILLIS) {
+    return { state: 'ready', appliedMillis };
+  }
+  return { state: 'pending', appliedMillis };
+}
+
+export class MigrationsNotReadyError extends Error {
+  constructor(readonly readiness: MigrationReadiness) {
+    super(
+      `Database migrations did not reach ${LATEST_MIGRATION_TAG ?? LATEST_MIGRATION_MILLIS} in time (applied: ${
+        readiness.state === 'pending'
+          ? (readiness.appliedMillis ?? 'none')
+          : readiness.state
+      }).`,
+    );
+    this.name = 'MigrationsNotReadyError';
+  }
+}
+
+/**
+ * Blocks until the database has every migration this build ships with.
+ *
+ * Deployments roll all services at once while migrations run only ahead of
+ * the api service, so a worker that reads a column the pending migration
+ * adds would otherwise crash at boot, exhaust the platform's restart budget
+ * within seconds, and stay down after the migration lands. Waiting here
+ * turns that into a delayed start. A database without drizzle bookkeeping
+ * is treated as ready; its schema is managed some other way.
+ */
+export async function waitForMigrations(options: {
+  database: DatabaseOrTransaction;
+  timeoutMs?: number;
+  intervalMs?: number;
+  logEveryMs?: number;
+  log?: (message: string) => void;
+}): Promise<MigrationReadiness> {
+  const timeoutMs = options.timeoutMs ?? 10 * 60_000;
+  const intervalMs = options.intervalMs ?? 5_000;
+  const logEveryMs = options.logEveryMs ?? 30_000;
+  const log = options.log ?? (() => {});
+  const startedAt = Date.now();
+  let lastLogAt = 0;
+
+  for (;;) {
+    const readiness = await checkMigrationReadiness(options.database);
+    if (readiness.state !== 'pending') return readiness;
+    const elapsed = Date.now() - startedAt;
+    if (elapsed >= timeoutMs) throw new MigrationsNotReadyError(readiness);
+    if (lastLogAt === 0 || Date.now() - lastLogAt >= logEveryMs) {
+      lastLogAt = Date.now();
+      log(
+        `Waiting for database migrations: applied ${readiness.appliedMillis ?? 'none'}, expected ${LATEST_MIGRATION_TAG ?? LATEST_MIGRATION_MILLIS} (${Math.round(elapsed / 1000)}s elapsed).`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}

--- a/packages/db/src/lib/migration-readiness.ts
+++ b/packages/db/src/lib/migration-readiness.ts
@@ -19,7 +19,7 @@ export const LATEST_MIGRATION_TAG =
 export type MigrationReadiness =
   | { state: 'ready'; appliedMillis: number }
   | { state: 'pending'; appliedMillis: number | null }
-  /** No drizzle bookkeeping at all: the schema is pushed directly (dev, tests). */
+  /** Tables exist but no drizzle bookkeeping: the schema is pushed directly (dev, tests). */
   | { state: 'unmanaged' };
 
 const MISSING_RELATION_CODES = new Set(['42P01', '3F000']);
@@ -34,21 +34,34 @@ function isMissingRelationError(error: unknown): boolean {
 export async function checkMigrationReadiness(
   database: DatabaseOrTransaction,
 ): Promise<MigrationReadiness> {
-  let rows: Array<{ applied: unknown }>;
+  let appliedMillis: number | null = null;
   try {
-    rows = (await database.execute(
+    const rows = (await database.execute(
       sql`select max(created_at) as applied from drizzle.__drizzle_migrations`,
     )) as unknown as Array<{ applied: unknown }>;
+    const raw = rows[0]?.applied;
+    appliedMillis = raw === null || raw === undefined ? null : Number(raw);
   } catch (error) {
-    if (isMissingRelationError(error)) return { state: 'unmanaged' };
-    throw error;
+    if (!isMissingRelationError(error)) throw error;
   }
-  const raw = rows[0]?.applied;
-  const appliedMillis = raw === null || raw === undefined ? null : Number(raw);
-  if (appliedMillis !== null && appliedMillis >= LATEST_MIGRATION_MILLIS) {
-    return { state: 'ready', appliedMillis };
+  if (appliedMillis !== null) {
+    return appliedMillis >= LATEST_MIGRATION_MILLIS
+      ? { state: 'ready', appliedMillis }
+      : { state: 'pending', appliedMillis };
   }
-  return { state: 'pending', appliedMillis };
+  // No applied migration on record (no bookkeeping, or an empty table). A
+  // brand-new database looks exactly like this until its first migration
+  // lands, so only an already-populated schema counts as managed some other
+  // way (drizzle push in dev and tests); an empty one is a migration that
+  // has not started yet. The migrator applies each migration and its
+  // bookkeeping row in one transaction, so a populated schema with an empty
+  // table is never a migration in flight.
+  const tables = (await database.execute(
+    sql`select count(*)::int as count from information_schema.tables where table_schema = 'public' and table_type = 'BASE TABLE'`,
+  )) as unknown as Array<{ count: unknown }>;
+  return Number(tables[0]?.count ?? 0) > 0
+    ? { state: 'unmanaged' }
+    : { state: 'pending', appliedMillis: null };
 }
 
 export class MigrationsNotReadyError extends Error {
@@ -71,8 +84,9 @@ export class MigrationsNotReadyError extends Error {
  * the api service, so a worker that reads a column the pending migration
  * adds would otherwise crash at boot, exhaust the platform's restart budget
  * within seconds, and stay down after the migration lands. Waiting here
- * turns that into a delayed start. A database without drizzle bookkeeping
- * is treated as ready; its schema is managed some other way.
+ * turns that into a delayed start. A populated database without drizzle
+ * bookkeeping is treated as ready (its schema is managed some other way);
+ * an empty one waits for its first migration like any other.
  */
 export async function waitForMigrations(options: {
   database: DatabaseOrTransaction;

--- a/packages/db/src/server.ts
+++ b/packages/db/src/server.ts
@@ -41,6 +41,7 @@ export * from './lib/map-raw-row';
 export * from './lib/legacy-task-inference-usage';
 export * from './lib/llm-usage';
 export * from './lib/deployment-auth-keypairs';
+export * from './lib/migration-readiness';
 export * from './lib/environment-variables';
 export * from './lib/task-id';
 export * from './lib/task-activity-timestamp';


### PR DESCRIPTION
## Summary

During the 1.2.0 fleet rollout, bullmq crashed on five Railway deployments (and one more had been down since the 1.1.0 rollout). Root cause: Railway rolls every service in parallel, migrations run only as the `api` service's pre-deploy step, and since 1.2.0 bullmq's boot recovers pending Fast parent events by querying `fast_agent_parent_events.claimed_until`. On one deployment the migration landed 2.5 minutes after bullmq started, by which point it had crashed every 2 seconds, exhausted Railway's restart budget, and stayed dead. Nothing re-triggers it once the schema catches up.

**Fix.** `packages/db` gains `waitForMigrations`, which compares `max(created_at)` in `drizzle.__drizzle_migrations` (drizzle writes each journal entry's `when` there) against the newest entry in the `_journal.json` this build ships, and polls until they match. bullmq and controller call it before their first database access, logging progress every 30 s and giving up with a clear error after 10 minutes. A database with no drizzle bookkeeping (schema pushed directly, as in dev and tests) is treated as ready.

This protects Compose and Coolify self-hosters as well, who get the same race without a Railway email.

## Verification

- New unit tests cover ready/pending/unmanaged detection, the wait loop, the timeout, and that the expected version tracks the journal.
- `check-types` for db, bullmq, controller; `pnpm lint:fast`; `pnpm knip`; the bullmq tsup bundle builds with the JSON journal import inlined.
- Operationally, the six crashed bullmq deployments were redeployed by hand once their migrations had landed and are healthy; this change prevents the next rollout from needing that.