### PR TITLE
fix: retry the Brain job worker when the queue lock is still held

### DIFF
--- a/.changeset/gbrain-supervisor-lock-retry.md
+++ b/.changeset/gbrain-supervisor-lock-retry.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fixed the Brain (gbrain) service crash-looping after a deploy when its job worker found the queue lock still held by the container being replaced. The worker now retries within the lock's TTL instead of taking the whole service down, so a fresh or redeployed Brain comes up on its own.

--- a/.docker/gbrain/entrypoint.sh
+++ b/.docker/gbrain/entrypoint.sh
@@ -375,7 +375,12 @@ run_job_worker() {
       --concurrency "${GBRAIN_WORKER_CONCURRENCY:-1}" \
       --pid-file "$DATA_DIR/gbrain-worker-supervisor.pid" &
     supervisor_pid=$!
-    trap 'kill -TERM "$supervisor_pid" 2>/dev/null' TERM INT
+    # Shutdown must end the wrapper too, whether it is waiting on a live
+    # supervisor or sleeping between retries; otherwise the loop outlives the
+    # entrypoint's stop and starts another supervisor mid-shutdown. Waiting
+    # for the forwarded signal to land lets the supervisor release its lock
+    # row, which is what spares the next container this whole retry.
+    trap 'kill -TERM "$supervisor_pid" 2>/dev/null; wait "$supervisor_pid" 2>/dev/null; exit 0' TERM INT
     if wait "$supervisor_pid"; then
       status=0
     else
@@ -387,7 +392,9 @@ run_job_worker() {
     fi
     attempt=$((attempt + 1))
     echo "[gbrain-entrypoint] job worker found the queue lock held; retrying in ${SUPERVISOR_LOCK_RETRY_SECONDS}s ($attempt/$SUPERVISOR_LOCK_RETRY_LIMIT)"
-    sleep "$SUPERVISOR_LOCK_RETRY_SECONDS"
+    # Backgrounded so the trap fires during the pause rather than after it.
+    sleep "$SUPERVISOR_LOCK_RETRY_SECONDS" &
+    wait $! || true
   done
 }
 

--- a/.docker/gbrain/entrypoint.sh
+++ b/.docker/gbrain/entrypoint.sh
@@ -357,11 +357,42 @@ if [ -n "$CONFIGURED_DIMENSIONS" ] && [ "$CONFIGURED_DIMENSIONS" != "$EMBEDDING_
   echo "[gbrain-entrypoint] WARNING:   gbrain migrate embeddings --to <provider:model> --yes"
 fi
 
+# The supervisor holds a queue-scoped lock row in Postgres with a 5-minute
+# TTL. On a rolling deploy the container being replaced can still hold it
+# (or have died without releasing it), and this gbrain exits with code 2
+# (LOCK_HELD) the moment it sees that. Treating that exit as fatal took the
+# server down too and crash-looped three fresh Brains past Railway's restart
+# budget before the TTL had even lapsed (2026-09-02). Retry within the TTL
+# plus a margin instead; anything else the supervisor exits with stays fatal.
+SUPERVISOR_LOCK_HELD_EXIT=2
+SUPERVISOR_LOCK_RETRY_SECONDS="${GBRAIN_SUPERVISOR_LOCK_RETRY_SECONDS:-30}"
+SUPERVISOR_LOCK_RETRY_LIMIT="${GBRAIN_SUPERVISOR_LOCK_RETRY_LIMIT:-14}"
+run_job_worker() {
+  attempt=0
+  while :; do
+    rm -f "$DATA_DIR/gbrain-worker-supervisor.pid"
+    gbrain jobs supervisor \
+      --concurrency "${GBRAIN_WORKER_CONCURRENCY:-1}" \
+      --pid-file "$DATA_DIR/gbrain-worker-supervisor.pid" &
+    supervisor_pid=$!
+    trap 'kill -TERM "$supervisor_pid" 2>/dev/null' TERM INT
+    if wait "$supervisor_pid"; then
+      status=0
+    else
+      status=$?
+    fi
+    if [ "$status" -ne "$SUPERVISOR_LOCK_HELD_EXIT" ] \
+      || [ "$attempt" -ge "$SUPERVISOR_LOCK_RETRY_LIMIT" ]; then
+      return "$status"
+    fi
+    attempt=$((attempt + 1))
+    echo "[gbrain-entrypoint] job worker found the queue lock held; retrying in ${SUPERVISOR_LOCK_RETRY_SECONDS}s ($attempt/$SUPERVISOR_LOCK_RETRY_LIMIT)"
+    sleep "$SUPERVISOR_LOCK_RETRY_SECONDS"
+  done
+}
+
 echo "[gbrain-entrypoint] starting durable job worker"
-rm -f "$DATA_DIR/gbrain-worker-supervisor.pid"
-gbrain jobs supervisor \
-  --concurrency "${GBRAIN_WORKER_CONCURRENCY:-1}" \
-  --pid-file "$DATA_DIR/gbrain-worker-supervisor.pid" &
+run_job_worker &
 WORKER_PID=$!
 
 echo "[gbrain-entrypoint] starting gbrain serve on :$PORT (full surface)"

--- a/apps/dev/src/services/__tests__/gbrain-image.test.ts
+++ b/apps/dev/src/services/__tests__/gbrain-image.test.ts
@@ -37,5 +37,12 @@ describe('gbrain image configuration', () => {
     expect(entrypoint).toContain(
       'https://github.com/garrytan/gbrain/issues/4294',
     );
+    // A supervisor beaten to the queue lock by a container still being
+    // replaced retries instead of taking the server down (LOCK_HELD = 2).
+    expect(entrypoint).toContain('SUPERVISOR_LOCK_HELD_EXIT=2');
+    expect(entrypoint).toContain('run_job_worker &');
+    expect(entrypoint).toContain(
+      'retrying in ${SUPERVISOR_LOCK_RETRY_SECONDS}s',
+    );
   });
 });


