### PR TITLE
[Fix] Render Slack links and bare URLs in transcripts; drop the mention pill

### DIFF
--- a/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
@@ -96,6 +96,22 @@ describe('SlackMessageText', () => {
     expect(resolveUsersState.lastEnabled).toBe(false);
   });
 
+  it('keeps balanced parentheses in bare urls and trims unbalanced ones', () => {
+    render(
+      <SlackMessageText text="see https://en.wikipedia.org/wiki/Function_(mathematics) (and https://example.com/a)." />,
+    );
+
+    expect(
+      screen
+        .getAllByTestId('slack-link')
+        .map((node) => node.getAttribute('href')),
+    ).toEqual([
+      'https://en.wikipedia.org/wiki/Function_(mathematics)',
+      'https://example.com/a',
+    ]);
+    expect(screen.getByText(/\)\.$/)).toBeInTheDocument();
+  });
+
   it('does not query without a transcript scope', () => {
     render(<SlackMessageText text="<@U1> hi" />);
 

--- a/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
@@ -5,9 +5,16 @@ import { SlackMessageText } from './slack-message-text';
 
 const resolveUsersState = vi.hoisted(() => ({
   data: undefined as
-    | { users: Record<string, { name: string; profileUrl: string | null }> }
+    | {
+        users: Record<string, { name: string; profileUrl: string | null }>;
+        channels?: Record<string, { name: string; url: string | null }>;
+      }
     | undefined,
-  lastInput: null as { scope: unknown; userIds: string[] } | null,
+  lastInput: null as {
+    scope: unknown;
+    userIds: string[];
+    channelIds: string[];
+  } | null,
   lastEnabled: null as boolean | null,
 }));
 
@@ -22,7 +29,11 @@ vi.mock('@/trpc/client', () => ({
   useTRPC: () => ({
     slack: {
       resolveUsers: {
-        queryOptions: (input: { scope: unknown; userIds: string[] }) => {
+        queryOptions: (input: {
+          scope: unknown;
+          userIds: string[];
+          channelIds: string[];
+        }) => {
           resolveUsersState.lastInput = input;
           return { queryKey: ['slack.resolveUsers', input] };
         },
@@ -75,6 +86,7 @@ describe('SlackMessageText', () => {
     expect(resolveUsersState.lastInput).toEqual({
       scope: { kind: 'session', sessionId: 'session-1' },
       userIds: ['U0BJNE7FC12'],
+      channelIds: [],
     });
     expect(resolveUsersState.lastEnabled).toBe(true);
   });
@@ -110,6 +122,37 @@ describe('SlackMessageText', () => {
       'https://example.com/a',
     ]);
     expect(screen.getByText(/\)\.$/)).toBeInTheDocument();
+  });
+
+  it('links resolved channel mentions to the channel', () => {
+    resolveUsersState.data = {
+      users: {},
+      channels: {
+        C0BSQGORZRS: {
+          name: 'ops-migration',
+          url: 'https://acme.slack.com/archives/C0BSQGORZRS',
+        },
+      },
+    };
+
+    render(
+      <SlackMentionProvider scope={{ kind: 'session', sessionId: 'session-1' }}>
+        <SlackMessageText text="the plan in <#C0BSQGORZRS> channel" />
+      </SlackMentionProvider>,
+    );
+
+    const mention = screen.getByTestId('slack-mention');
+    expect(mention).toHaveTextContent('#ops-migration');
+    expect(mention).toHaveAttribute(
+      'href',
+      'https://acme.slack.com/archives/C0BSQGORZRS',
+    );
+    expect(resolveUsersState.lastInput).toEqual({
+      scope: { kind: 'session', sessionId: 'session-1' },
+      userIds: [],
+      channelIds: ['C0BSQGORZRS'],
+    });
+    expect(resolveUsersState.lastEnabled).toBe(true);
   });
 
   it('does not query without a transcript scope', () => {

--- a/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.client.test.tsx
@@ -79,6 +79,23 @@ describe('SlackMessageText', () => {
     expect(resolveUsersState.lastEnabled).toBe(true);
   });
 
+  it('renders Slack link tokens and bare urls as links', () => {
+    render(
+      <SlackMessageText text="I like <https://roomote.dev> and <https://example.com|Example>, also https://docs.roomote.dev/start." />,
+    );
+
+    const links = screen.getAllByTestId('slack-link');
+    expect(
+      links.map((node) => [node.textContent, node.getAttribute('href')]),
+    ).toEqual([
+      ['https://roomote.dev', 'https://roomote.dev'],
+      ['Example', 'https://example.com'],
+      ['https://docs.roomote.dev/start', 'https://docs.roomote.dev/start'],
+    ]);
+    expect(screen.getByText(/, also/)).toBeInTheDocument();
+    expect(resolveUsersState.lastEnabled).toBe(false);
+  });
+
   it('does not query without a transcript scope', () => {
     render(<SlackMessageText text="<@U1> hi" />);
 

--- a/apps/web/src/components/ai-elements/slack-message-text.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.tsx
@@ -18,7 +18,34 @@ const MENTION_LINK_CLASS_NAME = `${MENTION_CLASS_NAME} no-underline hover:underl
 const LINK_CLASS_NAME =
   'text-primary underline underline-offset-2 hover:opacity-80';
 const BARE_URL_PATTERN = /https?:\/\/[^\s<>]+/g;
-const TRAILING_URL_PUNCTUATION = /[.,;:!?)\]]+$/;
+const TRAILING_URL_PUNCTUATION = /[.,;:!?)\]]$/;
+const CLOSER_TO_OPENER: Record<string, string> = { ')': '(', ']': '[' };
+
+function countChar(text: string, char: string): number {
+  let count = 0;
+  for (const current of text) {
+    if (current === char) count += 1;
+  }
+  return count;
+}
+
+/**
+ * Trims sentence punctuation that trails a bare URL. Closing parentheses and
+ * brackets stay attached while they balance an opener inside the URL, so
+ * `https://en.wikipedia.org/wiki/Function_(mathematics)` keeps its `)`.
+ */
+function trimTrailingUrlPunctuation(raw: string): string {
+  let url = raw;
+  while (TRAILING_URL_PUNCTUATION.test(url)) {
+    const last = url[url.length - 1] ?? '';
+    const opener = CLOSER_TO_OPENER[last];
+    if (opener && countChar(url, opener) >= countChar(url, last)) {
+      break;
+    }
+    url = url.slice(0, -1);
+  }
+  return url;
+}
 
 function SlackMention({ label, href }: { label: string; href: string | null }) {
   if (href) {
@@ -64,9 +91,7 @@ function renderTextWithBareUrls(text: string, keyPrefix: number): ReactNode[] {
 
   for (const match of text.matchAll(BARE_URL_PATTERN)) {
     const index = match.index ?? 0;
-    const raw = match[0];
-    const trailing = TRAILING_URL_PUNCTUATION.exec(raw)?.[0] ?? '';
-    const url = raw.slice(0, raw.length - trailing.length);
+    const url = trimTrailingUrlPunctuation(match[0]);
     if (index > lastIndex) {
       nodes.push(
         <Fragment key={`${keyPrefix}-${part++}`}>

--- a/apps/web/src/components/ai-elements/slack-message-text.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.tsx
@@ -13,9 +13,12 @@ import { useTRPC } from '@/trpc/client';
 
 import { useSlackMentionContext } from './slack-mention-context';
 
-const MENTION_CLASS_NAME =
-  'rounded-sm bg-primary/10 px-1 font-medium text-primary';
+const MENTION_CLASS_NAME = 'font-medium text-primary';
 const MENTION_LINK_CLASS_NAME = `${MENTION_CLASS_NAME} no-underline hover:underline`;
+const LINK_CLASS_NAME =
+  'text-primary underline underline-offset-2 hover:opacity-80';
+const BARE_URL_PATTERN = /https?:\/\/[^\s<>]+/g;
+const TRAILING_URL_PUNCTUATION = /[.,;:!?)\]]+$/;
 
 function SlackMention({ label, href }: { label: string; href: string | null }) {
   if (href) {
@@ -39,6 +42,55 @@ function SlackMention({ label, href }: { label: string; href: string | null }) {
   );
 }
 
+function SlackLink({ url, label }: { url: string; label: string | null }) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      className={LINK_CLASS_NAME}
+      data-testid="slack-link"
+    >
+      {label ?? url}
+    </a>
+  );
+}
+
+/** Plain text with bare http(s) URLs turned into links. */
+function renderTextWithBareUrls(text: string, keyPrefix: number): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+  let part = 0;
+
+  for (const match of text.matchAll(BARE_URL_PATTERN)) {
+    const index = match.index ?? 0;
+    const raw = match[0];
+    const trailing = TRAILING_URL_PUNCTUATION.exec(raw)?.[0] ?? '';
+    const url = raw.slice(0, raw.length - trailing.length);
+    if (index > lastIndex) {
+      nodes.push(
+        <Fragment key={`${keyPrefix}-${part++}`}>
+          {text.slice(lastIndex, index)}
+        </Fragment>,
+      );
+    }
+    nodes.push(
+      <SlackLink key={`${keyPrefix}-${part++}`} url={url} label={null} />,
+    );
+    lastIndex = index + url.length;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(
+      <Fragment key={`${keyPrefix}-${part++}`}>
+        {text.slice(lastIndex)}
+      </Fragment>,
+    );
+  }
+
+  return nodes;
+}
+
 function renderToken(
   token: SlackMessageToken,
   index: number,
@@ -46,7 +98,11 @@ function renderToken(
 ): ReactNode {
   switch (token.type) {
     case 'text':
-      return <Fragment key={index}>{token.text}</Fragment>;
+      return (
+        <Fragment key={index}>
+          {renderTextWithBareUrls(token.text, index)}
+        </Fragment>
+      );
     case 'user': {
       const resolved = users[token.userId];
       const label = resolved?.name ?? token.label ?? token.userId;
@@ -76,15 +132,18 @@ function renderToken(
       );
     case 'broadcast':
       return <SlackMention key={index} label={`@${token.name}`} href={null} />;
+    case 'link':
+      return <SlackLink key={index} url={token.url} label={token.label} />;
     default:
       return null;
   }
 }
 
 /**
- * Renders persisted Slack message text with `<@U…>`, `<#C…>`, and `<!…>`
- * tokens shown as readable mentions. User mentions resolve to display names
- * and link to the member's Slack profile; the stored text is never rewritten.
+ * Renders persisted Slack message text with `<@U…>`, `<#C…>`, `<!…>`, and
+ * `<url|label>` tokens shown as readable mentions and links, and bare URLs
+ * linkified. User mentions resolve to display names and link to the member's
+ * Slack profile; the stored text is never rewritten.
  */
 export function SlackMessageText({ text }: { text: string }) {
   const tokens = useMemo(() => parseSlackMessageTokens(text), [text]);
@@ -106,10 +165,6 @@ export function SlackMessageText({ text }: { text: string }) {
     staleTime: 10 * 60 * 1000,
   });
   const users = data?.users ?? {};
-
-  if (tokens.length === 1 && tokens[0]?.type === 'text') {
-    return <>{text}</>;
-  }
 
   return <>{tokens.map((token, index) => renderToken(token, index, users))}</>;
 }

--- a/apps/web/src/components/ai-elements/slack-message-text.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.tsx
@@ -4,6 +4,7 @@ import { Fragment, useMemo, type ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   SLACK_RESOLVE_USERS_MAX_IDS,
+  extractSlackChannelMentionIds,
   extractSlackUserMentionIds,
   parseSlackMessageTokens,
   type SlackMessageToken,
@@ -116,10 +117,15 @@ function renderTextWithBareUrls(text: string, keyPrefix: number): ReactNode[] {
   return nodes;
 }
 
+type ResolvedSlackReferences = {
+  users: Record<string, { name: string; profileUrl: string | null }>;
+  channels: Record<string, { name: string; url: string | null }>;
+};
+
 function renderToken(
   token: SlackMessageToken,
   index: number,
-  users: Record<string, { name: string; profileUrl: string | null }>,
+  { users, channels }: ResolvedSlackReferences,
 ): ReactNode {
   switch (token.type) {
     case 'text':
@@ -139,14 +145,17 @@ function renderToken(
         />
       );
     }
-    case 'channel':
+    case 'channel': {
+      const resolved = channels[token.channelId];
+      const label = resolved?.name ?? token.label ?? token.channelId;
       return (
         <SlackMention
           key={index}
-          label={`#${token.label ?? token.channelId}`}
-          href={null}
+          label={`#${label}`}
+          href={resolved?.url ?? null}
         />
       );
+    }
     case 'usergroup':
       return (
         <SlackMention
@@ -168,7 +177,8 @@ function renderToken(
  * Renders persisted Slack message text with `<@U…>`, `<#C…>`, `<!…>`, and
  * `<url|label>` tokens shown as readable mentions and links, and bare URLs
  * linkified. User mentions resolve to display names and link to the member's
- * Slack profile; the stored text is never rewritten.
+ * Slack profile, channel mentions resolve to channel names and link to the
+ * channel; the stored text is never rewritten.
  */
 export function SlackMessageText({ text }: { text: string }) {
   const tokens = useMemo(() => parseSlackMessageTokens(text), [text]);
@@ -179,17 +189,28 @@ export function SlackMessageText({ text }: { text: string }) {
       extractSlackUserMentionIds(text).slice(0, SLACK_RESOLVE_USERS_MAX_IDS),
     [text],
   );
+  const channelIds = useMemo(
+    () =>
+      extractSlackChannelMentionIds(text).slice(0, SLACK_RESOLVE_USERS_MAX_IDS),
+    [text],
+  );
   const { scope } = useSlackMentionContext();
   const trpc = useTRPC();
   const { data } = useQuery({
     ...trpc.slack.resolveUsers.queryOptions({
       scope: scope ?? { kind: 'task', taskId: '' },
       userIds,
+      channelIds,
     }),
-    enabled: scope !== null && userIds.length > 0,
+    enabled: scope !== null && (userIds.length > 0 || channelIds.length > 0),
     staleTime: 10 * 60 * 1000,
   });
-  const users = data?.users ?? {};
+  const resolved: ResolvedSlackReferences = {
+    users: data?.users ?? {},
+    channels: data?.channels ?? {},
+  };
 
-  return <>{tokens.map((token, index) => renderToken(token, index, users))}</>;
+  return (
+    <>{tokens.map((token, index) => renderToken(token, index, resolved))}</>
+  );
 }

--- a/apps/web/src/components/ai-elements/slack-message-text.tsx
+++ b/apps/web/src/components/ai-elements/slack-message-text.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useMemo, type ReactNode } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
+  SLACK_RESOLVE_CHANNELS_MAX_IDS,
   SLACK_RESOLVE_USERS_MAX_IDS,
   extractSlackChannelMentionIds,
   extractSlackUserMentionIds,
@@ -191,7 +192,10 @@ export function SlackMessageText({ text }: { text: string }) {
   );
   const channelIds = useMemo(
     () =>
-      extractSlackChannelMentionIds(text).slice(0, SLACK_RESOLVE_USERS_MAX_IDS),
+      extractSlackChannelMentionIds(text).slice(
+        0,
+        SLACK_RESOLVE_CHANNELS_MAX_IDS,
+      ),
     [text],
   );
   const { scope } = useSlackMentionContext();

--- a/apps/web/src/trpc/commands/slack/index.ts
+++ b/apps/web/src/trpc/commands/slack/index.ts
@@ -825,6 +825,8 @@ export async function completePendingSlackAuthenticationCommand(
 
 const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]+$/;
 const SLACK_CHANNEL_ID_PATTERN = /^[CDG][A-Z0-9]+$/;
+/** Parallel `conversations.info` calls per resolve request, kept well under Slack's per-method quota. */
+const SLACK_CHANNEL_LOOKUP_CONCURRENCY = 4;
 
 /**
  * Slack team a transcript belongs to, derived server-side from the task run
@@ -978,23 +980,33 @@ export async function resolveSlackUsersCommand(
   }
 
   if (channelIds.length > 0 && slack) {
-    await Promise.all(
-      channelIds.map(async (slackChannelId) => {
-        const name = await slack
-          .getChannelName(slackChannelId)
-          .catch(() => null);
-        if (name) {
-          channels[slackChannelId] = {
-            name,
-            url: buildSlackChannelUrl({
-              slackChannelId,
-              slackTeamId: teamId,
-              slackWorkspaceDomain: teamDomain,
-            }),
-          };
-        }
-      }),
-    );
+    for (
+      let start = 0;
+      start < channelIds.length;
+      start += SLACK_CHANNEL_LOOKUP_CONCURRENCY
+    ) {
+      const batch = channelIds.slice(
+        start,
+        start + SLACK_CHANNEL_LOOKUP_CONCURRENCY,
+      );
+      await Promise.all(
+        batch.map(async (slackChannelId) => {
+          const name = await slack
+            .getChannelName(slackChannelId)
+            .catch(() => null);
+          if (name) {
+            channels[slackChannelId] = {
+              name,
+              url: buildSlackChannelUrl({
+                slackChannelId,
+                slackTeamId: teamId,
+                slackWorkspaceDomain: teamDomain,
+              }),
+            };
+          }
+        }),
+      );
+    }
   }
 
   return { users, channels };

--- a/apps/web/src/trpc/commands/slack/index.ts
+++ b/apps/web/src/trpc/commands/slack/index.ts
@@ -1,4 +1,8 @@
-import { SlackNotifier, shouldResumeSlackAuthThread } from '@roomote/slack';
+import {
+  SlackChannelInfoCache,
+  SlackNotifier,
+  shouldResumeSlackAuthThread,
+} from '@roomote/slack';
 import {
   enqueueSlackAccountLinkEducation,
   recordSlackConversationMessageBestEffort,
@@ -959,11 +963,14 @@ export async function resolveSlackUsersCommand(
   }
 
   const unresolved = userIds.filter((userId) => !users[userId]);
+  // The channel-info cache is Redis-backed, so a channel name is fetched
+  // from Slack once per TTL across every transcript view, not per render.
   const slack = installation?.botAccessToken
     ? new SlackNotifier(installation.botAccessToken, {
         botUserId: installation.botUserId,
         botName: installation.botName,
         appName: installation.appName,
+        channelInfoCache: new SlackChannelInfoCache(teamId),
       })
     : null;
   if (unresolved.length > 0 && slack) {

--- a/apps/web/src/trpc/commands/slack/index.ts
+++ b/apps/web/src/trpc/commands/slack/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@roomote/sdk/server';
 import {
   PRODUCT_NAME,
+  buildSlackChannelUrl,
   buildSlackUserProfileUrl,
   getSlackTeamIdFromTaskPayload,
 } from '@roomote/types';
@@ -823,6 +824,7 @@ export async function completePendingSlackAuthenticationCommand(
 }
 
 const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]+$/;
+const SLACK_CHANNEL_ID_PATTERN = /^[CDG][A-Z0-9]+$/;
 
 /**
  * Slack team a transcript belongs to, derived server-side from the task run
@@ -865,9 +867,11 @@ export async function resolveSlackUsersCommand(
       | { kind: 'task'; taskId: string }
       | { kind: 'session'; sessionId: string };
     userIds: string[];
+    channelIds?: string[];
   },
 ): Promise<{
   users: Record<string, { name: string; profileUrl: string | null }>;
+  channels: Record<string, { name: string; url: string | null }>;
 }> {
   const userIds = [
     ...new Set(
@@ -876,14 +880,22 @@ export async function resolveSlackUsersCommand(
         .filter((userId) => SLACK_USER_ID_PATTERN.test(userId)),
     ),
   ];
+  const channelIds = [
+    ...new Set(
+      (input.channelIds ?? [])
+        .map((channelId) => channelId.trim())
+        .filter((channelId) => SLACK_CHANNEL_ID_PATTERN.test(channelId)),
+    ),
+  ];
   const users: Record<string, { name: string; profileUrl: string | null }> = {};
-  if (userIds.length === 0) {
-    return { users };
+  const channels: Record<string, { name: string; url: string | null }> = {};
+  if (userIds.length === 0 && channelIds.length === 0) {
+    return { users, channels };
   }
 
   const teamId = await resolveSlackMentionScopeTeamId(auth, input.scope);
   if (!teamId) {
-    return { users };
+    return { users, channels };
   }
 
   const installation =
@@ -945,12 +957,14 @@ export async function resolveSlackUsersCommand(
   }
 
   const unresolved = userIds.filter((userId) => !users[userId]);
-  if (unresolved.length > 0 && installation?.botAccessToken) {
-    const slack = new SlackNotifier(installation.botAccessToken, {
-      botUserId: installation.botUserId,
-      botName: installation.botName,
-      appName: installation.appName,
-    });
+  const slack = installation?.botAccessToken
+    ? new SlackNotifier(installation.botAccessToken, {
+        botUserId: installation.botUserId,
+        botName: installation.botName,
+        appName: installation.appName,
+      })
+    : null;
+  if (unresolved.length > 0 && slack) {
     try {
       const names = await slack.getUserDisplayNames(unresolved);
       for (const [slackUserId, name] of names) {
@@ -963,5 +977,25 @@ export async function resolveSlackUsersCommand(
     }
   }
 
-  return { users };
+  if (channelIds.length > 0 && slack) {
+    await Promise.all(
+      channelIds.map(async (slackChannelId) => {
+        const name = await slack
+          .getChannelName(slackChannelId)
+          .catch(() => null);
+        if (name) {
+          channels[slackChannelId] = {
+            name,
+            url: buildSlackChannelUrl({
+              slackChannelId,
+              slackTeamId: teamId,
+              slackWorkspaceDomain: teamDomain,
+            }),
+          };
+        }
+      }),
+    );
+  }
+
+  return { users, channels };
 }

--- a/apps/web/src/trpc/commands/slack/index.ts
+++ b/apps/web/src/trpc/commands/slack/index.ts
@@ -831,6 +831,34 @@ const SLACK_USER_ID_PATTERN = /^[UW][A-Z0-9]+$/;
 const SLACK_CHANNEL_ID_PATTERN = /^[CDG][A-Z0-9]+$/;
 /** Parallel `conversations.info` calls per resolve request, kept well under Slack's per-method quota. */
 const SLACK_CHANNEL_LOOKUP_CONCURRENCY = 4;
+/** How long one in-process channel-info cache serves a workspace before a fresh instance replaces it. */
+const SLACK_CHANNEL_INFO_CACHE_WINDOW_MS = 60_000;
+
+const channelInfoCachesByTeam = new Map<
+  string,
+  { cache: SlackChannelInfoCache; createdAt: number }
+>();
+
+/**
+ * One `SlackChannelInfoCache` per workspace, shared across concurrent resolve
+ * requests in this process so transcript messages that mount together
+ * coalesce on a single in-flight `conversations.info` call per channel
+ * instead of each racing the cold Redis layer. Instances are recycled on a
+ * short window so the in-memory memo cannot serve a renamed channel forever.
+ */
+function getSharedChannelInfoCache(teamId: string): SlackChannelInfoCache {
+  const now = Date.now();
+  const existing = channelInfoCachesByTeam.get(teamId);
+  if (
+    existing &&
+    now - existing.createdAt < SLACK_CHANNEL_INFO_CACHE_WINDOW_MS
+  ) {
+    return existing.cache;
+  }
+  const cache = new SlackChannelInfoCache(teamId);
+  channelInfoCachesByTeam.set(teamId, { cache, createdAt: now });
+  return cache;
+}
 
 /**
  * Slack team a transcript belongs to, derived server-side from the task run
@@ -963,14 +991,15 @@ export async function resolveSlackUsersCommand(
   }
 
   const unresolved = userIds.filter((userId) => !users[userId]);
-  // The channel-info cache is Redis-backed, so a channel name is fetched
-  // from Slack once per TTL across every transcript view, not per render.
+  // The channel-info cache is Redis-backed and shared across requests in
+  // this process, so a channel name is fetched from Slack once per TTL and
+  // concurrent cold lookups for the same channel collapse into one call.
   const slack = installation?.botAccessToken
     ? new SlackNotifier(installation.botAccessToken, {
         botUserId: installation.botUserId,
         botName: installation.botName,
         appName: installation.appName,
-        channelInfoCache: new SlackChannelInfoCache(teamId),
+        channelInfoCache: getSharedChannelInfoCache(teamId),
       })
     : null;
   if (unresolved.length > 0 && slack) {

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -1351,6 +1351,10 @@ export const appRouter = createRouter({
           userIds: z
             .array(z.string().trim().min(1).max(64))
             .max(SLACK_RESOLVE_USERS_MAX_IDS),
+          channelIds: z
+            .array(z.string().trim().min(1).max(64))
+            .max(SLACK_RESOLVE_USERS_MAX_IDS)
+            .optional(),
         }),
       )
       .query(({ ctx: { auth }, input }) =>

--- a/apps/web/src/trpc/routers/_app.ts
+++ b/apps/web/src/trpc/routers/_app.ts
@@ -5,6 +5,7 @@ import {
 } from '@roomote/auth';
 
 import {
+  SLACK_RESOLVE_CHANNELS_MAX_IDS,
   SLACK_RESOLVE_USERS_MAX_IDS,
   ALL_REPOSITORIES,
   FAST_EXECUTION,
@@ -1353,7 +1354,7 @@ export const appRouter = createRouter({
             .max(SLACK_RESOLVE_USERS_MAX_IDS),
           channelIds: z
             .array(z.string().trim().min(1).max(64))
-            .max(SLACK_RESOLVE_USERS_MAX_IDS)
+            .max(SLACK_RESOLVE_CHANNELS_MAX_IDS)
             .optional(),
         }),
       )

--- a/packages/types/src/__tests__/slack.test.ts
+++ b/packages/types/src/__tests__/slack.test.ts
@@ -1,6 +1,8 @@
 import {
+  buildSlackChannelUrl,
   buildSlackThreadPermalink,
   buildSlackUserProfileUrl,
+  extractSlackChannelMentionIds,
   extractSlackUserMentionIds,
   parseSlackChannelPermalink,
   parseSlackMessagePermalink,
@@ -73,6 +75,36 @@ describe('extractSlackUserMentionIds', () => {
     expect(
       extractSlackUserMentionIds('<@U2> then <@U1> and <@U2> again <#C1>'),
     ).toEqual(['U2', 'U1']);
+  });
+});
+
+describe('extractSlackChannelMentionIds', () => {
+  it('dedupes channel ids in first-seen order', () => {
+    expect(
+      extractSlackChannelMentionIds('<#C2|ops> then <#C1> and <#C2> <@U1>'),
+    ).toEqual(['C2', 'C1']);
+  });
+});
+
+describe('buildSlackChannelUrl', () => {
+  it('prefers the workspace archive url when the domain is known', () => {
+    expect(
+      buildSlackChannelUrl({
+        slackChannelId: 'C123',
+        slackTeamId: 'T123',
+        slackWorkspaceDomain: 'acme-team',
+      }),
+    ).toBe('https://acme-team.slack.com/archives/C123');
+  });
+
+  it('falls back to the app redirect with only a team id', () => {
+    expect(
+      buildSlackChannelUrl({ slackChannelId: 'C123', slackTeamId: 'T123' }),
+    ).toBe('https://slack.com/app_redirect?channel=C123&team=T123');
+  });
+
+  it('returns null without a team id or domain', () => {
+    expect(buildSlackChannelUrl({ slackChannelId: 'C123' })).toBeNull();
   });
 });
 

--- a/packages/types/src/__tests__/slack.test.ts
+++ b/packages/types/src/__tests__/slack.test.ts
@@ -46,11 +46,24 @@ describe('parseSlackMessageTokens', () => {
     ]);
   });
 
-  it('leaves unrelated angle-bracket text alone', () => {
+  it('parses Slack link references and drops labels that repeat the url', () => {
     expect(
-      parseSlackMessageTokens('<https://example.com|link> and <b>bold</b>'),
+      parseSlackMessageTokens(
+        'I like <https://roomote.dev> and <https://example.com/path|Example> <mailto:a@b.co|a@b.co>',
+      ),
     ).toEqual([
-      { type: 'text', text: '<https://example.com|link> and <b>bold</b>' },
+      { type: 'text', text: 'I like ' },
+      { type: 'link', url: 'https://roomote.dev', label: null },
+      { type: 'text', text: ' and ' },
+      { type: 'link', url: 'https://example.com/path', label: 'Example' },
+      { type: 'text', text: ' ' },
+      { type: 'link', url: 'mailto:a@b.co', label: null },
+    ]);
+  });
+
+  it('leaves unrelated angle-bracket text alone', () => {
+    expect(parseSlackMessageTokens('use <b>bold</b> or <T> generics')).toEqual([
+      { type: 'text', text: 'use <b>bold</b> or <T> generics' },
     ]);
   });
 });

--- a/packages/types/src/slack.ts
+++ b/packages/types/src/slack.ts
@@ -211,6 +211,12 @@ export type SlackMessageToken =
 
 /** Upper bound on Slack user IDs resolved in one `slack.resolveUsers` call. */
 export const SLACK_RESOLVE_USERS_MAX_IDS = 50;
+/**
+ * Upper bound on Slack channel IDs resolved in one `slack.resolveUsers` call.
+ * Channel names come from `conversations.info`, one call per cold ID, so this
+ * stays small to keep a single transcript message well under Slack's quota.
+ */
+export const SLACK_RESOLVE_CHANNELS_MAX_IDS = 10;
 
 // Each pattern is anchored and applied only to the bounded text between one
 // `<` and the next `>`, so parsing stays linear in the message length even

--- a/packages/types/src/slack.ts
+++ b/packages/types/src/slack.ts
@@ -346,6 +346,45 @@ export function extractSlackUserMentionIds(text: string): string[] {
   return [...userIds];
 }
 
+/** Unique Slack channel IDs referenced by `<#C…>` tokens, in first-seen order. */
+export function extractSlackChannelMentionIds(text: string): string[] {
+  const channelIds = new Set<string>();
+  for (const token of parseSlackMessageTokens(text)) {
+    if (token.type === 'channel') {
+      channelIds.add(token.channelId);
+    }
+  }
+  return [...channelIds];
+}
+
+/**
+ * Link to a Slack channel. Prefers the workspace web URL when the domain is
+ * known and falls back to Slack's app redirect when only the team ID is
+ * available.
+ */
+export function buildSlackChannelUrl(params: {
+  slackChannelId: string;
+  slackTeamId?: string | null;
+  slackWorkspaceDomain?: string | null;
+}): string | null {
+  const slackChannelId = params.slackChannelId.trim();
+  if (!slackChannelId) {
+    return null;
+  }
+
+  const slackWorkspaceDomain = params.slackWorkspaceDomain?.trim();
+  if (slackWorkspaceDomain) {
+    return `https://${encodeURIComponent(slackWorkspaceDomain)}.slack.com/archives/${encodeURIComponent(slackChannelId)}`;
+  }
+
+  const slackTeamId = params.slackTeamId?.trim();
+  if (slackTeamId) {
+    return `https://slack.com/app_redirect?channel=${encodeURIComponent(slackChannelId)}&team=${encodeURIComponent(slackTeamId)}`;
+  }
+
+  return null;
+}
+
 /**
  * Link to a Slack member profile. Prefers the workspace web URL when the
  * workspace domain is known and falls back to the `slack://` deep link that

--- a/packages/types/src/slack.ts
+++ b/packages/types/src/slack.ts
@@ -206,7 +206,8 @@ export type SlackMessageToken =
   | { type: 'user'; userId: string; label: string | null }
   | { type: 'channel'; channelId: string; label: string | null }
   | { type: 'usergroup'; usergroupId: string; label: string | null }
-  | { type: 'broadcast'; name: string };
+  | { type: 'broadcast'; name: string }
+  | { type: 'link'; url: string; label: string | null };
 
 /** Upper bound on Slack user IDs resolved in one `slack.resolveUsers` call. */
 export const SLACK_RESOLVE_USERS_MAX_IDS = 50;
@@ -219,6 +220,8 @@ const SLACK_CHANNEL_REFERENCE_PATTERN = /^#([CDG][A-Z0-9]+)(?:\|([^|]*))?$/;
 const SLACK_USERGROUP_REFERENCE_PATTERN =
   /^!subteam\^([A-Z0-9]+)(?:\|([^|]*))?$/;
 const SLACK_BROADCAST_REFERENCE_PATTERN = /^!(here|channel|everyone)(?:\|.*)?$/;
+const SLACK_LINK_REFERENCE_PATTERN =
+  /^((?:https?:\/\/|mailto:)[^|\s]+)(?:\|(.*))?$/;
 
 function normalizeSlackTokenLabel(label: string | undefined): string | null {
   const trimmed = label?.trim().replace(/^@/, '') ?? '';
@@ -258,13 +261,28 @@ function parseSlackReference(inner: string): SlackMessageToken | null {
     return { type: 'broadcast', name: broadcast[1] };
   }
 
+  const link = SLACK_LINK_REFERENCE_PATTERN.exec(inner);
+  if (link?.[1]) {
+    const url = link[1];
+    const label = link[2]?.trim() ?? '';
+    // Slack repeats the url (or the address behind `mailto:`) as the label
+    // when the sender typed a bare link; that adds nothing, so drop it.
+    const redundantLabels = new Set([url, url.replace(/^mailto:/, '')]);
+    return {
+      type: 'link',
+      url,
+      label: label.length > 0 && !redundantLabels.has(label) ? label : null,
+    };
+  }
+
   return null;
 }
 
 /**
  * Splits raw Slack message text into plain-text runs and Slack references
  * (`<@U123>`, `<@U123|name>`, `<#C123|general>`, `<!subteam^S123|@team>`,
- * `<!here>`). Text without references comes back as a single text token.
+ * `<!here>`, `<https://example.com|label>`). Text without references comes
+ * back as a single text token.
  *
  * Single forward scan: a `<` opens a candidate, the candidate ends at the
  * next `>`, and another `<` before that restarts the candidate there, so no


### PR DESCRIPTION
Follow-up to #2103, which merged before this commit landed on its branch.

## What changed

- Slack wraps URLs as `<https://roomote.dev>` or `<url|label>`, and Fast turns keep that raw form since #2005, so links showed up verbatim in the web transcript. The message renderer now parses `<url>`, `<url|label>`, and `<mailto:…>` references as link tokens and renders them as anchors, dropping labels that just repeat the URL. Bare `http(s)` URLs in plain text are linkified as well.
- Mentions render as plain colored text with an underline on hover instead of a highlighted pill.

## Testing

- Tokenizer tests for link references; component test for link tokens and bare URLs.
- Lint, typecheck, knip, and the types and web transcript suites pass.

- Channel mentions (`<#C…>`) resolve to the channel name via `conversations.info` and link to the channel, the same way user mentions do.