### PR TITLE
fix: let a trusted request_user_input preset win over placeholder questions

### DIFF
--- a/.changeset/request-user-input-preset-wins.md
+++ b/.changeset/request-user-input-preset-wins.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fixed the setup session failing to offer starter-work choices when the orchestration model passes the trusted `setup_starter_tasks` preset together with placeholder questions. The preset now wins and model-supplied questions are discarded instead of rejecting the call, so onboarding no longer stalls at "choose your first work" on models that fill every optional tool parameter.

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-bridge.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-bridge.test.ts
@@ -214,7 +214,7 @@ describe('Fast native OpenCode tool bridge', () => {
     expect(requestUserInputSource).toContain('.max(4).optional()');
     expect(requestUserInputSource).toContain('preset: z.enum');
     expect(requestUserInputSource).toContain(
-      'exactly one of questions or preset',
+      'questions are ignored when a preset is set',
     );
     expect(skillSource).toContain('Exact skill ID returned by list_skills');
     expect(skillSource).not.toContain('"explore-and-act"');

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -713,24 +713,82 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     });
   });
 
-  it('rejects request_user_input calls that mix questions with a trusted preset', async () => {
+  it('lets a trusted preset win when the model also passes placeholder questions', async () => {
+    const presetQuestions = [
+      {
+        id: 'setup-starter-tasks',
+        header: 'First work',
+        question: 'What should Roomote work on first?',
+        isOther: false,
+        isSecret: false,
+        multiple: true,
+        options: [
+          {
+            label: 'fix-flaky-tests',
+            description: 'Find and fix flaky tests.',
+          },
+        ],
+      },
+    ];
     let toolResult: unknown;
     const requestUserInput = vi.fn();
-    const resolveUserInputPreset = vi.fn();
+    const resolveUserInputPreset = vi.fn(async () => presetQuestions);
     mocks.generateText.mockImplementation(
       async (_params, _session, options) => {
         await options.onSessionReady('opencode-session-1');
         options.onPromptStarted?.();
+        // Some models fill every optional parameter; the placeholder
+        // questions must be discarded, never rendered or used to reject.
         toolResult = await invokeTool(nativeToolNames.requestUserInput, {
           preset: 'setup_starter_tasks',
           questions: [
             {
-              id: 'starter-work',
-              header: 'First work',
-              question: 'What should I work on first?',
+              id: 'placeholder',
+              header: 'placeholder',
+              question: 'placeholder',
+              options: [{ label: 'placeholder', description: 'placeholder' }],
             },
           ],
         });
+        return '';
+      },
+    );
+
+    await answerFastAgentQuestion({
+      ...baseParams,
+      conversation: {
+        surface: 'web',
+        workspaceId: 'deployment-1',
+        conversationId: 'setup-session-1',
+      },
+      turnSource: 'platform_event',
+      platformEventKind: 'setup',
+      platformEventVisibility: 'required',
+      setupSession: true,
+      adapter: callbacks({ requestUserInput, resolveUserInputPreset }),
+    });
+
+    expect(toolResult).toEqual({
+      success: true,
+      requestId: expect.any(String),
+      closed: true,
+    });
+    expect(resolveUserInputPreset).toHaveBeenCalledWith('setup_starter_tasks');
+    expect(requestUserInput).toHaveBeenCalledWith({
+      requestId: expect.any(String),
+      preset: 'setup_starter_tasks',
+      questions: presetQuestions,
+    });
+  });
+
+  it('rejects request_user_input calls with neither questions nor a preset', async () => {
+    let toolResult: unknown;
+    const requestUserInput = vi.fn();
+    mocks.generateText.mockImplementation(
+      async (_params, _session, options) => {
+        await options.onSessionReady('opencode-session-1');
+        options.onPromptStarted?.();
+        toolResult = await invokeTool(nativeToolNames.requestUserInput, {});
         return 'Please choose your first task.';
       },
     );
@@ -742,13 +800,18 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         workspaceId: 'deployment-1',
         conversationId: 'setup-session-1',
       },
+      turnSource: 'platform_event',
+      platformEventKind: 'setup',
+      platformEventVisibility: 'required',
       setupSession: true,
-      adapter: callbacks({ requestUserInput, resolveUserInputPreset }),
+      adapter: callbacks({ requestUserInput }),
     });
 
-    expect(toolResult).toMatchObject({ success: false });
+    expect(toolResult).toEqual({
+      success: false,
+      error: 'Pass either questions to ask or a trusted preset name.',
+    });
     expect(requestUserInput).not.toHaveBeenCalled();
-    expect(resolveUserInputPreset).not.toHaveBeenCalled();
   });
 
   it('lets a required setup platform event end with trusted structured input', async () => {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
@@ -487,7 +487,7 @@ import { z } from "zod"
 import { invoke } from "../roomote-fast-tool-bridge.js"
 
 export default {
-  description: "Ask structured questions, or use a trusted setup preset whose options Roomote supplies. Pass exactly one of questions or preset. Multiple-choice questions require explicit submission. The turn resumes from the persisted answer.",
+  description: "Ask structured questions, or use a trusted setup preset whose options Roomote supplies. Pass a preset alone when setup instructions name one; questions are ignored when a preset is set. Multiple-choice questions require explicit submission. The turn resumes from the persisted answer.",
   args: {
     questions: z.array(z.object({
       id: z.string().min(1).max(80),

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -478,14 +478,27 @@ const requestUserInputQuestionSchema = z.object({
   multiple: z.boolean().optional(),
 });
 const fastAgentInputPresetSchema = z.enum(['setup_starter_tasks']);
-const requestUserInputArgsSchema = z.union([
-  z
-    .object({
-      questions: z.array(requestUserInputQuestionSchema).min(1).max(4),
-    })
-    .strict(),
-  z.object({ preset: fastAgentInputPresetSchema }).strict(),
-]);
+// Some models fill every optional tool parameter, so a trusted preset may
+// arrive alongside placeholder questions. The preset wins: its questions are
+// server-supplied and model-provided ones are discarded rather than rejected.
+const requestUserInputArgsSchema = z
+  .object({
+    questions: z.array(requestUserInputQuestionSchema).min(1).max(4).optional(),
+    preset: fastAgentInputPresetSchema.optional(),
+  })
+  .transform(
+    (
+      args,
+    ):
+      | { preset: FastAgentInputPreset }
+      | { questions: z.output<typeof requestUserInputQuestionSchema>[] }
+      | null =>
+      args.preset
+        ? { preset: args.preset }
+        : args.questions
+          ? { questions: args.questions }
+          : null,
+  );
 
 function normalizeThreadText(text: string): string {
   return text.replace(/\s+/g, ' ').trim();
@@ -3491,6 +3504,12 @@ export async function answerFastAgentQuestion({
               };
             }
             const args = requestUserInputArgsSchema.parse(call.args);
+            if (!args) {
+              return {
+                success: false,
+                error: 'Pass either questions to ask or a trusted preset name.',
+              };
+            }
             const preset = 'preset' in args ? args.preset : undefined;
             if (preset && (!setupSession || !adapter.resolveUserInputPreset)) {
               return {


### PR DESCRIPTION
## Problem

On a fresh deployment the setup session never rendered the starter-work control. Every `request_user_input` call from the starter-request platform event failed with:

```
ZodError | unrecognized_keys: 'preset'
```

The orchestration model (observed with `openai/gpt-5.6-luna`) passes the trusted preset **and** a placeholder `questions` array in the same call, e.g. `{ preset: "setup_starter_tasks", questions: [{ id: "placeholder", ... }] }`. The server schema was a strict union requiring exactly one of the two, so the call was rejected before any readiness check ran. The model retried 6 times, then apologized that "the setup control returned an error", and retried 31 more times on the next human turn. Onboarding stalled at "choose your first work".

## Fix

- `requestUserInputArgsSchema` is now one object with both fields optional. When `preset` is present it wins and model-supplied questions are discarded (the preset's questions are server-supplied, so nothing from the model reaches the UI). Neither field present returns a plain error instead of a Zod dump.
- Tool description tells the model that questions are ignored when a preset is set.
- Tests: the previous "rejects mixed args" case is replaced with "preset wins over placeholder questions", plus a new "neither field" case.

## Verification

- `fast-agent-service.test.ts` (169 tests) and `fast-agent-setup-tools.test.ts` pass.
- `tsc`, `oxfmt`, `oxlint` clean on `packages/cloud-agents`.

Affected deployments recover on the next setup reconcile: no starter selection was recorded, so the `starter_request` event re-fires.
