### PR TITLE
[Fix] Render raw Slack mentions as linked names in web transcripts

### DIFF
--- a/apps/api/src/handlers/slack/events/active-run.ts
+++ b/apps/api/src/handlers/slack/events/active-run.ts
@@ -462,6 +462,7 @@ export async function processActiveRunMessage(
         }),
         slack.normalizeIncomingText(
           stripLeadingRawSlackMention(event.authoredText ?? event.text),
+          { preserveMentions: true },
         ),
         getLatestSlackBotReply(event.channel, threadId),
       ]);

--- a/apps/api/src/handlers/slack/events/snapshot-resume.ts
+++ b/apps/api/src/handlers/slack/events/snapshot-resume.ts
@@ -126,6 +126,7 @@ export async function processSnapshotResume(
       }),
       slack.normalizeIncomingText(
         stripLeadingRawSlackMention(event.authoredText ?? event.text),
+        { preserveMentions: true },
       ),
       getLatestSlackBotReply(event.channel, threadId),
     ]);

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.client.test.tsx
@@ -51,6 +51,13 @@ vi.mock('@/trpc/client', () => ({
     },
   }),
   useTRPC: () => ({
+    slack: {
+      resolveUsers: {
+        queryOptions: (input: unknown) => ({
+          queryKey: ['slack.resolveUsers', input],
+        }),
+      },
+    },
     fastSessions: {
       composerSuggestion: {
         queryOptions: (input: unknown, options?: Record<string, unknown>) => ({

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.tsx
@@ -34,6 +34,7 @@ import {
   MessageUiOptionsProvider,
   Shimmer,
 } from '@/components/ai-elements';
+import { SlackMentionProvider } from '@/components/ai-elements/slack-mention-context';
 import { WorkspaceHeader } from '@/components/layout';
 import {
   SessionPromptInput,
@@ -282,6 +283,7 @@ export function FastSessionTranscript({
   owner,
   headerExtras,
   timelineExtras,
+  slackTeamId = null,
 }: {
   sessionId: string;
   initialMessages: FastSessionMessage[];
@@ -296,6 +298,8 @@ export function FastSessionTranscript({
   owner?: TranscriptOwner;
   headerExtras?: ReactNode;
   timelineExtras?: ReactNode;
+  /** Slack team the session's raw `<@U…>` mention tokens belong to. */
+  slackTeamId?: string | null;
 }) {
   const trpcClient = useTRPCClient();
   const openTaskPanel = useOpenSessionTaskPanel();
@@ -735,94 +739,96 @@ export function FastSessionTranscript({
     <MessageUiOptionsProvider
       value={{ displayMode, hidePrReviewActions: true }}
     >
-      <WorkspaceHeader
-        className="py-4.25"
-        contentClassName={SESSION_HEADER_CONTENT_CLASS_NAME}
-      >
-        <h1 className={`ph-no-capture ${SESSION_HEADER_TITLE_CLASS_NAME}`}>
-          {title ?? fallbackTitle}
-        </h1>
-        {headerExtras}
-      </WorkspaceHeader>
-      <Conversation className="min-h-0 flex-1" initial="instant">
-        <ConversationContent className="ph-no-capture mx-auto w-full max-w-4xl p-4">
-          {hasOlderMessages ? (
-            <p className="mb-4 rounded-md border border-border bg-muted px-3 py-2 text-center text-xs text-muted-foreground">
-              Older messages in this session are not shown.
-            </p>
-          ) : null}
-          <AcpTranscriptBlockList
-            blocks={renderBlocks}
-            showInternalMessages={false}
-            onSuppress={suppressMessage}
-            onOpenDelegatedTask={openTaskPanel ?? undefined}
-          />
-          {hasVisibleAssistantMessage ? timelineExtras : null}
-          {pendingResponseState.pendingAfter !== null &&
-          streamMessages.length === 0 ? (
-            <ThinkingMessage />
-          ) : !isSending &&
-            conversationResponding !== true &&
-            runningTaskCount > 0 &&
-            openTasksPanel ? (
-            <RunningTasksMessage
-              count={runningTaskCount}
-              onOpenTasks={openTasksPanel}
+      <SlackMentionProvider slackTeamId={slackTeamId}>
+        <WorkspaceHeader
+          className="py-4.25"
+          contentClassName={SESSION_HEADER_CONTENT_CLASS_NAME}
+        >
+          <h1 className={`ph-no-capture ${SESSION_HEADER_TITLE_CLASS_NAME}`}>
+            {title ?? fallbackTitle}
+          </h1>
+          {headerExtras}
+        </WorkspaceHeader>
+        <Conversation className="min-h-0 flex-1" initial="instant">
+          <ConversationContent className="ph-no-capture mx-auto w-full max-w-4xl p-4">
+            {hasOlderMessages ? (
+              <p className="mb-4 rounded-md border border-border bg-muted px-3 py-2 text-center text-xs text-muted-foreground">
+                Older messages in this session are not shown.
+              </p>
+            ) : null}
+            <AcpTranscriptBlockList
+              blocks={renderBlocks}
+              showInternalMessages={false}
+              onSuppress={suppressMessage}
+              onOpenDelegatedTask={openTaskPanel ?? undefined}
             />
-          ) : null}
-          {reviewOffers.map((offer) => (
-            <PrReviewActionOffer
-              key={offer.deliveryId}
-              className="mt-3 rounded-lg border border-border/70 bg-muted/40 px-3 py-3"
-              offer={offer}
-              showQuestion
-              onAction={(choice) =>
-                handleReviewAction(offer.deliveryId, choice)
+            {hasVisibleAssistantMessage ? timelineExtras : null}
+            {pendingResponseState.pendingAfter !== null &&
+            streamMessages.length === 0 ? (
+              <ThinkingMessage />
+            ) : !isSending &&
+              conversationResponding !== true &&
+              runningTaskCount > 0 &&
+              openTasksPanel ? (
+              <RunningTasksMessage
+                count={runningTaskCount}
+                onOpenTasks={openTasksPanel}
+              />
+            ) : null}
+            {reviewOffers.map((offer) => (
+              <PrReviewActionOffer
+                key={offer.deliveryId}
+                className="mt-3 rounded-lg border border-border/70 bg-muted/40 px-3 py-3"
+                offer={offer}
+                showQuestion
+                onAction={(choice) =>
+                  handleReviewAction(offer.deliveryId, choice)
+                }
+              />
+            ))}
+            {pendingInputRequest ? (
+              <div className="mt-3">
+                {pendingInputRequest.preset === 'setup_starter_tasks' ? (
+                  <SetupStarterTasksCard
+                    sessionId={sessionId}
+                    request={pendingInputRequest}
+                  />
+                ) : (
+                  <SessionUserInputCard
+                    sessionId={sessionId}
+                    request={pendingInputRequest}
+                  />
+                )}
+              </div>
+            ) : null}
+          </ConversationContent>
+          <ConversationScrollButton />
+        </Conversation>
+        {canReply && !pendingInputRequest ? (
+          <div className="mx-auto w-full shrink-0 overflow-clip rounded-t-md rounded-b-3xl border-2 border-background bg-card transition-colors @[56rem]:rounded-t-lg">
+            <SessionPromptInput
+              sessionId={sessionId}
+              isBusy={isSending}
+              onSend={sendReply}
+              historyMessageCount={suggestionHistory.messageCount}
+              assistantMessageCount={suggestionHistory.assistantCount}
+              taskStateRevision={taskStateRevision}
+              agentWorking={
+                isSending ||
+                conversationResponding === true ||
+                pendingResponseState.pendingAfter !== null
               }
+              initialModel={sessionModel}
+              initialReasoningEffort={sessionReasoningEffort}
+              defaultModelId={defaultModelId}
+              defaultReasoningEffort={defaultReasoningEffort}
             />
-          ))}
-          {pendingInputRequest ? (
-            <div className="mt-3">
-              {pendingInputRequest.preset === 'setup_starter_tasks' ? (
-                <SetupStarterTasksCard
-                  sessionId={sessionId}
-                  request={pendingInputRequest}
-                />
-              ) : (
-                <SessionUserInputCard
-                  sessionId={sessionId}
-                  request={pendingInputRequest}
-                />
-              )}
-            </div>
-          ) : null}
-        </ConversationContent>
-        <ConversationScrollButton />
-      </Conversation>
-      {canReply && !pendingInputRequest ? (
-        <div className="mx-auto w-full shrink-0 overflow-clip rounded-t-md rounded-b-3xl border-2 border-background bg-card transition-colors @[56rem]:rounded-t-lg">
-          <SessionPromptInput
-            sessionId={sessionId}
-            isBusy={isSending}
-            onSend={sendReply}
-            historyMessageCount={suggestionHistory.messageCount}
-            assistantMessageCount={suggestionHistory.assistantCount}
-            taskStateRevision={taskStateRevision}
-            agentWorking={
-              isSending ||
-              conversationResponding === true ||
-              pendingResponseState.pendingAfter !== null
-            }
-            initialModel={sessionModel}
-            initialReasoningEffort={sessionReasoningEffort}
-            defaultModelId={defaultModelId}
-            defaultReasoningEffort={defaultReasoningEffort}
-          />
-          {replyError ? (
-            <p className="px-4 pb-2 text-xs text-destructive">{replyError}</p>
-          ) : null}
-        </div>
-      ) : null}
+            {replyError ? (
+              <p className="px-4 pb-2 text-xs text-destructive">{replyError}</p>
+            ) : null}
+          </div>
+        ) : null}
+      </SlackMentionProvider>
     </MessageUiOptionsProvider>
   );
 }

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.tsx
@@ -34,7 +34,10 @@ import {
   MessageUiOptionsProvider,
   Shimmer,
 } from '@/components/ai-elements';
-import { SlackMentionProvider } from '@/components/ai-elements/slack-mention-context';
+import {
+  SlackMentionProvider,
+  type SlackMentionScope,
+} from '@/components/ai-elements/slack-mention-context';
 import { WorkspaceHeader } from '@/components/layout';
 import {
   SessionPromptInput,
@@ -283,7 +286,6 @@ export function FastSessionTranscript({
   owner,
   headerExtras,
   timelineExtras,
-  slackTeamId = null,
 }: {
   sessionId: string;
   initialMessages: FastSessionMessage[];
@@ -298,8 +300,6 @@ export function FastSessionTranscript({
   owner?: TranscriptOwner;
   headerExtras?: ReactNode;
   timelineExtras?: ReactNode;
-  /** Slack team the session's raw `<@U…>` mention tokens belong to. */
-  slackTeamId?: string | null;
 }) {
   const trpcClient = useTRPCClient();
   const openTaskPanel = useOpenSessionTaskPanel();
@@ -308,6 +308,10 @@ export function FastSessionTranscript({
   const taskStateRevision = useSessionTaskStateRevision();
   const { enabled: narrationModeEnabled } = useNarrationMode();
   const displayMode = narrationModeEnabled ? 'narration' : 'default';
+  const slackMentionScope = useMemo<SlackMentionScope>(
+    () => ({ kind: 'session', sessionId }),
+    [sessionId],
+  );
   const [serverMessages, setServerMessages] = useState<
     Map<string, TranscriptMessage>
   >(
@@ -739,7 +743,7 @@ export function FastSessionTranscript({
     <MessageUiOptionsProvider
       value={{ displayMode, hidePrReviewActions: true }}
     >
-      <SlackMentionProvider slackTeamId={slackTeamId}>
+      <SlackMentionProvider scope={slackMentionScope}>
         <WorkspaceHeader
           className="py-4.25"
           contentClassName={SESSION_HEADER_CONTENT_CLASS_NAME}

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/page.tsx
@@ -162,6 +162,9 @@ export default async function SessionDetailPage({
                   sessionReasoningEffort={session.reasoningEffort}
                   defaultModelId={defaultModelId}
                   defaultReasoningEffort={defaultReasoningEffort}
+                  slackTeamId={
+                    session.surface === 'slack' ? session.workspaceId : null
+                  }
                   {...(unifiedSession.ownerUserId
                     ? {
                         owner: {
@@ -251,6 +254,7 @@ export default async function SessionDetailPage({
           sessionReasoningEffort={session.reasoningEffort}
           defaultModelId={defaultModelId}
           defaultReasoningEffort={defaultReasoningEffort}
+          slackTeamId={session.surface === 'slack' ? session.workspaceId : null}
           owner={{
             userId: session.userId,
             name: session.ownerName,

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/page.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/page.tsx
@@ -162,9 +162,6 @@ export default async function SessionDetailPage({
                   sessionReasoningEffort={session.reasoningEffort}
                   defaultModelId={defaultModelId}
                   defaultReasoningEffort={defaultReasoningEffort}
-                  slackTeamId={
-                    session.surface === 'slack' ? session.workspaceId : null
-                  }
                   {...(unifiedSession.ownerUserId
                     ? {
                         owner: {
@@ -254,7 +251,6 @@ export default async function SessionDetailPage({
           sessionReasoningEffort={session.reasoningEffort}
           defaultModelId={defaultModelId}
           defaultReasoningEffort={defaultReasoningEffort}
-          slackTeamId={session.surface === 'slack' ? session.workspaceId : null}
           owner={{
             userId: session.userId,
             name: session.ownerName,

--- a/apps/web/src/app/(sandbox)/task/[taskId]/Messages.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/Messages.tsx
@@ -8,7 +8,6 @@ import {
   type MutableRefObject,
 } from 'react';
 import type { ScrollToBottom } from 'use-stick-to-bottom';
-import { getSlackTeamIdFromTaskPayload } from '@roomote/types';
 
 import {
   Conversation,
@@ -22,7 +21,10 @@ import {
   MessageUiOptionsProvider,
   type MessageUiOptions,
 } from '@/components/ai-elements/message-ui-options';
-import { SlackMentionProvider } from '@/components/ai-elements/slack-mention-context';
+import {
+  SlackMentionProvider,
+  type SlackMentionScope,
+} from '@/components/ai-elements/slack-mention-context';
 import { useNarrationMode } from '@/hooks/useNarrationMode';
 import { useMindReaderMode } from '@/hooks/useMindReaderMode';
 import { Lightbulb, Skeleton } from '@/components/system';
@@ -163,11 +165,14 @@ const MessagesBase = ({
     taskPhase === 'running' &&
     !hasVisibleAssistantOutput(renderBlocks);
 
-  const slackTeamId = getSlackTeamIdFromTaskPayload(session.taskRun?.payload);
+  const slackMentionScope = useMemo<SlackMentionScope>(
+    () => ({ kind: 'task', taskId: session.taskId }),
+    [session.taskId],
+  );
 
   return (
     <MessageUiOptionsProvider value={resolvedMessageUiOptions}>
-      <SlackMentionProvider slackTeamId={slackTeamId}>
+      <SlackMentionProvider scope={slackMentionScope}>
         <Conversation
           className="min-h-0 flex-1"
           initial={hasAnchor ? false : initialScrollBehavior}

--- a/apps/web/src/app/(sandbox)/task/[taskId]/Messages.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/Messages.tsx
@@ -8,6 +8,7 @@ import {
   type MutableRefObject,
 } from 'react';
 import type { ScrollToBottom } from 'use-stick-to-bottom';
+import { getSlackTeamIdFromTaskPayload } from '@roomote/types';
 
 import {
   Conversation,
@@ -21,6 +22,7 @@ import {
   MessageUiOptionsProvider,
   type MessageUiOptions,
 } from '@/components/ai-elements/message-ui-options';
+import { SlackMentionProvider } from '@/components/ai-elements/slack-mention-context';
 import { useNarrationMode } from '@/hooks/useNarrationMode';
 import { useMindReaderMode } from '@/hooks/useMindReaderMode';
 import { Lightbulb, Skeleton } from '@/components/system';
@@ -161,34 +163,38 @@ const MessagesBase = ({
     taskPhase === 'running' &&
     !hasVisibleAssistantOutput(renderBlocks);
 
+  const slackTeamId = getSlackTeamIdFromTaskPayload(session.taskRun?.payload);
+
   return (
     <MessageUiOptionsProvider value={resolvedMessageUiOptions}>
-      <Conversation
-        className="min-h-0 flex-1"
-        initial={hasAnchor ? false : initialScrollBehavior}
-      >
-        <ConversationContent
-          className={cn('ph-no-capture', conversationClassName)}
+      <SlackMentionProvider slackTeamId={slackTeamId}>
+        <Conversation
+          className="min-h-0 flex-1"
+          initial={hasAnchor ? false : initialScrollBehavior}
         >
-          {shouldRenderSessionPrompt && sessionPrompt && (
-            <AcpTextMessage msg={sessionPrompt} />
-          )}
-          {!historyReady && <TranscriptSkeleton />}
-          <AcpTranscriptBlockList
-            blocks={renderBlocks}
-            showInternalMessages={showInternalMessages}
-            onSuppress={suppressMessage}
-          />
-          {session.taskRun && <SleepWakeMessages taskRun={session.taskRun} />}
-          {shouldShowNarrationWorkingReasoning && (
-            <NarrationWorkingReasoningMessage />
-          )}
-          {footer}
-        </ConversationContent>
-        <ConversationScrollButton />
-        {scrollRef && <ScrollBridge handleRef={scrollRef} />}
-        <ScrollToHash messages={messages} />
-      </Conversation>
+          <ConversationContent
+            className={cn('ph-no-capture', conversationClassName)}
+          >
+            {shouldRenderSessionPrompt && sessionPrompt && (
+              <AcpTextMessage msg={sessionPrompt} />
+            )}
+            {!historyReady && <TranscriptSkeleton />}
+            <AcpTranscriptBlockList
+              blocks={renderBlocks}
+              showInternalMessages={showInternalMessages}
+              onSuppress={suppressMessage}
+            />
+            {session.taskRun && <SleepWakeMessages taskRun={session.taskRun} />}
+            {shouldShowNarrationWorkingReasoning && (
+              <NarrationWorkingReasoningMessage />
+            )}
+            {footer}
+          </ConversationContent>
+          <ConversationScrollButton />
+          {scrollRef && <ScrollBridge handleRef={scrollRef} />}
+          <ScrollToHash messages={messages} />
+        </Conversation>
+      </SlackMentionProvider>
     </MessageUiOptionsProvider>
   );
 };

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpTextMessage.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpTextMessage.tsx
@@ -45,6 +45,7 @@ import { ProviderRetryNoticeMessage } from './ProviderRetryNoticeMessage';
 import { TerminalProviderErrorMessage } from './TerminalProviderErrorMessage';
 import { PrReviewActionOffer } from '@/components/ai-elements/pr-review-action-offer';
 import { useMessageUiOptions } from '@/components/ai-elements/message-ui-options';
+import { SlackMessageText } from '@/components/ai-elements/slack-message-text';
 
 const UserMessageToggle = ({
   isExpanded,
@@ -360,10 +361,12 @@ export function AcpTextMessage({ msg }: AcpTextMessageProps) {
                         </p>
                       ),
                     )}
-                    <span className="mt-2 block">{baseContent}</span>
+                    <span className="mt-2 block">
+                      <SlackMessageText text={baseContent} />
+                    </span>
                   </>
                 ) : (
-                  baseContent
+                  <SlackMessageText text={baseContent} />
                 )}
               </MessagePlainText>
             </CollapsibleContent>

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpTextMessage.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpTextMessage.client.test.tsx
@@ -7,12 +7,29 @@ const transcriptVisibilityState = vi.hoisted(() => ({
 }));
 const reviewActionMutate = vi.hoisted(() => vi.fn());
 
+const slackUsersState = vi.hoisted(() => ({
+  users: {} as Record<string, { name: string; profileUrl: string | null }>,
+}));
+
 vi.mock('@/trpc/client', () => ({
   useTRPCClient: () => ({
     sandboxSession: {
       handlePrReviewNotificationAction: { mutate: reviewActionMutate },
     },
   }),
+  useTRPC: () => ({
+    slack: {
+      resolveUsers: {
+        queryOptions: (input: unknown) => ({
+          queryKey: ['slack.resolveUsers', input],
+        }),
+      },
+    },
+  }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: { users: slackUsersState.users } }),
 }));
 
 vi.mock('@/components/ai-elements', () => ({
@@ -128,6 +145,7 @@ describe('AcpTextMessage', () => {
   beforeEach(() => {
     transcriptVisibilityState.enabled = false;
     reviewActionMutate.mockReset();
+    slackUsersState.users = {};
   });
 
   const reviewOfferMessage = (status = 'pending') => ({
@@ -421,6 +439,44 @@ describe('AcpTextMessage', () => {
     expect(
       screen.getByRole('button', { name: 'new-task:Continue' }),
     ).toBeVisible();
+  });
+
+  it('renders raw Slack mention tokens in user text as linked names', () => {
+    slackUsersState.users = {
+      U0BJNE7FC12: {
+        name: 'Roomote',
+        profileUrl: 'https://acme.slack.com/team/U0BJNE7FC12',
+      },
+    };
+
+    render(
+      <AcpTextMessage
+        msg={{
+          id: 'message-1',
+          ts: 123,
+          role: 'user',
+          kind: 'text',
+          partial: false,
+          sessionId: 'session-1',
+          updateType: 'roomote_runtime.user_prompt',
+          text: '<@U0BJNE7FC12> determine why the mobile app cannot handle the link',
+          data: {},
+        }}
+      />,
+    );
+
+    const mention = screen.getByTestId('slack-mention');
+    expect(mention).toHaveTextContent('@Roomote');
+    expect(mention).toHaveAttribute(
+      'href',
+      'https://acme.slack.com/team/U0BJNE7FC12',
+    );
+    expect(screen.getByTestId('message-plain-text')).toHaveTextContent(
+      '@Roomote determine why the mobile app cannot handle the link',
+    );
+    expect(screen.getByTestId('message-plain-text')).not.toHaveTextContent(
+      '<@U0BJNE7FC12>',
+    );
   });
 
   it('renders user text as plain text instead of markdown', () => {

--- a/apps/web/src/components/ai-elements/slack-mention-context.tsx
+++ b/apps/web/src/components/ai-elements/slack-mention-context.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+interface SlackMentionContextValue {
+  /** Slack team the surrounding transcript came from, when known. */
+  slackTeamId: string | null;
+}
+
+const DEFAULT_SLACK_MENTION_CONTEXT: SlackMentionContextValue = {
+  slackTeamId: null,
+};
+
+const SlackMentionContext = createContext<SlackMentionContextValue>(
+  DEFAULT_SLACK_MENTION_CONTEXT,
+);
+
+/**
+ * Tells transcript messages which Slack workspace their raw `<@U…>` mention
+ * tokens belong to so they can be resolved to names and profile links.
+ */
+export function SlackMentionProvider({
+  children,
+  slackTeamId,
+}: {
+  children: ReactNode;
+  slackTeamId: string | null | undefined;
+}) {
+  return (
+    <SlackMentionContext.Provider value={{ slackTeamId: slackTeamId ?? null }}>
+      {children}
+    </SlackMentionContext.Provider>
+  );
+}
+
+export function useSlackMentionContext() {
+  return useContext(SlackMentionContext);
+}

--- a/apps/web/src/components/ai-elements/slack-mention-context.tsx
+++ b/apps/web/src/components/ai-elements/slack-mention-context.tsx
@@ -2,13 +2,20 @@
 
 import { createContext, useContext, type ReactNode } from 'react';
 
+/**
+ * Transcript a Slack mention belongs to. The server derives the Slack team
+ * from this resource; the browser never names a workspace directly.
+ */
+export type SlackMentionScope =
+  | { kind: 'task'; taskId: string }
+  | { kind: 'session'; sessionId: string };
+
 interface SlackMentionContextValue {
-  /** Slack team the surrounding transcript came from, when known. */
-  slackTeamId: string | null;
+  scope: SlackMentionScope | null;
 }
 
 const DEFAULT_SLACK_MENTION_CONTEXT: SlackMentionContextValue = {
-  slackTeamId: null,
+  scope: null,
 };
 
 const SlackMentionContext = createContext<SlackMentionContextValue>(
@@ -16,18 +23,18 @@ const SlackMentionContext = createContext<SlackMentionContextValue>(
 );
 
 /**
- * Tells transcript messages which Slack workspace their raw `<@U…>` mention
+ * Tells transcript messages which task or session their raw `<@U…>` mention
  * tokens belong to so they can be resolved to names and profile links.
  */
 export function SlackMentionProvider({
   children,
-  slackTeamId,
+  scope,
 }: {
   children: ReactNode;
-  slackTeamId: string | null | undefined;
+  scope: SlackMentionScope | null | undefined;
 }) {
   return (
-    <SlackMentionContext.Provider value={{ slackTeamId: slackTeamId ?? null }}>
+    <SlackMentionContext.Provider value={{ scope: scope ?? null }}>
       {children}
     </SlackMentionContext.Provider>
   );

--- a/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+
+import { SlackMentionProvider } from './slack-mention-context';
+import { SlackMessageText } from './slack-message-text';
+
+const resolveUsersState = vi.hoisted(() => ({
+  data: undefined as
+    | { users: Record<string, { name: string; profileUrl: string | null }> }
+    | undefined,
+  lastInput: null as { teamId: string | null; userIds: string[] } | null,
+  lastEnabled: null as boolean | null,
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (options: { enabled?: boolean }) => {
+    resolveUsersState.lastEnabled = options.enabled ?? true;
+    return { data: resolveUsersState.data };
+  },
+}));
+
+vi.mock('@/trpc/client', () => ({
+  useTRPC: () => ({
+    slack: {
+      resolveUsers: {
+        queryOptions: (input: { teamId: string | null; userIds: string[] }) => {
+          resolveUsersState.lastInput = input;
+          return { queryKey: ['slack.resolveUsers', input] };
+        },
+      },
+    },
+  }),
+}));
+
+describe('SlackMessageText', () => {
+  beforeEach(() => {
+    resolveUsersState.data = undefined;
+    resolveUsersState.lastInput = null;
+    resolveUsersState.lastEnabled = null;
+  });
+
+  it('renders plain text untouched without querying Slack', () => {
+    render(<SlackMessageText text="just a message" />);
+
+    expect(screen.getByText('just a message')).toBeInTheDocument();
+    expect(resolveUsersState.lastEnabled).toBe(false);
+    expect(screen.queryByTestId('slack-mention')).not.toBeInTheDocument();
+  });
+
+  it('links resolved user mentions to their Slack profile', () => {
+    resolveUsersState.data = {
+      users: {
+        U0BJNE7FC12: {
+          name: 'Roomote',
+          profileUrl: 'https://acme.slack.com/team/U0BJNE7FC12',
+        },
+      },
+    };
+
+    render(
+      <SlackMentionProvider slackTeamId="T123">
+        <SlackMessageText text="<@U0BJNE7FC12> determine why the link fails" />
+      </SlackMentionProvider>,
+    );
+
+    const mention = screen.getByTestId('slack-mention');
+    expect(mention).toHaveTextContent('@Roomote');
+    expect(mention).toHaveAttribute(
+      'href',
+      'https://acme.slack.com/team/U0BJNE7FC12',
+    );
+    expect(mention).toHaveAttribute('target', '_blank');
+    expect(
+      screen.getByText(/determine why the link fails/),
+    ).toBeInTheDocument();
+    expect(resolveUsersState.lastInput).toEqual({
+      teamId: 'T123',
+      userIds: ['U0BJNE7FC12'],
+    });
+    expect(resolveUsersState.lastEnabled).toBe(true);
+  });
+
+  it('falls back to the inline label or raw id while unresolved', () => {
+    render(
+      <SlackMessageText text="<@U1|jane> and <@U2> in <#C1|general> <!here>" />,
+    );
+
+    const mentions = screen.getAllByTestId('slack-mention');
+    expect(mentions.map((node) => node.textContent)).toEqual([
+      '@jane',
+      '@U2',
+      '#general',
+      '@here',
+    ]);
+    for (const mention of mentions) {
+      expect(mention.tagName).toBe('SPAN');
+    }
+  });
+});

--- a/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
@@ -7,7 +7,7 @@ const resolveUsersState = vi.hoisted(() => ({
   data: undefined as
     | { users: Record<string, { name: string; profileUrl: string | null }> }
     | undefined,
-  lastInput: null as { teamId: string | null; userIds: string[] } | null,
+  lastInput: null as { scope: unknown; userIds: string[] } | null,
   lastEnabled: null as boolean | null,
 }));
 
@@ -22,7 +22,7 @@ vi.mock('@/trpc/client', () => ({
   useTRPC: () => ({
     slack: {
       resolveUsers: {
-        queryOptions: (input: { teamId: string | null; userIds: string[] }) => {
+        queryOptions: (input: { scope: unknown; userIds: string[] }) => {
           resolveUsersState.lastInput = input;
           return { queryKey: ['slack.resolveUsers', input] };
         },
@@ -57,7 +57,7 @@ describe('SlackMessageText', () => {
     };
 
     render(
-      <SlackMentionProvider slackTeamId="T123">
+      <SlackMentionProvider scope={{ kind: 'session', sessionId: 'session-1' }}>
         <SlackMessageText text="<@U0BJNE7FC12> determine why the link fails" />
       </SlackMentionProvider>,
     );
@@ -73,16 +73,27 @@ describe('SlackMessageText', () => {
       screen.getByText(/determine why the link fails/),
     ).toBeInTheDocument();
     expect(resolveUsersState.lastInput).toEqual({
-      teamId: 'T123',
+      scope: { kind: 'session', sessionId: 'session-1' },
       userIds: ['U0BJNE7FC12'],
     });
     expect(resolveUsersState.lastEnabled).toBe(true);
   });
 
+  it('does not query without a transcript scope', () => {
+    render(<SlackMessageText text="<@U1> hi" />);
+
+    expect(resolveUsersState.lastEnabled).toBe(false);
+    expect(screen.getByTestId('slack-mention')).toHaveTextContent('@U1');
+  });
+
   it('caps the lookup at the resolver limit and leaves overflow raw', () => {
     const text = Array.from({ length: 60 }, (_, i) => `<@U${i}>`).join(' ');
 
-    render(<SlackMessageText text={text} />);
+    render(
+      <SlackMentionProvider scope={{ kind: 'task', taskId: 'task-1' }}>
+        <SlackMessageText text={text} />
+      </SlackMentionProvider>,
+    );
 
     expect(resolveUsersState.lastInput?.userIds).toHaveLength(50);
     expect(screen.getAllByTestId('slack-mention')).toHaveLength(60);

--- a/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
@@ -79,6 +79,15 @@ describe('SlackMessageText', () => {
     expect(resolveUsersState.lastEnabled).toBe(true);
   });
 
+  it('caps the lookup at the resolver limit and leaves overflow raw', () => {
+    const text = Array.from({ length: 60 }, (_, i) => `<@U${i}>`).join(' ');
+
+    render(<SlackMessageText text={text} />);
+
+    expect(resolveUsersState.lastInput?.userIds).toHaveLength(50);
+    expect(screen.getAllByTestId('slack-mention')).toHaveLength(60);
+  });
+
   it('falls back to the inline label or raw id while unresolved', () => {
     render(
       <SlackMessageText text="<@U1|jane> and <@U2> in <#C1|general> <!here>" />,

--- a/apps/web/src/components/ai-elements/slack-message-text.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.tsx
@@ -95,11 +95,14 @@ export function SlackMessageText({ text }: { text: string }) {
       extractSlackUserMentionIds(text).slice(0, SLACK_RESOLVE_USERS_MAX_IDS),
     [text],
   );
-  const { slackTeamId } = useSlackMentionContext();
+  const { scope } = useSlackMentionContext();
   const trpc = useTRPC();
   const { data } = useQuery({
-    ...trpc.slack.resolveUsers.queryOptions({ teamId: slackTeamId, userIds }),
-    enabled: userIds.length > 0,
+    ...trpc.slack.resolveUsers.queryOptions({
+      scope: scope ?? { kind: 'task', taskId: '' },
+      userIds,
+    }),
+    enabled: scope !== null && userIds.length > 0,
     staleTime: 10 * 60 * 1000,
   });
   const users = data?.users ?? {};

--- a/apps/web/src/components/ai-elements/slack-message-text.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useMemo, type ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
+  SLACK_RESOLVE_USERS_MAX_IDS,
   extractSlackUserMentionIds,
   parseSlackMessageTokens,
   type SlackMessageToken,
@@ -87,7 +88,13 @@ function renderToken(
  */
 export function SlackMessageText({ text }: { text: string }) {
   const tokens = useMemo(() => parseSlackMessageTokens(text), [text]);
-  const userIds = useMemo(() => extractSlackUserMentionIds(text), [text]);
+  // Resolve at most the first N distinct users; any overflow stays as the
+  // raw token rather than failing the whole lookup.
+  const userIds = useMemo(
+    () =>
+      extractSlackUserMentionIds(text).slice(0, SLACK_RESOLVE_USERS_MAX_IDS),
+    [text],
+  );
   const { slackTeamId } = useSlackMentionContext();
   const trpc = useTRPC();
   const { data } = useQuery({

--- a/apps/web/src/components/ai-elements/slack-message-text.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Fragment, useMemo, type ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  extractSlackUserMentionIds,
+  parseSlackMessageTokens,
+  type SlackMessageToken,
+} from '@roomote/types';
+
+import { useTRPC } from '@/trpc/client';
+
+import { useSlackMentionContext } from './slack-mention-context';
+
+const MENTION_CLASS_NAME =
+  'rounded-sm bg-primary/10 px-1 font-medium text-primary';
+const MENTION_LINK_CLASS_NAME = `${MENTION_CLASS_NAME} no-underline hover:underline`;
+
+function SlackMention({ label, href }: { label: string; href: string | null }) {
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer"
+        className={MENTION_LINK_CLASS_NAME}
+        data-testid="slack-mention"
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <span className={MENTION_CLASS_NAME} data-testid="slack-mention">
+      {label}
+    </span>
+  );
+}
+
+function renderToken(
+  token: SlackMessageToken,
+  index: number,
+  users: Record<string, { name: string; profileUrl: string | null }>,
+): ReactNode {
+  switch (token.type) {
+    case 'text':
+      return <Fragment key={index}>{token.text}</Fragment>;
+    case 'user': {
+      const resolved = users[token.userId];
+      const label = resolved?.name ?? token.label ?? token.userId;
+      return (
+        <SlackMention
+          key={index}
+          label={`@${label}`}
+          href={resolved?.profileUrl ?? null}
+        />
+      );
+    }
+    case 'channel':
+      return (
+        <SlackMention
+          key={index}
+          label={`#${token.label ?? token.channelId}`}
+          href={null}
+        />
+      );
+    case 'usergroup':
+      return (
+        <SlackMention
+          key={index}
+          label={`@${token.label ?? token.usergroupId}`}
+          href={null}
+        />
+      );
+    case 'broadcast':
+      return <SlackMention key={index} label={`@${token.name}`} href={null} />;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Renders persisted Slack message text with `<@U…>`, `<#C…>`, and `<!…>`
+ * tokens shown as readable mentions. User mentions resolve to display names
+ * and link to the member's Slack profile; the stored text is never rewritten.
+ */
+export function SlackMessageText({ text }: { text: string }) {
+  const tokens = useMemo(() => parseSlackMessageTokens(text), [text]);
+  const userIds = useMemo(() => extractSlackUserMentionIds(text), [text]);
+  const { slackTeamId } = useSlackMentionContext();
+  const trpc = useTRPC();
+  const { data } = useQuery({
+    ...trpc.slack.resolveUsers.queryOptions({ teamId: slackTeamId, userIds }),
+    enabled: userIds.length > 0,
+    staleTime: 10 * 60 * 1000,
+  });
+  const users = data?.users ?? {};
+
+  if (tokens.length === 1 && tokens[0]?.type === 'text') {
+    return <>{text}</>;
+  }
+
+  return <>{tokens.map((token, index) => renderToken(token, index, users))}</>;
+}

--- a/apps/web/src/trpc/commands/slack/index.ts
+++ b/apps/web/src/trpc/commands/slack/index.ts
@@ -29,7 +29,8 @@ import {
 import type { UserAuthSuccess } from '@/types';
 import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
 import { findAccessibleFastSession } from '@/lib/server/fast-sessions';
-import { getLatestTaskRunsByTaskId } from '@/lib/server/task-runs';
+
+import { getTaskByIdCommand } from '../tasks/by-id';
 import { getSlackRedirectUri } from '@/lib/server/slack-redirect-uri';
 import { syncUser } from '@/lib/server/sync-internal';
 import { buildSlackInstallUrl } from '@/lib/slack-install-url';
@@ -842,10 +843,12 @@ async function resolveSlackMentionScopeTeamId(
     return session?.surface === 'slack' ? (session.workspaceId ?? null) : null;
   }
 
-  const taskRun = (await getLatestTaskRunsByTaskId([scope.taskId]))[
-    scope.taskId
-  ];
-  return taskRun ? getSlackTeamIdFromTaskPayload(taskRun.payload) : null;
+  // Same lookup the task page uses, so soft-deleted or otherwise
+  // inaccessible tasks never reveal which workspace they came from.
+  const task = await getTaskByIdCommand(auth, { taskId: scope.taskId });
+  return task?.taskRun
+    ? getSlackTeamIdFromTaskPayload(task.taskRun.payload)
+    : null;
 }
 
 /**

--- a/apps/web/src/trpc/commands/slack/index.ts
+++ b/apps/web/src/trpc/commands/slack/index.ts
@@ -815,15 +815,6 @@ export async function completePendingSlackAuthenticationCommand(
   }
 }
 
-interface ResolvedSlackUser {
-  name: string;
-  profileUrl: string | null;
-}
-
-interface ResolveSlackUsersResult {
-  users: Record<string, ResolvedSlackUser>;
-}
-
 const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]{2,}$/;
 
 /**
@@ -836,7 +827,9 @@ const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]{2,}$/;
 export async function resolveSlackUsersCommand(
   _auth: UserAuthSuccess,
   input: { teamId?: string | null; userIds: string[] },
-): Promise<ResolveSlackUsersResult> {
+): Promise<{
+  users: Record<string, { name: string; profileUrl: string | null }>;
+}> {
   const userIds = [
     ...new Set(
       input.userIds
@@ -844,7 +837,7 @@ export async function resolveSlackUsersCommand(
         .filter((userId) => SLACK_USER_ID_PATTERN.test(userId)),
     ),
   ];
-  const users: Record<string, ResolvedSlackUser> = {};
+  const users: Record<string, { name: string; profileUrl: string | null }> = {};
   if (userIds.length === 0) {
     return { users };
   }

--- a/apps/web/src/trpc/commands/slack/index.ts
+++ b/apps/web/src/trpc/commands/slack/index.ts
@@ -3,7 +3,11 @@ import {
   enqueueSlackAccountLinkEducation,
   recordSlackConversationMessageBestEffort,
 } from '@roomote/sdk/server';
-import { PRODUCT_NAME, buildSlackUserProfileUrl } from '@roomote/types';
+import {
+  PRODUCT_NAME,
+  buildSlackUserProfileUrl,
+  getSlackTeamIdFromTaskPayload,
+} from '@roomote/types';
 import {
   type SlackAuthToken,
   type SlackInstallation,
@@ -24,6 +28,8 @@ import {
 
 import type { UserAuthSuccess } from '@/types';
 import { bootstrapWebRuntimeEnv } from '@/lib/server/bootstrap-runtime-env';
+import { findAccessibleFastSession } from '@/lib/server/fast-sessions';
+import { getLatestTaskRunsByTaskId } from '@/lib/server/task-runs';
 import { getSlackRedirectUri } from '@/lib/server/slack-redirect-uri';
 import { syncUser } from '@/lib/server/sync-internal';
 import { buildSlackInstallUrl } from '@/lib/slack-install-url';
@@ -815,7 +821,32 @@ export async function completePendingSlackAuthenticationCommand(
   }
 }
 
-const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]{2,}$/;
+const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]+$/;
+
+/**
+ * Slack team a transcript belongs to, derived server-side from the task run
+ * payload or the Fast conversation so the browser never chooses which
+ * workspace's directory and bot token answer a lookup.
+ */
+async function resolveSlackMentionScopeTeamId(
+  auth: UserAuthSuccess,
+  scope:
+    | { kind: 'task'; taskId: string }
+    | { kind: 'session'; sessionId: string },
+): Promise<string | null> {
+  if (scope.kind === 'session') {
+    const session = await findAccessibleFastSession(
+      { userId: auth.userId, isAdmin: auth.isAdmin },
+      scope.sessionId,
+    );
+    return session?.surface === 'slack' ? (session.workspaceId ?? null) : null;
+  }
+
+  const taskRun = (await getLatestTaskRunsByTaskId([scope.taskId]))[
+    scope.taskId
+  ];
+  return taskRun ? getSlackTeamIdFromTaskPayload(taskRun.payload) : null;
+}
 
 /**
  * Resolves raw Slack user IDs referenced by `<@U…>` tokens in persisted
@@ -825,8 +856,13 @@ const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]{2,}$/;
  * are omitted so the caller can fall back to the raw token.
  */
 export async function resolveSlackUsersCommand(
-  _auth: UserAuthSuccess,
-  input: { teamId?: string | null; userIds: string[] },
+  auth: UserAuthSuccess,
+  input: {
+    scope:
+      | { kind: 'task'; taskId: string }
+      | { kind: 'session'; sessionId: string };
+    userIds: string[];
+  },
 ): Promise<{
   users: Record<string, { name: string; profileUrl: string | null }>;
 }> {
@@ -842,23 +878,24 @@ export async function resolveSlackUsersCommand(
     return { users };
   }
 
-  const teamId = input.teamId?.trim() || null;
+  const teamId = await resolveSlackMentionScopeTeamId(auth, input.scope);
+  if (!teamId) {
+    return { users };
+  }
+
   const installation =
     (await db.query.slackInstallations.findFirst({
-      where: teamId
-        ? and(
-            eq(slackInstallations.isActive, true),
-            eq(slackInstallations.teamId, teamId),
-          )
-        : eq(slackInstallations.isActive, true),
+      where: and(
+        eq(slackInstallations.isActive, true),
+        eq(slackInstallations.teamId, teamId),
+      ),
       orderBy: [desc(slackInstallations.updatedAt)],
     })) ?? null;
-  const resolvedTeamId = installation?.teamId ?? teamId;
   const teamDomain = installation?.teamDomain ?? null;
   const toProfileUrl = (slackUserId: string) =>
     buildSlackUserProfileUrl({
       slackUserId,
-      slackTeamId: resolvedTeamId,
+      slackTeamId: teamId,
       slackWorkspaceDomain: teamDomain,
     });
 
@@ -874,7 +911,7 @@ export async function resolveSlackUsersCommand(
   }
 
   const unresolvedAfterBot = userIds.filter((userId) => !users[userId]);
-  if (unresolvedAfterBot.length > 0 && resolvedTeamId) {
+  if (unresolvedAfterBot.length > 0) {
     const directoryRows = await db
       .select({
         slackUserId: slackDirectoryUsers.slackUserId,
@@ -885,7 +922,7 @@ export async function resolveSlackUsersCommand(
       .from(slackDirectoryUsers)
       .where(
         and(
-          eq(slackDirectoryUsers.slackTeamId, resolvedTeamId),
+          eq(slackDirectoryUsers.slackTeamId, teamId),
           inArray(slackDirectoryUsers.slackUserId, unresolvedAfterBot),
         ),
       );

--- a/apps/web/src/trpc/commands/slack/index.ts
+++ b/apps/web/src/trpc/commands/slack/index.ts
@@ -3,7 +3,7 @@ import {
   enqueueSlackAccountLinkEducation,
   recordSlackConversationMessageBestEffort,
 } from '@roomote/sdk/server';
-import { PRODUCT_NAME } from '@roomote/types';
+import { PRODUCT_NAME, buildSlackUserProfileUrl } from '@roomote/types';
 import {
   type SlackAuthToken,
   type SlackInstallation,
@@ -13,8 +13,10 @@ import {
   desc,
   eq,
   gt,
+  inArray,
   resolveEffectiveDeploymentEnvVars,
   slackAuthTokens,
+  slackDirectoryUsers,
   slackInstallations,
   slackUserMappings,
   users,
@@ -811,4 +813,122 @@ export async function completePendingSlackAuthenticationCommand(
           : 'Failed to complete authentication',
     };
   }
+}
+
+interface ResolvedSlackUser {
+  name: string;
+  profileUrl: string | null;
+}
+
+interface ResolveSlackUsersResult {
+  users: Record<string, ResolvedSlackUser>;
+}
+
+const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]{2,}$/;
+
+/**
+ * Resolves raw Slack user IDs referenced by `<@U…>` tokens in persisted
+ * message text to display names and profile links for the web transcript.
+ * The Brain Slack directory answers first; anything it does not know goes
+ * through `users.info` with the installation's bot token. Unresolvable IDs
+ * are omitted so the caller can fall back to the raw token.
+ */
+export async function resolveSlackUsersCommand(
+  _auth: UserAuthSuccess,
+  input: { teamId?: string | null; userIds: string[] },
+): Promise<ResolveSlackUsersResult> {
+  const userIds = [
+    ...new Set(
+      input.userIds
+        .map((userId) => userId.trim())
+        .filter((userId) => SLACK_USER_ID_PATTERN.test(userId)),
+    ),
+  ];
+  const users: Record<string, ResolvedSlackUser> = {};
+  if (userIds.length === 0) {
+    return { users };
+  }
+
+  const teamId = input.teamId?.trim() || null;
+  const installation =
+    (await db.query.slackInstallations.findFirst({
+      where: teamId
+        ? and(
+            eq(slackInstallations.isActive, true),
+            eq(slackInstallations.teamId, teamId),
+          )
+        : eq(slackInstallations.isActive, true),
+      orderBy: [desc(slackInstallations.updatedAt)],
+    })) ?? null;
+  const resolvedTeamId = installation?.teamId ?? teamId;
+  const teamDomain = installation?.teamDomain ?? null;
+  const toProfileUrl = (slackUserId: string) =>
+    buildSlackUserProfileUrl({
+      slackUserId,
+      slackTeamId: resolvedTeamId,
+      slackWorkspaceDomain: teamDomain,
+    });
+
+  if (installation?.botUserId && userIds.includes(installation.botUserId)) {
+    const botName =
+      installation.botName?.trim() || installation.appName?.trim() || null;
+    if (botName) {
+      users[installation.botUserId] = {
+        name: botName,
+        profileUrl: toProfileUrl(installation.botUserId),
+      };
+    }
+  }
+
+  const unresolvedAfterBot = userIds.filter((userId) => !users[userId]);
+  if (unresolvedAfterBot.length > 0 && resolvedTeamId) {
+    const directoryRows = await db
+      .select({
+        slackUserId: slackDirectoryUsers.slackUserId,
+        displayName: slackDirectoryUsers.displayName,
+        realName: slackDirectoryUsers.realName,
+        username: slackDirectoryUsers.username,
+      })
+      .from(slackDirectoryUsers)
+      .where(
+        and(
+          eq(slackDirectoryUsers.slackTeamId, resolvedTeamId),
+          inArray(slackDirectoryUsers.slackUserId, unresolvedAfterBot),
+        ),
+      );
+    for (const row of directoryRows) {
+      const name =
+        row.displayName?.trim() ||
+        row.realName?.trim() ||
+        row.username?.trim() ||
+        null;
+      if (name) {
+        users[row.slackUserId] = {
+          name,
+          profileUrl: toProfileUrl(row.slackUserId),
+        };
+      }
+    }
+  }
+
+  const unresolved = userIds.filter((userId) => !users[userId]);
+  if (unresolved.length > 0 && installation?.botAccessToken) {
+    const slack = new SlackNotifier(installation.botAccessToken, {
+      botUserId: installation.botUserId,
+      botName: installation.botName,
+      appName: installation.appName,
+    });
+    try {
+      const names = await slack.getUserDisplayNames(unresolved);
+      for (const [slackUserId, name] of names) {
+        users[slackUserId] = { name, profileUrl: toProfileUrl(slackUserId) };
+      }
+    } catch (error) {
+      console.warn(
+        `[resolveSlackUsers] Failed to resolve Slack users: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return { users };
 }

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -1360,7 +1360,16 @@ export const appRouter = createRouter({
     resolveUsers: protectedProcedure
       .input(
         z.object({
-          teamId: z.string().trim().max(64).nullable().optional(),
+          scope: z.discriminatedUnion('kind', [
+            z.object({
+              kind: z.literal('task'),
+              taskId: z.string().trim().min(1).max(64),
+            }),
+            z.object({
+              kind: z.literal('session'),
+              sessionId: z.string().trim().min(1).max(64),
+            }),
+          ]),
           userIds: z
             .array(z.string().trim().min(1).max(64))
             .max(SLACK_RESOLVE_USERS_MAX_IDS),

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -151,6 +151,7 @@ import {
   startAuthenticateSlackAccountCommand,
   finishAuthenticateSlackAccountCommand,
   completePendingSlackAuthenticationCommand,
+  resolveSlackUsersCommand,
 } from '../commands/slack';
 import {
   getLinearInstallationCommand,
@@ -1354,6 +1355,17 @@ export const appRouter = createRouter({
     installation: protectedProcedure.query(({ ctx: { auth } }) =>
       getSlackInstallationCommand(auth),
     ),
+
+    resolveUsers: protectedProcedure
+      .input(
+        z.object({
+          teamId: z.string().trim().max(64).nullable().optional(),
+          userIds: z.array(z.string().trim().min(1).max(64)).max(50),
+        }),
+      )
+      .query(({ ctx: { auth }, input }) =>
+        resolveSlackUsersCommand(auth, input),
+      ),
 
     connectApp: protectedProcedure
       .input(z.object({ redirectPath: z.string().optional() }).optional())

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -5,6 +5,7 @@ import {
 } from '@roomote/auth';
 
 import {
+  SLACK_RESOLVE_USERS_MAX_IDS,
   ALL_REPOSITORIES,
   FAST_EXECUTION,
   CONFLICT_RESOLUTION_MAX_PR_AGE_DAYS_OPTIONS,
@@ -1360,7 +1361,9 @@ export const appRouter = createRouter({
       .input(
         z.object({
           teamId: z.string().trim().max(64).nullable().optional(),
-          userIds: z.array(z.string().trim().min(1).max(64)).max(50),
+          userIds: z
+            .array(z.string().trim().min(1).max(64))
+            .max(SLACK_RESOLVE_USERS_MAX_IDS),
         }),
       )
       .query(({ ctx: { auth }, input }) =>

--- a/packages/slack/src/__tests__/fast-agent-live-task-launcher.test.ts
+++ b/packages/slack/src/__tests__/fast-agent-live-task-launcher.test.ts
@@ -198,7 +198,7 @@ describe('createFastAgentSlackLiveTaskLauncher', () => {
     });
   });
 
-  it('normalizes Slack mentions before launching the child task', async () => {
+  it('normalizes Slack links but keeps raw mentions before launching the child task', async () => {
     await createLauncher()({
       prompt: 'Ask <@U456> about the regression',
       environmentId: 'env-1',
@@ -208,6 +208,7 @@ describe('createFastAgentSlackLiveTaskLauncher', () => {
 
     expect(mocks.normalizeIncomingText).toHaveBeenCalledWith(
       'Ask <@U456> about the regression',
+      { preserveMentions: true },
     );
     expect(mocks.setSlackLiveTaskStreamData).toHaveBeenCalledWith(
       'task-1',

--- a/packages/slack/src/__tests__/slack-notifier.test.ts
+++ b/packages/slack/src/__tests__/slack-notifier.test.ts
@@ -3284,6 +3284,18 @@ describe('SlackNotifier', () => {
 
       expect(output).toBe('Hi @Alice [Example](https://example.com/path)');
     });
+
+    it('keeps raw mention tokens when preserveMentions is set', async () => {
+      const replaceSpy = vi.spyOn(notifier, 'replaceMentionsWithNames');
+
+      const output = await notifier.normalizeIncomingText(
+        'Hi <@U123> <https://example.com/path|Example>',
+        { preserveMentions: true },
+      );
+
+      expect(output).toBe('Hi <@U123> [Example](https://example.com/path)');
+      expect(replaceSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('unfurlTaskUrl', () => {

--- a/packages/slack/src/fast-agent-live-task-launcher.ts
+++ b/packages/slack/src/fast-agent-live-task-launcher.ts
@@ -188,7 +188,7 @@ export function createFastAgentSlackLiveTaskLauncher(
 
   return async (input) => {
     const prompt = await slack
-      .normalizeIncomingText(input.prompt)
+      .normalizeIncomingText(input.prompt, { preserveMentions: true })
       .catch((error) => {
         console.warn(
           `[Fast Agent] Failed to normalize the Slack task prompt: ${describeError(error)}`,

--- a/packages/slack/src/slack-notifier.ts
+++ b/packages/slack/src/slack-notifier.ts
@@ -2498,22 +2498,7 @@ export class SlackNotifier {
         matches.map((match) => match[1]).filter((id): id is string => !!id),
       ),
     ];
-
-    const botNameOverrides = new Map<string, string>();
-    if (this.botUserId && this.botName && userIds.includes(this.botUserId)) {
-      botNameOverrides.set(this.botUserId, this.botName);
-    }
-
-    // Fetch display names that are not already known from installation metadata.
-    const unresolvedUserIds = userIds.filter(
-      (userId) => !botNameOverrides.has(userId),
-    );
-    const usernameMap = unresolvedUserIds.length
-      ? await this.getUsersInfo(unresolvedUserIds)
-      : new Map<string, string>();
-    for (const [userId, botName] of botNameOverrides) {
-      usernameMap.set(userId, botName);
-    }
+    const usernameMap = await this.getUserDisplayNames(userIds);
 
     // Replace each mention with the user's display name
     let result = text;
@@ -2534,13 +2519,52 @@ export class SlackNotifier {
   }
 
   /**
+   * Resolves Slack user IDs to display names. The installation's own bot
+   * user resolves from stored metadata without a Slack API call; every other
+   * ID goes through `users.info`. IDs that cannot be resolved are omitted.
+   */
+  public async getUserDisplayNames(
+    userIds: string[],
+  ): Promise<Map<string, string>> {
+    const uniqueUserIds = [...new Set(userIds)];
+    const botNameOverrides = new Map<string, string>();
+    if (
+      this.botUserId &&
+      this.botName &&
+      uniqueUserIds.includes(this.botUserId)
+    ) {
+      botNameOverrides.set(this.botUserId, this.botName);
+    }
+
+    const unresolvedUserIds = uniqueUserIds.filter(
+      (userId) => !botNameOverrides.has(userId),
+    );
+    const usernameMap = unresolvedUserIds.length
+      ? await this.getUsersInfo(unresolvedUserIds)
+      : new Map<string, string>();
+    for (const [userId, botName] of botNameOverrides) {
+      usernameMap.set(userId, botName);
+    }
+
+    return usernameMap;
+  }
+
+  /**
    * Normalizes inbound Slack text for internal model/web consumption.
-   * - Expands user mentions to readable names.
+   * - Expands user mentions to readable names unless `preserveMentions` is
+   *   set, in which case raw `<@U…>` tokens stay in the text so the stored
+   *   message matches what the sender typed and the web transcript can
+   *   render them as linked mentions.
    * - Converts Slack mrkdwn links to standard markdown/plain URLs.
    */
-  public async normalizeIncomingText(text: string): Promise<string> {
+  public async normalizeIncomingText(
+    text: string,
+    options: { preserveMentions?: boolean } = {},
+  ): Promise<string> {
     return convertSlackLinksToMarkdown(
-      await this.replaceMentionsWithNames(text),
+      options.preserveMentions
+        ? text
+        : await this.replaceMentionsWithNames(text),
     );
   }
 }

--- a/packages/slack/src/start-auto-routed-slack-task.ts
+++ b/packages/slack/src/start-auto-routed-slack-task.ts
@@ -253,8 +253,12 @@ export async function startAutoRoutedSlackTask({
       }
     }
 
+    // Mentions stay raw (`<@U123>`) so the persisted prompt matches what the
+    // sender typed; the web transcript renders them as linked names.
     const taskDescription = stripLeadingSlackProductMention(
-      await slack.normalizeIncomingText(stripLeadingRawSlackMention(prompt)),
+      await slack.normalizeIncomingText(stripLeadingRawSlackMention(prompt), {
+        preserveMentions: true,
+      }),
     );
     const warningText = buildStatuspageSlackWarning(
       await getStatuspageIncident(),

--- a/packages/types/src/__tests__/slack.test.ts
+++ b/packages/types/src/__tests__/slack.test.ts
@@ -1,8 +1,75 @@
 import {
   buildSlackThreadPermalink,
+  buildSlackUserProfileUrl,
+  extractSlackUserMentionIds,
   parseSlackChannelPermalink,
   parseSlackMessagePermalink,
+  parseSlackMessageTokens,
 } from '../slack';
+
+describe('parseSlackMessageTokens', () => {
+  it('returns plain text untouched', () => {
+    expect(parseSlackMessageTokens('just words')).toEqual([
+      { type: 'text', text: 'just words' },
+    ]);
+  });
+
+  it('splits user, channel, usergroup, and broadcast references', () => {
+    expect(
+      parseSlackMessageTokens(
+        '<@U0BJNE7FC12> ping <@W123|jane> in <#C456|general> <!subteam^S789|@eng> <!here>',
+      ),
+    ).toEqual([
+      { type: 'user', userId: 'U0BJNE7FC12', label: null },
+      { type: 'text', text: ' ping ' },
+      { type: 'user', userId: 'W123', label: 'jane' },
+      { type: 'text', text: ' in ' },
+      { type: 'channel', channelId: 'C456', label: 'general' },
+      { type: 'text', text: ' ' },
+      { type: 'usergroup', usergroupId: 'S789', label: 'eng' },
+      { type: 'text', text: ' ' },
+      { type: 'broadcast', name: 'here' },
+    ]);
+  });
+
+  it('leaves unrelated angle-bracket text alone', () => {
+    expect(
+      parseSlackMessageTokens('<https://example.com|link> and <b>bold</b>'),
+    ).toEqual([
+      { type: 'text', text: '<https://example.com|link> and <b>bold</b>' },
+    ]);
+  });
+});
+
+describe('extractSlackUserMentionIds', () => {
+  it('dedupes user ids in first-seen order', () => {
+    expect(
+      extractSlackUserMentionIds('<@U2> then <@U1> and <@U2> again <#C1>'),
+    ).toEqual(['U2', 'U1']);
+  });
+});
+
+describe('buildSlackUserProfileUrl', () => {
+  it('prefers the workspace web profile when the domain is known', () => {
+    expect(
+      buildSlackUserProfileUrl({
+        slackUserId: 'U123',
+        slackTeamId: 'T123',
+        slackWorkspaceDomain: 'acme-team',
+      }),
+    ).toBe('https://acme-team.slack.com/team/U123');
+  });
+
+  it('falls back to the slack:// deep link with only a team id', () => {
+    expect(
+      buildSlackUserProfileUrl({ slackUserId: 'U123', slackTeamId: 'T123' }),
+    ).toBe('slack://user?team=T123&id=U123');
+  });
+
+  it('returns null without a team id or domain', () => {
+    expect(buildSlackUserProfileUrl({ slackUserId: 'U123' })).toBeNull();
+  });
+});
 
 describe('buildSlackThreadPermalink', () => {
   it('builds an app.slack.com permalink when no workspace domain is available', () => {

--- a/packages/types/src/__tests__/slack.test.ts
+++ b/packages/types/src/__tests__/slack.test.ts
@@ -32,6 +32,20 @@ describe('parseSlackMessageTokens', () => {
     ]);
   });
 
+  it('parses malformed reference fragments in linear time', () => {
+    const malformed = '<@U0|'.repeat(20_000);
+    const started = performance.now();
+    const tokens = parseSlackMessageTokens(malformed);
+    expect(performance.now() - started).toBeLessThan(200);
+    expect(tokens).toEqual([{ type: 'text', text: malformed }]);
+
+    expect(parseSlackMessageTokens('<@U1|<@U2|jane> tail')).toEqual([
+      { type: 'text', text: '<@U1|' },
+      { type: 'user', userId: 'U2', label: 'jane' },
+      { type: 'text', text: ' tail' },
+    ]);
+  });
+
   it('leaves unrelated angle-bracket text alone', () => {
     expect(
       parseSlackMessageTokens('<https://example.com|link> and <b>bold</b>'),

--- a/packages/types/src/slack.ts
+++ b/packages/types/src/slack.ts
@@ -208,67 +208,110 @@ export type SlackMessageToken =
   | { type: 'usergroup'; usergroupId: string; label: string | null }
   | { type: 'broadcast'; name: string };
 
-const SLACK_MESSAGE_TOKEN_PATTERN =
-  /<(?:@([UW][A-Z0-9]+)(?:\|([^>]*))?|#([CDG][A-Z0-9]+)(?:\|([^>]*))?|!subteam\^([A-Z0-9]+)(?:\|([^>]*))?|!(here|channel|everyone)(?:\|[^>]*)?)>/g;
+/** Upper bound on Slack user IDs resolved in one `slack.resolveUsers` call. */
+export const SLACK_RESOLVE_USERS_MAX_IDS = 50;
+
+// Each pattern is anchored and applied only to the bounded text between one
+// `<` and the next `>`, so parsing stays linear in the message length even
+// for sender-controlled text full of unterminated `<@U0|` fragments.
+const SLACK_USER_REFERENCE_PATTERN = /^@([UW][A-Z0-9]+)(?:\|([^|]*))?$/;
+const SLACK_CHANNEL_REFERENCE_PATTERN = /^#([CDG][A-Z0-9]+)(?:\|([^|]*))?$/;
+const SLACK_USERGROUP_REFERENCE_PATTERN =
+  /^!subteam\^([A-Z0-9]+)(?:\|([^|]*))?$/;
+const SLACK_BROADCAST_REFERENCE_PATTERN = /^!(here|channel|everyone)(?:\|.*)?$/;
 
 function normalizeSlackTokenLabel(label: string | undefined): string | null {
   const trimmed = label?.trim().replace(/^@/, '') ?? '';
   return trimmed.length > 0 ? trimmed : null;
 }
 
+function parseSlackReference(inner: string): SlackMessageToken | null {
+  const user = SLACK_USER_REFERENCE_PATTERN.exec(inner);
+  if (user?.[1]) {
+    return {
+      type: 'user',
+      userId: user[1],
+      label: normalizeSlackTokenLabel(user[2]),
+    };
+  }
+
+  const channel = SLACK_CHANNEL_REFERENCE_PATTERN.exec(inner);
+  if (channel?.[1]) {
+    return {
+      type: 'channel',
+      channelId: channel[1],
+      label: normalizeSlackTokenLabel(channel[2]),
+    };
+  }
+
+  const usergroup = SLACK_USERGROUP_REFERENCE_PATTERN.exec(inner);
+  if (usergroup?.[1]) {
+    return {
+      type: 'usergroup',
+      usergroupId: usergroup[1],
+      label: normalizeSlackTokenLabel(usergroup[2]),
+    };
+  }
+
+  const broadcast = SLACK_BROADCAST_REFERENCE_PATTERN.exec(inner);
+  if (broadcast?.[1]) {
+    return { type: 'broadcast', name: broadcast[1] };
+  }
+
+  return null;
+}
+
 /**
  * Splits raw Slack message text into plain-text runs and Slack references
  * (`<@U123>`, `<@U123|name>`, `<#C123|general>`, `<!subteam^S123|@team>`,
  * `<!here>`). Text without references comes back as a single text token.
+ *
+ * Single forward scan: a `<` opens a candidate, the candidate ends at the
+ * next `>`, and another `<` before that restarts the candidate there, so no
+ * character is examined more than a constant number of times.
  */
 export function parseSlackMessageTokens(text: string): SlackMessageToken[] {
   const tokens: SlackMessageToken[] = [];
-  let lastIndex = 0;
+  let textStart = 0;
+  let index = 0;
 
-  for (const match of text.matchAll(SLACK_MESSAGE_TOKEN_PATTERN)) {
-    const index = match.index ?? 0;
-    if (index > lastIndex) {
-      tokens.push({ type: 'text', text: text.slice(lastIndex, index) });
+  while (index < text.length) {
+    const open = text.indexOf('<', index);
+    if (open === -1) {
+      break;
     }
 
-    const [
-      ,
-      userId,
-      userLabel,
-      channelId,
-      channelLabel,
-      usergroupId,
-      usergroupLabel,
-      broadcast,
-    ] = match;
-
-    if (userId) {
-      tokens.push({
-        type: 'user',
-        userId,
-        label: normalizeSlackTokenLabel(userLabel),
-      });
-    } else if (channelId) {
-      tokens.push({
-        type: 'channel',
-        channelId,
-        label: normalizeSlackTokenLabel(channelLabel),
-      });
-    } else if (usergroupId) {
-      tokens.push({
-        type: 'usergroup',
-        usergroupId,
-        label: normalizeSlackTokenLabel(usergroupLabel),
-      });
-    } else if (broadcast) {
-      tokens.push({ type: 'broadcast', name: broadcast });
+    let cursor = open + 1;
+    while (
+      cursor < text.length &&
+      text[cursor] !== '>' &&
+      text[cursor] !== '<'
+    ) {
+      cursor += 1;
     }
 
-    lastIndex = index + match[0].length;
+    if (cursor >= text.length) {
+      break;
+    }
+
+    if (text[cursor] === '<') {
+      index = cursor;
+      continue;
+    }
+
+    const token = parseSlackReference(text.slice(open + 1, cursor));
+    if (token) {
+      if (open > textStart) {
+        tokens.push({ type: 'text', text: text.slice(textStart, open) });
+      }
+      tokens.push(token);
+      textStart = cursor + 1;
+    }
+    index = cursor + 1;
   }
 
-  if (lastIndex < text.length) {
-    tokens.push({ type: 'text', text: text.slice(lastIndex) });
+  if (textStart < text.length) {
+    tokens.push({ type: 'text', text: text.slice(textStart) });
   }
 
   return tokens;

--- a/packages/types/src/slack.ts
+++ b/packages/types/src/slack.ts
@@ -194,3 +194,121 @@ export function parseSlackChannelPermalink(raw: string): {
 
   return null;
 }
+
+/**
+ * Slack-native inline references that can appear in raw message text.
+ * Roomote persists inbound Slack text verbatim so the model sees exactly
+ * what the sender typed; the web transcript uses these tokens to render
+ * readable, linked equivalents without rewriting the stored text.
+ */
+export type SlackMessageToken =
+  | { type: 'text'; text: string }
+  | { type: 'user'; userId: string; label: string | null }
+  | { type: 'channel'; channelId: string; label: string | null }
+  | { type: 'usergroup'; usergroupId: string; label: string | null }
+  | { type: 'broadcast'; name: string };
+
+const SLACK_MESSAGE_TOKEN_PATTERN =
+  /<(?:@([UW][A-Z0-9]+)(?:\|([^>]*))?|#([CDG][A-Z0-9]+)(?:\|([^>]*))?|!subteam\^([A-Z0-9]+)(?:\|([^>]*))?|!(here|channel|everyone)(?:\|[^>]*)?)>/g;
+
+function normalizeSlackTokenLabel(label: string | undefined): string | null {
+  const trimmed = label?.trim().replace(/^@/, '') ?? '';
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Splits raw Slack message text into plain-text runs and Slack references
+ * (`<@U123>`, `<@U123|name>`, `<#C123|general>`, `<!subteam^S123|@team>`,
+ * `<!here>`). Text without references comes back as a single text token.
+ */
+export function parseSlackMessageTokens(text: string): SlackMessageToken[] {
+  const tokens: SlackMessageToken[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(SLACK_MESSAGE_TOKEN_PATTERN)) {
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      tokens.push({ type: 'text', text: text.slice(lastIndex, index) });
+    }
+
+    const [
+      ,
+      userId,
+      userLabel,
+      channelId,
+      channelLabel,
+      usergroupId,
+      usergroupLabel,
+      broadcast,
+    ] = match;
+
+    if (userId) {
+      tokens.push({
+        type: 'user',
+        userId,
+        label: normalizeSlackTokenLabel(userLabel),
+      });
+    } else if (channelId) {
+      tokens.push({
+        type: 'channel',
+        channelId,
+        label: normalizeSlackTokenLabel(channelLabel),
+      });
+    } else if (usergroupId) {
+      tokens.push({
+        type: 'usergroup',
+        usergroupId,
+        label: normalizeSlackTokenLabel(usergroupLabel),
+      });
+    } else if (broadcast) {
+      tokens.push({ type: 'broadcast', name: broadcast });
+    }
+
+    lastIndex = index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    tokens.push({ type: 'text', text: text.slice(lastIndex) });
+  }
+
+  return tokens;
+}
+
+/** Unique Slack user IDs referenced by `<@U…>` tokens, in first-seen order. */
+export function extractSlackUserMentionIds(text: string): string[] {
+  const userIds = new Set<string>();
+  for (const token of parseSlackMessageTokens(text)) {
+    if (token.type === 'user') {
+      userIds.add(token.userId);
+    }
+  }
+  return [...userIds];
+}
+
+/**
+ * Link to a Slack member profile. Prefers the workspace web URL when the
+ * workspace domain is known and falls back to the `slack://` deep link that
+ * the desktop app handles when only the team ID is available.
+ */
+export function buildSlackUserProfileUrl(params: {
+  slackUserId: string;
+  slackTeamId?: string | null;
+  slackWorkspaceDomain?: string | null;
+}): string | null {
+  const slackUserId = params.slackUserId.trim();
+  if (!slackUserId) {
+    return null;
+  }
+
+  const slackWorkspaceDomain = params.slackWorkspaceDomain?.trim();
+  if (slackWorkspaceDomain) {
+    return `https://${encodeURIComponent(slackWorkspaceDomain)}.slack.com/team/${encodeURIComponent(slackUserId)}`;
+  }
+
+  const slackTeamId = params.slackTeamId?.trim();
+  if (slackTeamId) {
+    return `slack://user?team=${encodeURIComponent(slackTeamId)}&id=${encodeURIComponent(slackUserId)}`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Problem

Slack Fast turns persist the sender's text verbatim (#2005), so raw `<@U0BJNE7FC12>` tokens show up unchanged in the web session transcript. Legacy Slack task prompts took the opposite approach and flattened mentions to plain `@Name` text server-side, so what the model and the transcript saw depended on which entry path the message took.

## What changed

- **Raw mentions are the stored form on both paths.** Legacy Slack task launches and thread follow-ups now keep `<@U…>` tokens in the persisted prompt (`normalizeIncomingText` gains a `preserveMentions` option; Slack `<url|label>` links still convert to markdown). Fast turns already did this.
- **New `slack.resolveUsers` tRPC query** maps Slack user IDs to display names and profile links. It checks the Brain Slack directory first, uses installation metadata for the bot user, and falls back to `users.info` with the bot token. Unresolvable IDs are omitted so the client falls back to the raw token.
- **Transcripts render mentions as readable, linked names.** User messages in both the task view and the Fast session view now tokenize `<@U…>`, `<@U…|label>`, `<#C…|channel>`, `<!subteam^S…|@group>`, and `<!here|channel|everyone>`. User mentions link to the member's Slack profile (`https://<workspace>.slack.com/team/<id>` when the domain is known, `slack://user?team=…&id=…` otherwise). The stored text is never rewritten, so copy and "new task" still carry the original.
- **Team context** comes from the task run payload (`teamId`) on the task page and from the conversation's `workspaceId` on the session page.
- Token parser and profile URL builder live in `@roomote/types` so the API and web share one definition.

## Tradeoff

The model on legacy tasks now sees `<@U123>` instead of `@Jane Doe` for mid-text mentions, matching Fast. The Slack workflow prompt already documents the raw form. If that turns out to hurt task quality, the fix is to add a resolved-name hint alongside the prompt rather than to rewrite the stored text.

## Testing

- Unit tests for the tokenizer and profile URL builder (`packages/types`), `preserveMentions` on the notifier, the launcher call site, the new `SlackMessageText` component, and mention rendering in `AcpTextMessage`.
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip`, plus the full `@roomote/slack`, `apps/api` Slack event, and `apps/web` tRPC suites pass.