### PR DESCRIPTION
## Summary

During the 1.2.1 fleet rollout, three freshly provisioned Brains (`gbrain`) ended up `CRASHED` on Railway. Their logs show the durable job worker exiting immediately with:

```
Supervisor already running for queue 'default' on this database (another supervisor holds the queue lock, regardless of pidfile path). Exiting.
```

**Cause.** Cloud creates the `gbrain` service (Railway deploys it at once), then sets its health check, image, and variables, which triggers a second deployment and stops the first container. When the first container had already booted far enough to take the supervisor's queue lock (a `gbrain_cycle_locks` row with a 5-minute TTL), the second one found it held. The gbrain ref we pin exits with code 2 (`LOCK_HELD`) on the spot; upstream later added a wait-for-takeover, but our pin predates it. Our entrypoint treated any child exit as fatal, so the whole container died, Railway restarted it every 6 s, and the restart budget ran out three minutes before the lock's TTL expired. Verified on one tenant: lock row acquired 23:34:38 by the first container's hostname, second container started 23:34:46, crash-loop until 23:36, TTL 23:39:38. Timing-dependent, hence 3 of 86.

**Fix.** The entrypoint wraps `gbrain jobs supervisor` in `run_job_worker`, which retries an exit code of 2 every 30 s for up to 14 attempts (7 minutes, comfortably past the TTL plus refresh grace) while `gbrain serve` keeps running. Any other supervisor exit stays fatal exactly as before, and SIGTERM is forwarded to the inner process. Both knobs are overridable (`GBRAIN_SUPERVISOR_LOCK_RETRY_SECONDS`, `GBRAIN_SUPERVISOR_LOCK_RETRY_LIMIT`).

This also covers ordinary Brain redeploys on every platform, where the old container can die mid-lease.

## Verification
- `sh -n` on the entrypoint; `deploy/ci/validate-deployment-artifacts.mjs` passes; `gbrain-image.test.ts` extended and passing.
- The three affected tenants were redeployed by hand after their locks expired and came up.