### PR TITLE
[Feat] Every Teams entry starts a Fast Session

### DIFF
--- a/apps/api/src/handlers/teams/__tests__/index.test.ts
+++ b/apps/api/src/handlers/teams/__tests__/index.test.ts
@@ -610,6 +610,49 @@ describe('Teams webhook handler', () => {
         launchClaimedAt: new Date('2026-08-07T00:00:00.000Z'),
       },
     });
+    // The kickoff gate must run inside the enqueue, before the child becomes
+    // runnable; model both sides so the wiring is exercised, not assumed.
+    const postKickoff = vi.fn().mockResolvedValue(undefined);
+    launchPinnedMock.mockImplementationOnce(
+      async (input: {
+        launchId: string;
+        conversation: unknown;
+        launch: (context: {
+          parent: { sessionId: string; conversation: unknown };
+          launchIdempotencyKey: string;
+          postKickoff: () => Promise<void>;
+        }) => Promise<
+          { success: true; taskId: string } | { success: false; error: string }
+        >;
+      }) => {
+        const result = await input.launch({
+          parent: { sessionId: 'fast-1', conversation: input.conversation },
+          launchIdempotencyKey: `pinned-launch:${input.launchId}`,
+          postKickoff,
+        });
+        if (!result.success) throw new Error(result.error);
+        return {
+          sessionId: 'session-1',
+          fastConversationId: 'fast-1',
+          taskId: result.taskId,
+          runId: 88,
+        };
+      },
+    );
+    enqueueTaskMock.mockImplementationOnce(
+      async (
+        _input: unknown,
+        options: {
+          beforeEnqueue?: (taskRun: {
+            id: number;
+            taskId: string;
+          }) => Promise<void>;
+        },
+      ) => {
+        await options.beforeEnqueue?.({ id: 88, taskId: 'task-new' });
+        return { id: 88, taskId: 'task-new' };
+      },
+    );
     // Drive the real launcher the way launchClaimedTeamsSuggestion would.
     launchClaimedTeamsSuggestionMock.mockImplementationOnce(
       async (params: {
@@ -675,8 +718,15 @@ describe('Teams webhook handler', () => {
       }),
       expect.objectContaining({ beforeEnqueue: expect.any(Function) }),
     );
+    // The Session transcript kickoff ran inside the launch gate, and the
+    // Teams acknowledgement was posted after the enqueue.
+    expect(postKickoff).toHaveBeenCalledOnce();
+    expect(postKickoff.mock.invocationCallOrder[0]).toBeLessThan(
+      postMessageMock.mock.invocationCallOrder[0]!,
+    );
     expect(postMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        channelId: '19:conversation@thread.v2',
         text: expect.stringContaining('Started a task in acme/app'),
       }),
     );

--- a/apps/api/src/handlers/teams/__tests__/index.test.ts
+++ b/apps/api/src/handlers/teams/__tests__/index.test.ts
@@ -25,6 +25,7 @@ const {
   queueCommunicationMessageMock,
   redisSetMock,
   launchClaimedTeamsSuggestionMock,
+  launchPinnedMock,
   resolveAndClaimTeamsSuggestionReactionMock,
   setTrustedRunActingUserMock,
   shouldRouteUnmentionedReplyMock,
@@ -83,6 +84,7 @@ const {
   queueCommunicationMessageMock: vi.fn(),
   redisSetMock: vi.fn(),
   launchClaimedTeamsSuggestionMock: vi.fn(),
+  launchPinnedMock: vi.fn(),
   resolveAndClaimTeamsSuggestionReactionMock: vi.fn(),
   setTrustedRunActingUserMock: vi.fn(),
   shouldRouteUnmentionedReplyMock: vi.fn(),
@@ -304,6 +306,7 @@ vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: enqueueTaskMock,
   getOrCreateFastAgentSession: getFastSessionMock,
   getTaskUrl: getTaskUrlMock,
+  launchPinnedFastSessionTask: launchPinnedMock,
 }));
 
 vi.mock('../bot-framework-auth.js', () => ({
@@ -406,6 +409,33 @@ describe('Teams webhook handler', () => {
       id: 88,
       taskId: 'task-new',
     });
+    // The pinned-launch primitive runs the surface launcher inside a Session.
+    launchPinnedMock.mockImplementation(
+      async (input: {
+        launchId: string;
+        conversation: unknown;
+        launch: (context: {
+          parent: { sessionId: string; conversation: unknown };
+          launchIdempotencyKey: string;
+          postKickoff: () => Promise<void>;
+        }) => Promise<
+          { success: true; taskId: string } | { success: false; error: string }
+        >;
+      }) => {
+        const result = await input.launch({
+          parent: { sessionId: 'fast-1', conversation: input.conversation },
+          launchIdempotencyKey: `pinned-launch:${input.launchId}`,
+          postKickoff: async () => {},
+        });
+        if (!result.success) throw new Error(result.error);
+        return {
+          sessionId: 'session-1',
+          fastConversationId: 'fast-1',
+          taskId: result.taskId,
+          runId: 88,
+        };
+      },
+    );
     postDirectMessageMock.mockResolvedValue({ messageId: 'dm-response' });
     postMessageMock.mockResolvedValue({ messageId: 'activity-response' });
     fetchMessageImageDataUrlsMock.mockResolvedValue([]);
@@ -559,6 +589,98 @@ describe('Teams webhook handler', () => {
     );
     expect(callViaEmojiConfigMock).not.toHaveBeenCalled();
     expect(queueFastReplyMock).not.toHaveBeenCalled();
+  });
+
+  it('launches a pinned suggestion through the owning Fast Session without a model turn', async () => {
+    trackedSuggestionMessageFindFirstMock.mockResolvedValue({
+      workItemId: 'suggestion-1',
+    });
+    teamsUserMappingFindFirstMock.mockResolvedValue({
+      userId: 'mapped-user-1',
+    });
+    resolveAndClaimTeamsSuggestionReactionMock.mockResolvedValue({
+      outcome: 'claimed',
+      suggestion: {
+        id: 'suggestion-1',
+        title: 'Fix the flaky test',
+        brief: 'Remove the timing race.',
+        investigationContext: null,
+        targetRepositoryFullName: 'acme/app',
+        targetEnvironmentId: null,
+        launchClaimedAt: new Date('2026-08-07T00:00:00.000Z'),
+      },
+    });
+    // Drive the real launcher the way launchClaimedTeamsSuggestion would.
+    launchClaimedTeamsSuggestionMock.mockImplementationOnce(
+      async (params: {
+        launchTask: (
+          promptText: string,
+          target: { kind: string },
+        ) => Promise<{ launchResult: { id: number } }>;
+      }) => {
+        const launch = await params.launchTask('Fix the flaky test', {
+          kind: 'legacy_pinned',
+        });
+        return { result: 'started', runId: launch.launchResult.id };
+      },
+    );
+
+    const response = await createApp().request('/teams', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer valid-token',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(
+        createTeamsActivity({
+          type: 'messageReaction',
+          id: 'suggestion-reaction-2',
+          text: undefined,
+          entities: undefined,
+          replyToId: 'suggestion-card-1',
+          reactionsAdded: [{ type: 'like' }],
+        }),
+      ),
+    });
+
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      started: true,
+      runId: 88,
+    });
+    expect(launchPinnedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'mapped-user-1',
+        surface: 'teams',
+        prompt: 'Fix the flaky test',
+        conversation: expect.objectContaining({
+          surface: 'teams',
+          workspaceId: 'tenant-1',
+        }),
+        kickoffMessage: 'Started a task in acme/app.',
+      }),
+    );
+    expect(enqueueTaskMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initiator: { kind: 'user', userId: 'mapped-user-1' },
+        surface: 'teams',
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            repo: 'acme/app',
+            description: 'Fix the flaky test',
+            reportConsumer: 'orchestrator',
+            fastAgentSessionId: 'fast-1',
+          }),
+        }),
+      }),
+      expect.objectContaining({ beforeEnqueue: expect.any(Function) }),
+    );
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining('Started a task in acme/app'),
+      }),
+    );
+    expect(continueFastReplyMock).not.toHaveBeenCalled();
   });
 
   it('starts a Fast-targeted suggestion in the personal chat’s shared Fast session', async () => {

--- a/apps/api/src/handlers/teams/__tests__/index.test.ts
+++ b/apps/api/src/handlers/teams/__tests__/index.test.ts
@@ -5,7 +5,6 @@ const {
   authAccountsFindFirstMock,
   authAccountsFindManyMock,
   authUsersFindFirstMock,
-  buildTeamsRoutingContextMock,
   enqueueTaskMock,
   envMock,
   fetchMessageImageDataUrlsMock,
@@ -25,7 +24,6 @@ const {
   redisGetMock,
   queueCommunicationMessageMock,
   redisSetMock,
-  routeTaskMock,
   launchClaimedTeamsSuggestionMock,
   resolveAndClaimTeamsSuggestionReactionMock,
   setTrustedRunActingUserMock,
@@ -51,7 +49,6 @@ const {
   authAccountsFindFirstMock: vi.fn(),
   authAccountsFindManyMock: vi.fn(),
   authUsersFindFirstMock: vi.fn(),
-  buildTeamsRoutingContextMock: vi.fn(),
   enqueueTaskMock: vi.fn(),
   envMock: {
     R_TEAMS_BOT_APP_ID: 'bot-app-id' as string | undefined,
@@ -85,7 +82,6 @@ const {
   redisGetMock: vi.fn(),
   queueCommunicationMessageMock: vi.fn(),
   redisSetMock: vi.fn(),
-  routeTaskMock: vi.fn(),
   launchClaimedTeamsSuggestionMock: vi.fn(),
   resolveAndClaimTeamsSuggestionReactionMock: vi.fn(),
   setTrustedRunActingUserMock: vi.fn(),
@@ -305,11 +301,9 @@ vi.mock('@roomote/cloud-agents/server', () => ({
     (input: unknown) =>
       `<external_input>${JSON.stringify(input)}</external_input>`,
   ),
-  buildTeamsRoutingContext: buildTeamsRoutingContextMock,
   enqueueTask: enqueueTaskMock,
   getOrCreateFastAgentSession: getFastSessionMock,
   getTaskUrl: getTaskUrlMock,
-  routeTask: routeTaskMock,
 }));
 
 vi.mock('../bot-framework-auth.js', () => ({
@@ -408,14 +402,6 @@ describe('Teams webhook handler', () => {
     queueCommunicationMessageMock.mockResolvedValue(undefined);
     claimPendingOutOfBandMock.mockResolvedValue([]);
     releaseClaimedOutOfBandMock.mockResolvedValue(undefined);
-    buildTeamsRoutingContextMock.mockResolvedValue({ context: true });
-    routeTaskMock.mockResolvedValue({
-      status: 'routed',
-      result: {
-        workspace: { type: 'all_repositories' },
-        reasoning: 'all repos',
-      },
-    });
     enqueueTaskMock.mockResolvedValue({
       id: 88,
       taskId: 'task-new',
@@ -1556,7 +1542,7 @@ describe('Teams webhook handler', () => {
     expect(enqueueTaskMock).not.toHaveBeenCalled();
   });
 
-  it('falls back to normal Teams task routing when Fast session setup fails', async () => {
+  it('replies with an error when Fast session setup fails', async () => {
     findFirstMock.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
     teamsUserMappingFindFirstMock.mockResolvedValueOnce({
       userId: 'mapped-user-1',
@@ -1574,11 +1560,16 @@ describe('Teams webhook handler', () => {
 
     await expect(response.json()).resolves.toEqual({
       ok: true,
-      started: true,
-      runId: 88,
+      queued: false,
+      fastUnavailable: true,
     });
-    expect(buildTeamsRoutingContextMock).toHaveBeenCalled();
-    expect(enqueueTaskMock).toHaveBeenCalled();
+    expect(postMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining("couldn't start a conversation"),
+      }),
+    );
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
+    expect(continueFastReplyMock).not.toHaveBeenCalled();
   });
 
   it('starts Fast with Teams image attachments', async () => {
@@ -1685,8 +1676,6 @@ describe('Teams webhook handler', () => {
       reason: 'account_link_required',
     });
     expect(response.status).toBe(200);
-    expect(buildTeamsRoutingContextMock).not.toHaveBeenCalled();
-    expect(routeTaskMock).not.toHaveBeenCalled();
     expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(queueCommunicationMessageMock).not.toHaveBeenCalled();
     expect(findFirstMock).toHaveBeenCalledTimes(1);
@@ -1791,6 +1780,12 @@ describe('Teams webhook handler', () => {
       userId: 'mapped-user-1',
     });
     findFirstMock.mockResolvedValueOnce(null).mockResolvedValueOnce(null);
+    continueFastReplyMock.mockImplementationOnce(
+      async ({ onAccepted }: { onAccepted?: (abort: unknown) => void }) => {
+        onAccepted?.(vi.fn());
+        return true;
+      },
+    );
 
     const response = await createApp().request('/teams/auth/resume', {
       method: 'POST',
@@ -1800,10 +1795,7 @@ describe('Teams webhook handler', () => {
 
     await expect(response.json()).resolves.toEqual({
       success: true,
-      status: 'started',
-      runId: 88,
-      taskId: 'task-new',
-      taskUrl: 'https://app.example.com/task/task-new',
+      status: 'fast',
     });
     expect(response.status).toBe(200);
     expect(redisGetMock).toHaveBeenCalledWith('teams:auth:teams-auth-token-1');
@@ -1812,27 +1804,27 @@ describe('Teams webhook handler', () => {
       1,
       'teams:auth:teams-auth-token-1',
     );
-    expect(enqueueTaskMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        task: expect.objectContaining({
-          type: 'standard',
-          payload: expect.objectContaining({
-            description: 'run the tests',
-            images: ['data:image/png;base64,abc123'],
-            communicationProvider: 'teams',
-            communicationChannelId: '19:conversation@thread.v2',
-            communicationThreadId: 'activity-root',
-          }),
-        }),
-        initiator: { kind: 'user', userId: 'mapped-user-1' },
-        workflow: 'standard',
+    expect(getFastSessionMock).toHaveBeenCalledWith({
+      userId: 'mapped-user-1',
+      conversation: {
         surface: 'teams',
-        trigger: 'message',
-      }),
+        workspaceId: 'tenant-1',
+        conversationId: 'activity-root:user:mapped-user-1',
+        replyTarget: {
+          channelId: '19:conversation@thread.v2',
+          threadId: 'activity-root',
+        },
+      },
+    });
+    expect(continueFastReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        launchClass: 'human',
+        userId: 'mapped-user-1',
+        question: 'run the tests',
+        images: ['data:image/png;base64,abc123'],
+        currentMessageId: 'pending-activity-1',
       }),
     );
+    expect(enqueueTaskMock).not.toHaveBeenCalled();
     expect(processImageAttachmentsMock).toHaveBeenCalledWith(
       [
         {

--- a/apps/api/src/handlers/teams/__tests__/suggestion-start.test.ts
+++ b/apps/api/src/handlers/teams/__tests__/suggestion-start.test.ts
@@ -238,24 +238,6 @@ describe('launchClaimedTeamsSuggestion', () => {
     expect(postMessage).not.toHaveBeenCalled();
   });
 
-  it('releases the claim with the token when routing replies inline (no task launched)', async () => {
-    const launchTask = vi.fn().mockResolvedValue({ status: 'replied_inline' });
-
-    const outcome = await launchClaimedTeamsSuggestion({
-      suggestion: buildClaimedSuggestion(),
-      launchTask,
-      postMessage: vi.fn(),
-    });
-
-    expect(outcome).toEqual({ result: 'replied_inline' });
-    expect(finalizeWorkItemLaunchedMock).not.toHaveBeenCalled();
-    expect(releaseWorkItemClaimMock).toHaveBeenCalledTimes(1);
-    expect(releaseWorkItemClaimMock).toHaveBeenCalledWith(expect.anything(), {
-      id: 'work-item-1',
-      claimedAt: CLAIMED_AT,
-    });
-  });
-
   it('releases the claim with the token and posts a visible failure when the launch throws', async () => {
     const launchTask = vi.fn().mockRejectedValue(new Error('enqueue exploded'));
     const postMessage = vi.fn();

--- a/apps/api/src/handlers/teams/index.ts
+++ b/apps/api/src/handlers/teams/index.ts
@@ -68,19 +68,21 @@ import {
   isDeploymentReadOnlyError,
   populateSnapshotResumeCommunicationMetadata,
   restoreSnapshotResumeVisiblePromptFields,
+  buildFastAgentChildTaskMetadata,
+  type FastAgentConversation,
+  type FastAgentParent,
 } from '@roomote/types';
 import { appendAttachmentTextsToPromptText } from '@roomote/cloud-agents';
 import {
   AUDIO_TRANSCRIPTION_MAX_SIZE_BYTES,
-  buildTeamsRoutingContext,
   buildFastAgentReactionExternalInputQuestion,
   enqueueTask,
   formatAudioAttachmentWarning,
   formatAudioTranscriptionResult,
   getTaskUrl,
   getOrCreateFastAgentSession,
+  launchPinnedFastSessionTask,
   resolveAudioTranscriptionMimeType,
-  routeTask,
   transcribeAudioAttachment,
   type FastAgentReactionExternalInput,
   type RoutingWorkspace,
@@ -152,7 +154,26 @@ async function resolveTeamsSuggestionWorkspace(
     suggestion,
   );
   if (!pinnedEnvironmentId) {
-    return { workspaceOverride: null, unavailableEnvironmentId: null };
+    // A card pinned to a bare repository keeps that repository; only cards
+    // with no target at all run against every repository.
+    const pinnedRepositoryFullName =
+      target.kind === 'legacy_pinned' &&
+      suggestion.targetRepositoryFullName &&
+      suggestion.targetRepositoryFullName !== ALL_REPOSITORIES
+        ? suggestion.targetRepositoryFullName
+        : null;
+    return {
+      workspaceOverride: pinnedRepositoryFullName
+        ? {
+            repoForPayload: pinnedRepositoryFullName,
+            workspaceDisplayName: pinnedRepositoryFullName,
+          }
+        : {
+            repoForPayload: ALL_REPOSITORIES,
+            workspaceDisplayName: 'all repos',
+          },
+      unavailableEnvironmentId: null,
+    };
   }
   const workspaceOverride = await resolveTeamsWorkspace({
     type: 'environment',
@@ -170,45 +191,64 @@ async function resolveTeamsSuggestionWorkspace(
  * turn completion) so the suggestion claim can be finalized immediately, and
  * returns an abort handle so a lost finalize can cancel the orphaned turn.
  */
-function startTeamsFastSuggestion(params: {
+/**
+ * The Fast conversation identity for a Teams activity: personal chats share
+ * one session per user (a DM has no threads, even though a reaction activity
+ * replies to a card), channel posts get one per root message.
+ */
+function resolveTeamsFastConversation(params: {
   activity: TeamsActivity;
   metadata: TeamsActivityCommunicationMetadata;
   mappedUserId: string;
-  prompt: string;
   currentMessageId: string;
-}): Promise<FastAgentStartResult> {
+}): Extract<FastAgentConversation, { surface: 'teams' }> | null {
   const tenantId = params.metadata.teamsTenantId;
   if (!tenantId) {
-    return Promise.resolve({
-      accepted: false,
-      reason: 'Fast mode is unavailable in this Teams conversation.',
-    });
+    return null;
   }
   const fastChannelId = getTeamsBaseConversationId(
     params.metadata.communicationChannelId,
   );
-  // Same session identity as the default Fast message path: personal chats
-  // share one session per user (a DM has no threads, even though the reaction
-  // activity replies to the card), channel posts get one per root message.
   const personalChat = isTeamsPersonalConversation(params.activity);
   const threadId = personalChat
     ? undefined
     : params.metadata.communicationThreadId;
   const providerConversationId =
     threadId ?? (personalChat ? fastChannelId : params.currentMessageId);
+  return {
+    surface: 'teams',
+    workspaceId: tenantId,
+    conversationId: `${providerConversationId}:user:${params.mappedUserId}`,
+    replyTarget: {
+      channelId: fastChannelId,
+      ...(threadId ? { threadId } : {}),
+    },
+  };
+}
+
+const TEAMS_FAST_UNAVAILABLE_MESSAGE =
+  "Roomote couldn't start a conversation right now. Please try again in a moment.";
+
+function startTeamsFastSuggestion(params: {
+  activity: TeamsActivity;
+  metadata: TeamsActivityCommunicationMetadata;
+  mappedUserId: string;
+  prompt: string;
+  currentMessageId: string;
+  images?: string[];
+}): Promise<FastAgentStartResult> {
+  const conversation = resolveTeamsFastConversation(params);
+  if (!conversation) {
+    return Promise.resolve({
+      accepted: false,
+      reason: 'Fast mode is unavailable in this Teams conversation.',
+    });
+  }
   return startAcceptedFastAgentTurn({
     run: async ({ onAccepted, onRejected }) => {
       const session = await getOrCreateFastAgentSession({
         userId: params.mappedUserId,
-        conversation: {
-          surface: 'teams',
-          workspaceId: tenantId,
-          conversationId: `${providerConversationId}:user:${params.mappedUserId}`,
-          replyTarget: {
-            channelId: fastChannelId,
-            ...(threadId ? { threadId } : {}),
-          },
-        },
+        conversation,
       });
       return continueFastAgentSurfaceReply({
         sessionId: session.id,
@@ -216,6 +256,7 @@ function startTeamsFastSuggestion(params: {
         senderDisplayName: params.activity.from?.name?.trim() || null,
         question: params.prompt,
         currentMessageId: params.currentMessageId,
+        ...(params.images?.length ? { images: params.images } : {}),
         onAccepted,
         onRejected,
       });
@@ -1438,106 +1479,22 @@ async function fetchTeamsThreadGraphMessagesBestEffort(input: {
 }
 
 /**
- * Best-effort Graph-backed thread history for routing context. Returns the
- * earlier thread messages (oldest first) for channel-thread mentions, or null
- * when history is unavailable so routing falls back to the single triggering
- * message.
+ * Enqueue a Teams task into a workspace that is already decided and post the
+ * task-started acknowledgement. Used by pinned suggestion launches that run
+ * inside a Fast Session.
  */
-async function fetchTeamsThreadMessagesBestEffort(input: {
-  metadata: TeamsActivityCommunicationMetadata;
-  userId: string;
-}): Promise<Array<{ id: string; user: string; text: string }> | null> {
-  const graphMessages = await fetchTeamsThreadGraphMessagesBestEffort(input);
-
-  if (!graphMessages) {
-    return null;
-  }
-
-  const messages = graphMessages
-    .filter((message) => message.text.trim().length > 0)
-    .map((message) => ({
-      id: message.id,
-      user: message.author,
-      text: message.text,
-    }));
-
-  return messages.length > 0 ? messages : null;
-}
-
-async function startNewTeamsTask(input: {
-  activity: TeamsActivity;
+async function launchTeamsTask(input: {
   mappedUserId: string;
   queuedMessage: QueuedTeamsCommunicationMessage;
   metadata: TeamsActivityCommunicationMetadata;
-  workspaceOverride?: TeamsWorkspaceSelection;
+  workspace: TeamsWorkspaceSelection;
+  /** The Fast Session that owns this task; its transcript gets the kickoff. */
+  fastAgentParent?: FastAgentParent;
+  /** Runs inside the launch gate before the child becomes runnable. */
+  beforeEnqueue?: (taskRun: { id: number; taskId: string }) => Promise<void>;
 }) {
   const launchUserId = input.mappedUserId;
-  const threadHistory = await fetchTeamsThreadMessagesBestEffort({
-    metadata: input.metadata,
-    userId: launchUserId,
-  });
-  const triggeringMessage = {
-    user: input.queuedMessage.user,
-    text: input.queuedMessage.text,
-  };
-  // Dedupe by activity id: Graph channel message ids match Bot Framework
-  // activity ids, while text comparison fails because the queued text has the
-  // bot mention stripped and the Graph copy keeps it as `@Bot ...`.
-  const historyMessages = (threadHistory ?? []).map(({ user, text }) => ({
-    user,
-    text,
-  }));
-  const threadMessages =
-    threadHistory &&
-    threadHistory.some((message) => message.id === input.queuedMessage.ts)
-      ? historyMessages
-      : [...historyMessages, triggeringMessage];
-
-  const routingContext = await buildTeamsRoutingContext({
-    userId: launchUserId,
-    taskDescription: input.queuedMessage.text,
-    teamName: input.activity.channelData?.team?.name,
-    channelName:
-      input.activity.channelData?.channel?.name ??
-      input.activity.conversation.name,
-    threadMessages,
-    ...(input.queuedMessage.images?.length
-      ? { images: input.queuedMessage.images }
-      : {}),
-    apiBaseUrl: Env.TRPC_URL ?? Env.R_APP_URL,
-  });
-  const routingDecision = await routeTask(routingContext);
-
-  if (
-    routingDecision.status === 'platform_answer' &&
-    !input.workspaceOverride
-  ) {
-    await postTeamsMessageBestEffort({
-      conversationId: input.metadata.communicationChannelId,
-      threadId: input.metadata.communicationThreadId,
-      serviceUrl: input.metadata.communicationServiceUrl,
-      text: routingDecision.result.answer,
-    });
-
-    return {
-      status: 'replied_inline' as const,
-      routingDecision,
-    };
-  }
-
-  const workspace =
-    input.workspaceOverride ??
-    (routingDecision.status === 'routed'
-      ? await resolveTeamsWorkspace(routingDecision.result.workspace)
-      : {
-          repoForPayload: ALL_REPOSITORIES,
-          workspaceDisplayName: 'all repos',
-        });
-
-  if (!workspace) {
-    throw new Error('Teams task routing selected an unavailable workspace.');
-  }
-
+  const workspace = input.workspace;
   const task: Extract<TaskSpec, { type: typeof TaskPayloadKind.StandardTask }> =
     {
       type: TaskPayloadKind.StandardTask,
@@ -1551,6 +1508,9 @@ async function startNewTeamsTask(input: {
           ? { images: input.queuedMessage.images }
           : {}),
         ...input.metadata,
+        ...(input.fastAgentParent
+          ? buildFastAgentChildTaskMetadata(input.fastAgentParent)
+          : {}),
       },
     };
   const launchResult = await enqueueTask(
@@ -1563,6 +1523,7 @@ async function startNewTeamsTask(input: {
     },
     {
       launchClass: 'human',
+      ...(input.beforeEnqueue ? { beforeEnqueue: input.beforeEnqueue } : {}),
     },
   );
 
@@ -1584,15 +1545,65 @@ async function startNewTeamsTask(input: {
   return {
     status: 'started' as const,
     launchResult,
-    routingDecision,
     workspace,
+  };
+}
+
+/**
+ * A pinned suggestion card already names its workspace, so the owning Fast
+ * Session delegates the task straight away, without a model turn.
+ */
+async function launchPinnedTeamsSuggestionTask(input: {
+  activity: TeamsActivity;
+  metadata: TeamsActivityCommunicationMetadata;
+  mappedUserId: string;
+  suggestionId: string;
+  queuedMessage: QueuedTeamsCommunicationMessage;
+  workspace: TeamsWorkspaceSelection;
+}) {
+  const conversation = resolveTeamsFastConversation({
+    activity: input.activity,
+    metadata: input.metadata,
+    mappedUserId: input.mappedUserId,
+    currentMessageId: input.queuedMessage.ts,
+  });
+  if (!conversation) {
+    throw new Error('Fast mode is unavailable in this Teams conversation.');
+  }
+  let launchResult: { id: number; taskId: string } | null = null;
+  const pinned = await launchPinnedFastSessionTask({
+    userId: input.mappedUserId,
+    senderDisplayName: input.activity.from?.name?.trim() || null,
+    conversation,
+    launchId: `teams-suggestion:${input.suggestionId}:${input.queuedMessage.ts}`,
+    prompt: input.queuedMessage.text,
+    surface: 'teams',
+    kickoffMessage: `Started a task in ${input.workspace.workspaceDisplayName}.`,
+    launch: async ({ parent, postKickoff }) => {
+      const launched = await launchTeamsTask({
+        mappedUserId: input.mappedUserId,
+        queuedMessage: input.queuedMessage,
+        metadata: input.metadata,
+        workspace: input.workspace,
+        fastAgentParent: parent,
+        beforeEnqueue: async () => {
+          await postKickoff();
+        },
+      });
+      launchResult = launched.launchResult;
+      return { success: true, taskId: launched.launchResult.taskId };
+    },
+  });
+  return {
+    status: 'started' as const,
+    launchResult: launchResult ?? { id: pinned.runId, taskId: pinned.taskId },
   };
 }
 
 type ResumePendingTeamsAuthResult =
   | {
       success: true;
-      status: 'queued' | 'resumed' | 'started' | 'replied_inline';
+      status: 'queued' | 'resumed' | 'fast' | 'replied_inline';
       runId?: number;
       taskId?: string;
       taskUrl?: string;
@@ -1602,7 +1613,8 @@ type ResumePendingTeamsAuthResult =
       error:
         | 'invalid_or_expired_auth_token'
         | 'account_link_required'
-        | 'unsupported_activity';
+        | 'unsupported_activity'
+        | 'fast_session_not_accepted';
     };
 
 async function resumePendingTeamsAuthToken(
@@ -1756,49 +1768,25 @@ async function resumePendingTeamsAuthToken(
     }
   }
 
-  let launch: Awaited<ReturnType<typeof startNewTeamsTask>>;
-  try {
-    launch = await startNewTeamsTask({
-      activity: claimedPending.activity,
-      mappedUserId,
-      queuedMessage: queuedMessageWithImages,
-      metadata,
-    });
-  } catch (error) {
-    if (isDeploymentReadOnlyError(error)) {
-      await postTeamsMessageBestEffort({
-        conversationId: metadata.communicationChannelId,
-        threadId: metadata.communicationThreadId,
-        serviceUrl: metadata.communicationServiceUrl,
-        text: MANAGED_DEPLOYMENT_READ_ONLY_MESSAGE,
-      });
+  const fastStart = await startTeamsFastSuggestion({
+    activity: claimedPending.activity,
+    metadata,
+    mappedUserId,
+    prompt: queuedMessageWithImages.text.trim(),
+    currentMessageId: queuedMessageWithImages.ts,
+    ...(queuedMessageWithImages.images?.length
+      ? { images: queuedMessageWithImages.images }
+      : {}),
+  });
 
-      return {
-        success: true,
-        status: 'replied_inline',
-      };
-    }
-
-    throw error;
+  if (!fastStart.accepted) {
+    apiLogger.warn(
+      `[teams] Pending Teams auth request was not accepted by Fast: ${fastStart.reason}`,
+    );
+    return { success: false, error: 'fast_session_not_accepted' };
   }
 
-  if (launch.status === 'replied_inline') {
-    return {
-      success: true,
-      status: 'replied_inline',
-    };
-  }
-
-  return {
-    success: true,
-    status: 'started',
-    runId: launch.launchResult!.id,
-    taskId: launch.launchResult!.taskId,
-    taskUrl: getTaskUrl({
-      taskId: launch.launchResult!.taskId,
-      utm: { source: 'teams', campaign: 'teams.thread_start' },
-    }),
-  };
+  return { success: true, status: 'fast' };
 }
 
 export const teams = new Hono();
@@ -1834,7 +1822,8 @@ teams.post('/auth/resume', async (c) => {
   }
 
   const status =
-    result.error === 'account_link_required'
+    result.error === 'account_link_required' ||
+    result.error === 'fast_session_not_accepted'
       ? 409
       : result.error === 'invalid_or_expired_auth_token'
         ? 404
@@ -2142,15 +2131,16 @@ teams.post('/', async (c) => {
     const suggestionLaunch = await launchClaimedTeamsSuggestion({
       suggestion: claimedSuggestionReaction,
       launchTask: (promptText) =>
-        startNewTeamsTask({
+        launchPinnedTeamsSuggestionTask({
           activity,
+          metadata,
           mappedUserId: mappedUserId!,
+          suggestionId: claimedSuggestionReaction.id,
           queuedMessage: {
             ...queuedMessage!,
             text: promptText,
           } as QueuedTeamsCommunicationMessage,
-          metadata,
-          ...(workspaceOverride ? { workspaceOverride } : {}),
+          workspace: workspaceOverride!,
         }),
       launchFast: (promptText) =>
         startTeamsFastSuggestion({
@@ -2395,12 +2385,13 @@ teams.post('/', async (c) => {
         const suggestionLaunch = await launchClaimedTeamsSuggestion({
           suggestion: resolution.suggestion,
           launchTask: (promptText) =>
-            startNewTeamsTask({
+            launchPinnedTeamsSuggestionTask({
               activity,
-              mappedUserId,
-              queuedMessage: { ...queuedMessage!, text: promptText },
               metadata,
-              ...(workspaceOverride ? { workspaceOverride } : {}),
+              mappedUserId,
+              suggestionId: resolution.suggestion.id,
+              queuedMessage: { ...queuedMessage!, text: promptText },
+              workspace: workspaceOverride!,
             }),
           launchFast: (promptText) =>
             startTeamsFastSuggestion({
@@ -2510,102 +2501,70 @@ teams.post('/', async (c) => {
       }
     }
 
-    if (tenantId) {
-      const providerConversationId =
-        metadata.communicationThreadId ??
-        (activity.conversation.conversationType === 'personal'
-          ? fastChannelId
-          : queuedMessage.ts);
-      const conversation = {
-        surface: 'teams' as const,
-        workspaceId: tenantId,
-        conversationId: `${providerConversationId}:user:${mappedUserId}`,
-        replyTarget: {
-          channelId: fastChannelId,
-          ...(metadata.communicationThreadId
-            ? { threadId: metadata.communicationThreadId }
-            : {}),
-        },
-      };
+    const conversation = resolveTeamsFastConversation({
+      activity,
+      metadata,
+      mappedUserId,
+      currentMessageId: queuedMessage.ts,
+    });
+    if (!conversation) {
+      apiLogger.warn(
+        `[teams] Activity ${queuedMessage.ts} carries no tenant id, so no Fast conversation can own it`,
+      );
+      await postTeamsMessageBestEffort({
+        conversationId: metadata.communicationChannelId,
+        threadId: metadata.communicationThreadId,
+        serviceUrl: metadata.communicationServiceUrl,
+        text: TEAMS_FAST_UNAVAILABLE_MESSAGE,
+      });
+      return c.json({ ok: true, queued: false, fastUnavailable: true });
+    }
 
-      try {
-        const session = await getOrCreateFastAgentSession({
-          userId: mappedUserId,
-          conversation,
-        });
-        void continueFastAgentSurfaceReply({
-          sessionId: session.id,
-          userId: mappedUserId,
-          senderDisplayName: activity.from?.name?.trim() || null,
-          question: queuedMessage.text.trim(),
-          currentMessageId: queuedMessage.ts,
-          ...(queuedMessage.images ? { images: queuedMessage.images } : {}),
-        })
-          .then((continued) => {
-            if (!continued) {
-              apiLogger.warn(
-                `[teams] Default Fast session ${session.id} could not resolve an active delivery route`,
-              );
-            }
-          })
-          .catch((error) => {
-            apiLogger.error(
-              `[teams] Default Fast response failed: ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            );
-          });
+    let session: Awaited<ReturnType<typeof getOrCreateFastAgentSession>>;
+    try {
+      session = await getOrCreateFastAgentSession({
+        userId: mappedUserId,
+        conversation,
+      });
+    } catch (error) {
+      apiLogger.error(
+        `[teams] Failed to initialize the Fast session for conversation ${metadata.communicationChannelId}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      await postTeamsMessageBestEffort({
+        conversationId: metadata.communicationChannelId,
+        threadId: metadata.communicationThreadId,
+        serviceUrl: metadata.communicationServiceUrl,
+        text: TEAMS_FAST_UNAVAILABLE_MESSAGE,
+      });
+      return c.json({ ok: true, queued: false, fastUnavailable: true });
+    }
 
-        return c.json({ ok: true, fastAnswered: true, fastDefaulted: true });
-      } catch (error) {
-        apiLogger.warn(
-          `[teams] Failed to initialize the default Fast session; falling back to task routing: ${
+    void continueFastAgentSurfaceReply({
+      sessionId: session.id,
+      userId: mappedUserId,
+      senderDisplayName: activity.from?.name?.trim() || null,
+      question: queuedMessage.text.trim(),
+      currentMessageId: queuedMessage.ts,
+      ...(queuedMessage.images ? { images: queuedMessage.images } : {}),
+    })
+      .then((continued) => {
+        if (!continued) {
+          apiLogger.warn(
+            `[teams] Fast session ${session.id} could not resolve an active delivery route`,
+          );
+        }
+      })
+      .catch((error) => {
+        apiLogger.error(
+          `[teams] Fast response failed: ${
             error instanceof Error ? error.message : String(error)
           }`,
         );
-      }
-    }
-
-    let launch: Awaited<ReturnType<typeof startNewTeamsTask>>;
-    try {
-      launch = await startNewTeamsTask({
-        activity,
-        mappedUserId,
-        queuedMessage,
-        metadata,
       });
-    } catch (error) {
-      if (isDeploymentReadOnlyError(error)) {
-        await postTeamsMessageBestEffort({
-          conversationId: metadata.communicationChannelId,
-          threadId: metadata.communicationThreadId,
-          serviceUrl: metadata.communicationServiceUrl,
-          text: MANAGED_DEPLOYMENT_READ_ONLY_MESSAGE,
-        });
 
-        return c.json({
-          ok: true,
-          queued: false,
-          repliedInline: true,
-        });
-      }
-
-      throw error;
-    }
-
-    if (launch.status === 'replied_inline') {
-      return c.json({
-        ok: true,
-        queued: false,
-        repliedInline: true,
-      });
-    }
-
-    return c.json({
-      ok: true,
-      started: true,
-      runId: launch.launchResult!.id,
-    });
+    return c.json({ ok: true, fastAnswered: true, fastDefaulted: true });
   }
 
   queuedMessage = await attachTeamsActivityMediaToQueuedMessage(

--- a/apps/api/src/handlers/teams/suggestion-start.ts
+++ b/apps/api/src/handlers/teams/suggestion-start.ts
@@ -252,10 +252,11 @@ function buildTeamsSuggestionTaskPromptText(
   ].join('\n');
 }
 
-/** Minimal structural view of startNewTeamsTask's launch outcomes. */
-type TeamsSuggestionLaunchOutcome =
-  | { status: 'started'; launchResult: { id: number; taskId: string } }
-  | { status: 'replied_inline' };
+/** Minimal structural view of a pinned suggestion launch outcome. */
+type TeamsSuggestionLaunchOutcome = {
+  status: 'started';
+  launchResult: { id: number; taskId: string };
+};
 
 type LaunchClaimedTeamsSuggestionResult =
   | { result: 'started'; runId: number | null }
@@ -282,7 +283,7 @@ type LaunchClaimedTeamsSuggestionResult =
  */
 export async function launchClaimedTeamsSuggestion(params: {
   suggestion: ClaimedTeamsSuggestion;
-  /** Launches the task from the suggestion prompt (startNewTeamsTask). */
+  /** Launches the task from the suggestion prompt inside the owning Session. */
   launchTask: (
     promptText: string,
     target: SuggestedTaskLaunchTarget,
@@ -298,17 +299,16 @@ export async function launchClaimedTeamsSuggestion(params: {
 }): Promise<LaunchClaimedTeamsSuggestionResult> {
   const { suggestion } = params;
   const target = resolveSuggestedTaskLaunchTarget(suggestion);
+  // Cards without a pinned workspace let Fast decide; pinned cards delegate
+  // through the owning Session without a model turn.
+  const usesFastTurn = target.kind === 'fast' || target.kind === 'router';
   const launchResult = await launchClaimedSuggestedTask({
     suggestion,
     policy: {
-      fastEligible: target.kind === 'fast',
-      userDefaultEnabled: target.kind === 'fast',
+      fastEligible: usesFastTurn,
+      userDefaultEnabled: usesFastTurn,
       fastAvailable: Boolean(params.launchFast),
-      ...(target.kind === 'fast'
-        ? { requiredMode: 'fast' as const }
-        : target.kind === 'environment' || target.kind === 'all_repositories'
-          ? { requiredMode: 'coding' as const }
-          : {}),
+      requiredMode: usesFastTurn ? ('fast' as const) : ('coding' as const),
     },
     launch: async (mode) => {
       const promptText = buildTeamsSuggestionTaskPromptText(suggestion);
@@ -327,13 +327,11 @@ export async function launchClaimedTeamsSuggestion(params: {
           : fastStart;
       }
       const launch = await params.launchTask(promptText, target);
-      return launch.status === 'started'
-        ? {
-            accepted: true,
-            runId: launch.launchResult.id,
-            taskId: launch.launchResult.taskId,
-          }
-        : { accepted: false };
+      return {
+        accepted: true,
+        runId: launch.launchResult.id,
+        taskId: launch.launchResult.taskId,
+      };
     },
   });
 

--- a/apps/docs/providers/communications/microsoft-teams.mdx
+++ b/apps/docs/providers/communications/microsoft-teams.mdx
@@ -156,12 +156,12 @@ mention or eligible thread-reply signals used for task entry. Sessions are
 isolated by linked Roomote user even when several people share one Teams thread.
 Unlinked senders receive the account-link prompt instead of starting work.
 
-Replies to Fast messages continue the bound Fast session. Existing task-only
+Replies to Fast messages continue the bound Fast session. Existing task
 conversations keep their active-task and resumable-snapshot behavior, and Fast
-can delegate repository work into those normal Roomote tasks. If Fast cannot
-initialize a new session, Roomote safely falls back to the existing task router.
-Bot Framework and Microsoft Graph images, image-only messages, and transcribed
-audio continue through the same attachment handling.
+delegates repository work into normal Roomote tasks. If Fast cannot start a
+conversation, Roomote says so in the chat instead of starting a task another
+way. Bot Framework and Microsoft Graph images, image-only messages, and
+transcribed audio continue through the same attachment handling.
 
 When a task calls `request_user_input`, Teams accepts a text reply in the same
 conversation. Sensitive input remains in the web app; Teams does not currently


### PR DESCRIPTION
## What changed

- Microsoft Teams no longer starts tasks directly or asks the LLM router where to run them. Every task-entry message from a linked user enters a Fast Session, which answers directly or delegates a task. The old "Fast could not initialize, fall back to the task router" path is gone; the conversation gets a short error instead, including the rare case of an activity with no tenant id.
- The account-link resume (`/api/webhooks/teams/auth/resume`) now enters Fast for the pending request instead of launching a task. It still queues to an active run or resumes a snapshot when the conversation already has one. The result reports `status: 'fast'`; a refused Fast turn returns `fast_session_not_accepted` with 409.
- Pinned suggestion cards (an environment, all repositories, or a bare repository) delegate through the owning Session immediately, without a model turn, using the shared `launchPinnedFastSessionTask` primitive with a Teams launcher that stamps the Session parent on the task. Router-backed cards let Fast decide. A card pinned to a bare repository keeps that repository.
- Removed: the router call, the platform-answer branch, and the Graph thread-history fetch that only fed routing context. `startNewTeamsTask` became `launchTeamsTask`, which requires a decided workspace.
- Kept: active-run follow-ups, `request_user_input` answers, and resumable-snapshot behavior for existing task conversations.
- Docs updated in `apps/docs/providers/communications/microsoft-teams.mdx`.

## Behavior notes

- Provider parity with Discord (#2105) and Telegram (#2111). Slack is next.
- The web OAuth callback treats any non-409 failure from the resume route the same way it did before; the new `fast` status needs no web change.

## Validation

- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` clean
- Teams handler suite: 8 files, 125 tests pass, including the Fast-unavailable reply and the account-link resume entering Fast with the pending image attachment