### PR TITLE
feat: start pinned suggestion tasks in the Session that produced them

### DIFF
--- a/apps/api/src/handlers/discord/__tests__/callback-actions.test.ts
+++ b/apps/api/src/handlers/discord/__tests__/callback-actions.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   handlePrReviewAction: vi.fn(),
   processFastAgentMessage: vi.fn(),
   launchPinned: vi.fn(),
+  getSessionForTask: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
@@ -39,6 +40,7 @@ vi.mock('@roomote/db/server', () => ({
   db: { query: { taskRuns: { findFirst: mocks.findRun } } },
   finalizeWorkItemLaunched: mocks.finalizeWorkItem,
   releaseWorkItemClaim: mocks.releaseWorkItem,
+  getSessionForTask: mocks.getSessionForTask,
 }));
 
 vi.mock('../../tasks/task-stop.js', () => ({ stopTaskRun: mocks.stopTaskRun }));
@@ -269,6 +271,7 @@ describe('Discord component callbacks', () => {
 
   it('starts a coding task for a pinned suggestion', async () => {
     const claimedAt = new Date('2026-08-28T00:00:00.000Z');
+    mocks.getSessionForTask.mockResolvedValue({ id: 'session-origin' });
     mocks.claimSuggestionByMessage.mockResolvedValue({
       outcome: 'claimed',
       suggestion: {
@@ -279,6 +282,7 @@ describe('Discord component callbacks', () => {
         targetRepositoryFullName: null,
         targetEnvironmentId: null,
         usesRouterLaunch: false,
+        sourceTaskId: 'scan-task-1',
         launchClaimedAt: claimedAt,
       },
     });
@@ -317,6 +321,13 @@ describe('Discord component callbacks', () => {
     });
 
     expect(mocks.startNewTask).toHaveBeenCalled();
+    expect(mocks.getSessionForTask).toHaveBeenCalledWith(
+      expect.anything(),
+      'scan-task-1',
+    );
+    expect(mocks.launchPinned).toHaveBeenCalledWith(
+      expect.objectContaining({ originSessionId: 'session-origin' }),
+    );
     expect(mocks.processFastAgentMessage).not.toHaveBeenCalled();
     expect(mocks.finalizeWorkItem).toHaveBeenCalledWith(expect.anything(), {
       id: 'suggestion-1',

--- a/apps/api/src/handlers/discord/callback-actions.ts
+++ b/apps/api/src/handlers/discord/callback-actions.ts
@@ -27,7 +27,10 @@ import { findDiscordMappedUserId } from '@roomote/sdk/server';
 import { parsePrReviewActionCallbackData } from '@roomote/types';
 
 import { apiLogger } from '../../logging.js';
-import { launchClaimedSuggestedTask } from '../tasks/suggestion-launch.js';
+import {
+  launchClaimedSuggestedTask,
+  resolveSuggestionOriginSessionId,
+} from '../tasks/suggestion-launch.js';
 import {
   resolveSuggestedTaskLaunchTarget,
   resolveSuggestedTaskPinnedEnvironmentId,
@@ -430,10 +433,14 @@ async function launchClaimedDiscordSuggestion(input: {
           channel: launchChannel,
           messageId: input.triggerId,
         });
+        const originSessionId = await resolveSuggestionOriginSessionId(
+          suggestion.sourceTaskId,
+        );
         let launchedRunId: number | null = null;
         const pinned = await launchPinnedFastSessionTask({
           userId: input.senderUserId,
           senderDisplayName: queuedMessage.user,
+          ...(originSessionId ? { originSessionId } : {}),
           conversation: {
             surface: 'discord',
             workspaceId: launchChannel.guildId ?? 'dm',

--- a/apps/api/src/handlers/discord/setup-suggestions.ts
+++ b/apps/api/src/handlers/discord/setup-suggestions.ts
@@ -53,6 +53,8 @@ type DiscordSuggestionLaunchClaim = {
   /** The card's explicit launch target, kept even when its environment FK was cleared. */
   launchTarget?: string;
   usesRouterLaunch: boolean;
+  /** The scan or onboarding task that produced the suggestion. */
+  sourceTaskId: string | null;
   launchClaimedAt: Date;
 };
 
@@ -226,6 +228,7 @@ export async function claimDiscordSuggestionLaunch(input: {
       ? { launchTarget: trackedCard.metadata.launchTarget }
       : {}),
     usesRouterLaunch: routed,
+    sourceTaskId: claimed.sourceTaskId,
     launchClaimedAt: claimed.launchClaimedAt,
   };
 }

--- a/apps/api/src/handlers/slack/events/reactions-chat-reply-suggestions.test.ts
+++ b/apps/api/src/handlers/slack/events/reactions-chat-reply-suggestions.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   resolveWorkspace: vi.fn(),
   lookupSlackUserMapping: vi.fn(),
   launchPinned: vi.fn(),
+  getSessionForTask: vi.fn(),
   liveTaskLauncher: vi.fn(),
   launchTask: vi.fn(),
   startFastAgentResponse: vi.fn(),
@@ -31,6 +32,7 @@ const workItem: {
   readinessMessage: null;
   sortOrder: number;
   status: string;
+  sourceTaskId: string | null;
 } = {
   id: 'work-item-1',
   title: 'Add retry telemetry',
@@ -44,6 +46,7 @@ const workItem: {
   readinessMessage: null,
   sortOrder: 0,
   status: 'open',
+  sourceTaskId: 'scan-task-1',
 };
 
 function createWorkItemSelectBuilder() {
@@ -87,8 +90,10 @@ vi.mock('@roomote/db/server', () => ({
     readinessMessage: 'readinessMessage',
     sortOrder: 'sortOrder',
     status: 'status',
+    sourceTaskId: 'sourceTaskId',
   },
   claimWorkItem: mocks.claimWorkItem,
+  getSessionForTask: mocks.getSessionForTask,
   finalizeWorkItemLaunched: mocks.finalizeWorkItemLaunched,
   releaseWorkItemClaim: mocks.releaseWorkItemClaim,
   db: {
@@ -342,6 +347,7 @@ describe('chat reply suggestion reactions', () => {
   });
 
   it('launches a pinned automation suggestion through the owning Session without a Fast turn', async () => {
+    mocks.getSessionForTask.mockResolvedValue({ id: 'session-origin' });
     mocks.trackedMessageFindFirst.mockResolvedValue({
       id: 'tracked-message-1',
       workItemId: 'work-item-1',
@@ -373,10 +379,15 @@ describe('chat reply suggestion reactions', () => {
     });
 
     expect(mocks.resolveWorkspace).toHaveBeenCalled();
+    expect(mocks.getSessionForTask).toHaveBeenCalledWith(
+      expect.anything(),
+      'scan-task-1',
+    );
     expect(mocks.launchPinned).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: 'user-1',
         surface: 'slack',
+        originSessionId: 'session-origin',
         conversation: {
           surface: 'slack',
           workspaceId: 'T1',

--- a/apps/api/src/handlers/slack/events/reactions.ts
+++ b/apps/api/src/handlers/slack/events/reactions.ts
@@ -35,7 +35,10 @@ import {
 
 import { apiLogger } from '../../../logging.js';
 import { getCallRoomoteViaEmojiConfiguration } from '../../call-roomote-via-emoji.js';
-import { launchClaimedSuggestedTask } from '../../tasks/suggestion-launch.js';
+import {
+  launchClaimedSuggestedTask,
+  resolveSuggestionOriginSessionId,
+} from '../../tasks/suggestion-launch.js';
 import { resolveSuggestedTaskLaunchTarget } from '../../tasks/suggestion-launch-target.js';
 import {
   SLACK_SETUP_SUGGESTION_LOCK_PREFIX,
@@ -271,6 +274,7 @@ async function launchTaskSuggestionTaskFromReaction({
       readinessMessage: workItems.readinessMessage,
       sortOrder: workItems.sortOrder,
       status: workItems.status,
+      sourceTaskId: workItems.sourceTaskId,
     })
     .from(workItems)
     .where(eq(workItems.id, workItemId))
@@ -599,8 +603,12 @@ async function launchTaskSuggestionTaskFromReaction({
             reason: UNLINKED_SLACK_ACCOUNT_FAST_LAUNCH_FAILURE,
           };
         }
+        const originSessionId = await resolveSuggestionOriginSessionId(
+          workItem.sourceTaskId,
+        );
         const pinned = await launchPinnedFastSessionTask({
           userId: launchOwnerUserId,
+          ...(originSessionId ? { originSessionId } : {}),
           conversation: {
             surface: 'slack',
             workspaceId: teamId,

--- a/apps/api/src/handlers/tasks/current-thread-suggestion-reaction.ts
+++ b/apps/api/src/handlers/tasks/current-thread-suggestion-reaction.ts
@@ -16,6 +16,8 @@ export type ClaimedCurrentThreadSuggestion = {
   targetEnvironmentId?: string | null;
   usesRouterLaunch?: boolean;
   launchTarget?: string;
+  /** The scan or onboarding task that produced the suggestion. */
+  sourceTaskId?: string | null;
   launchClaimedAt: Date;
 };
 
@@ -96,6 +98,7 @@ export async function claimCurrentThreadSuggestionByMessage(
       ...(typeof trackedCard.metadata?.launchTarget === 'string'
         ? { launchTarget: trackedCard.metadata.launchTarget }
         : {}),
+      sourceTaskId: claimed.sourceTaskId,
       launchClaimedAt: claimed.launchClaimedAt,
     },
   };

--- a/apps/api/src/handlers/tasks/suggestion-launch.test.ts
+++ b/apps/api/src/handlers/tasks/suggestion-launch.test.ts
@@ -2,12 +2,14 @@ const mocks = vi.hoisted(() => ({
   finalize: vi.fn(),
   release: vi.fn(),
   cancel: vi.fn(),
+  getSessionForTask: vi.fn(),
 }));
 
 vi.mock('@roomote/db/server', () => ({
   db: {},
   finalizeWorkItemLaunched: mocks.finalize,
   releaseWorkItemClaim: mocks.release,
+  getSessionForTask: mocks.getSessionForTask,
 }));
 
 vi.mock('./orphaned-work-item-run.js', () => ({
@@ -27,6 +29,7 @@ vi.mock('../fast-agent-entry.js', () => ({
 import {
   launchClaimedSuggestedTask,
   resolveSuggestedTaskLaunchMode,
+  resolveSuggestionOriginSessionId,
 } from './suggestion-launch';
 
 const claimedAt = new Date('2026-08-28T00:00:00.000Z');
@@ -238,5 +241,37 @@ describe('launchClaimedSuggestedTask', () => {
     });
     expect(abort).toHaveBeenCalledOnce();
     expect(mocks.release).toHaveBeenCalled();
+  });
+});
+
+describe('resolveSuggestionOriginSessionId', () => {
+  it('returns the Session that owns the source task', async () => {
+    mocks.getSessionForTask.mockResolvedValue({ id: 'session-origin' });
+
+    await expect(resolveSuggestionOriginSessionId('scan-task-1')).resolves.toBe(
+      'session-origin',
+    );
+    expect(mocks.getSessionForTask).toHaveBeenCalledWith(
+      expect.anything(),
+      'scan-task-1',
+    );
+  });
+
+  it('returns null without a source task, without a Session, or on a lookup failure', async () => {
+    await expect(resolveSuggestionOriginSessionId(null)).resolves.toBeNull();
+    expect(mocks.getSessionForTask).not.toHaveBeenCalled();
+
+    mocks.getSessionForTask.mockResolvedValueOnce(null);
+    await expect(
+      resolveSuggestionOriginSessionId('scan-task-1'),
+    ).resolves.toBeNull();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mocks.getSessionForTask.mockRejectedValueOnce(new Error('db down'));
+    await expect(
+      resolveSuggestionOriginSessionId('scan-task-1'),
+    ).resolves.toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/apps/api/src/handlers/tasks/suggestion-launch.ts
+++ b/apps/api/src/handlers/tasks/suggestion-launch.ts
@@ -2,6 +2,7 @@ import {
   db,
   finalizeWorkItemLaunched,
   releaseWorkItemClaim,
+  getSessionForTask,
 } from '@roomote/db/server';
 import { isDeploymentReadOnlyError } from '@roomote/types';
 
@@ -178,4 +179,26 @@ export async function launchClaimedSuggestedTask(input: {
     taskId: attempt.taskId,
     cancelNote,
   };
+}
+
+/**
+ * The Session that owns the task which produced a suggestion, so a launch
+ * lands next to that scan instead of opening a new Session. Null when the
+ * suggestion has no source task or that task has no Session.
+ */
+export async function resolveSuggestionOriginSessionId(
+  sourceTaskId: string | null | undefined,
+): Promise<string | null> {
+  if (!sourceTaskId) {
+    return null;
+  }
+  try {
+    const session = await getSessionForTask(db, sourceTaskId);
+    return session?.id ?? null;
+  } catch (error) {
+    console.warn(
+      `[suggestion-launch] Could not resolve the origin Session for task ${sourceTaskId}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
 }

--- a/apps/api/src/handlers/teams/__tests__/index.test.ts
+++ b/apps/api/src/handlers/teams/__tests__/index.test.ts
@@ -27,6 +27,7 @@ const {
   launchClaimedTeamsSuggestionMock,
   launchPinnedMock,
   resolveAndClaimTeamsSuggestionReactionMock,
+  getSessionForTaskMock,
   setTrustedRunActingUserMock,
   shouldRouteUnmentionedReplyMock,
   teamsInstallationsTable,
@@ -86,6 +87,7 @@ const {
   launchClaimedTeamsSuggestionMock: vi.fn(),
   launchPinnedMock: vi.fn(),
   resolveAndClaimTeamsSuggestionReactionMock: vi.fn(),
+  getSessionForTaskMock: vi.fn(),
   setTrustedRunActingUserMock: vi.fn(),
   shouldRouteUnmentionedReplyMock: vi.fn(),
   teamsInstallationsTable: {
@@ -140,6 +142,7 @@ vi.mock('../suggestion-start.js', () => ({
 vi.mock('@roomote/db/server', () => ({
   and: vi.fn((...conditions: unknown[]) => ({ and: conditions })),
   setTrustedRunActingUser: setTrustedRunActingUserMock,
+  getSessionForTask: getSessionForTaskMock,
   claimPendingOutOfBandTaskMessages: claimPendingOutOfBandMock,
   releaseClaimedOutOfBandTaskMessages: releaseClaimedOutOfBandMock,
   resolveTeamsBotRuntimeCredentials: vi.fn(async () => ({
@@ -607,9 +610,11 @@ describe('Teams webhook handler', () => {
         investigationContext: null,
         targetRepositoryFullName: 'acme/app',
         targetEnvironmentId: null,
+        sourceTaskId: 'scan-task-1',
         launchClaimedAt: new Date('2026-08-07T00:00:00.000Z'),
       },
     });
+    getSessionForTaskMock.mockResolvedValue({ id: 'session-origin' });
     // The kickoff gate must run inside the enqueue, before the child becomes
     // runnable; model both sides so the wiring is exercised, not assumed.
     const postKickoff = vi.fn().mockResolvedValue(undefined);
@@ -696,6 +701,7 @@ describe('Teams webhook handler', () => {
         userId: 'mapped-user-1',
         surface: 'teams',
         prompt: 'Fix the flaky test',
+        originSessionId: 'session-origin',
         conversation: expect.objectContaining({
           surface: 'teams',
           workspaceId: 'tenant-1',

--- a/apps/api/src/handlers/teams/index.ts
+++ b/apps/api/src/handlers/teams/index.ts
@@ -117,6 +117,7 @@ import {
   resolveAndClaimTeamsSuggestionReaction,
   type ClaimedTeamsSuggestion,
 } from './suggestion-start.js';
+import { resolveSuggestionOriginSessionId } from '../tasks/suggestion-launch.js';
 import { shouldRouteUnmentionedTeamsThreadReplyToAgent } from './unmentioned-thread-reply.js';
 
 const TEAMS_ACTIVITY_DEDUP_PREFIX = 'teams:activity:';
@@ -1558,6 +1559,8 @@ async function launchPinnedTeamsSuggestionTask(input: {
   metadata: TeamsActivityCommunicationMetadata;
   mappedUserId: string;
   suggestionId: string;
+  /** The task that produced the suggestion; its Session hosts the launch. */
+  sourceTaskId?: string | null;
   queuedMessage: QueuedTeamsCommunicationMessage;
   workspace: TeamsWorkspaceSelection;
 }) {
@@ -1570,11 +1573,15 @@ async function launchPinnedTeamsSuggestionTask(input: {
   if (!conversation) {
     throw new Error('Fast mode is unavailable in this Teams conversation.');
   }
+  const originSessionId = await resolveSuggestionOriginSessionId(
+    input.sourceTaskId,
+  );
   let launchResult: { id: number; taskId: string } | null = null;
   const pinned = await launchPinnedFastSessionTask({
     userId: input.mappedUserId,
     senderDisplayName: input.activity.from?.name?.trim() || null,
     conversation,
+    ...(originSessionId ? { originSessionId } : {}),
     launchId: `teams-suggestion:${input.suggestionId}:${input.queuedMessage.ts}`,
     prompt: input.queuedMessage.text,
     surface: 'teams',
@@ -2136,6 +2143,7 @@ teams.post('/', async (c) => {
           metadata,
           mappedUserId: mappedUserId!,
           suggestionId: claimedSuggestionReaction.id,
+          sourceTaskId: claimedSuggestionReaction.sourceTaskId,
           queuedMessage: {
             ...queuedMessage!,
             text: promptText,
@@ -2390,6 +2398,7 @@ teams.post('/', async (c) => {
               metadata,
               mappedUserId,
               suggestionId: resolution.suggestion.id,
+              sourceTaskId: resolution.suggestion.sourceTaskId,
               queuedMessage: { ...queuedMessage!, text: promptText },
               workspace: workspaceOverride!,
             }),

--- a/apps/api/src/handlers/teams/suggestion-start.ts
+++ b/apps/api/src/handlers/teams/suggestion-start.ts
@@ -79,6 +79,8 @@ export type ClaimedTeamsSuggestion = {
   targetEnvironmentId?: string | null;
   usesRouterLaunch?: boolean;
   launchTarget?: string;
+  /** The scan or onboarding task that produced the suggestion. */
+  sourceTaskId?: string | null;
   launchClaimedAt: Date;
 };
 
@@ -206,6 +208,7 @@ export async function resolveAndClaimTeamsSuggestionStart(input: {
       investigationContext: claimed.investigationContext,
       targetRepositoryFullName: claimed.targetRepositoryFullName,
       targetEnvironmentId: claimed.targetEnvironmentId,
+      sourceTaskId: claimed.sourceTaskId,
       launchClaimedAt: claimed.launchClaimedAt,
     },
   };

--- a/apps/api/src/handlers/telegram/__tests__/callback-actions.test.ts
+++ b/apps/api/src/handlers/telegram/__tests__/callback-actions.test.ts
@@ -23,6 +23,7 @@ const {
   resolveTelegramWorkspaceMock,
   launchTelegramTaskMock,
   launchPinnedMock,
+  getSessionForTaskMock,
   continueFastAgentSurfaceReplyMock,
   getOrCreateFastAgentSessionMock,
   fastAbortMock,
@@ -40,6 +41,7 @@ const {
   resolveTelegramWorkspaceMock: vi.fn(),
   launchTelegramTaskMock: vi.fn(),
   launchPinnedMock: vi.fn(),
+  getSessionForTaskMock: vi.fn(),
   continueFastAgentSurfaceReplyMock: vi.fn(),
   getOrCreateFastAgentSessionMock: vi.fn(),
   fastAbortMock: vi.fn(),
@@ -73,6 +75,7 @@ vi.mock('@roomote/db/server', () => ({
   db: { query: { taskRuns: { findFirst: vi.fn() } } },
   finalizeWorkItemLaunched: finalizeWorkItemLaunchedMock,
   releaseWorkItemClaim: releaseWorkItemClaimMock,
+  getSessionForTask: getSessionForTaskMock,
 }));
 
 vi.mock('../../../logging.js', () => ({ apiLogger: apiLoggerMock }));
@@ -149,6 +152,7 @@ beforeEach(() => {
     investigationContext: null,
     targetRepositoryFullName: '__all_repositories__',
     launchTarget: '__all_repositories__',
+    sourceTaskId: 'scan-task-1',
     launchClaimedAt: CLAIMED_AT,
   });
   findCurrentThreadSuggestionIdByMessageMock.mockResolvedValue(WORK_ITEM_ID);
@@ -161,9 +165,11 @@ beforeEach(() => {
       investigationContext: null,
       targetRepositoryFullName: '__all_repositories__',
       launchTarget: '__all_repositories__',
+      sourceTaskId: 'scan-task-1',
       launchClaimedAt: CLAIMED_AT,
     },
   });
+  getSessionForTaskMock.mockResolvedValue({ id: 'session-origin' });
   finalizeWorkItemLaunchedMock.mockResolvedValue(true);
   launchTelegramTaskMock.mockResolvedValue({ id: 7, taskId: 'task-1' });
   // The pinned-launch primitive runs the surface launcher inside a Session.
@@ -264,6 +270,14 @@ describe('handleTelegramCallbackQuery suggestion launch lifecycle', () => {
 
   it('starts a suggestion in a fresh topic while preserving its source topic for fallback', async () => {
     await handleTelegramCallbackQuery(buildSuggestionQuery(44));
+
+    expect(getSessionForTaskMock).toHaveBeenCalledWith(
+      expect.anything(),
+      'scan-task-1',
+    );
+    expect(launchPinnedMock).toHaveBeenCalledWith(
+      expect.objectContaining({ originSessionId: 'session-origin' }),
+    );
 
     expect(launchTelegramTaskMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/api/src/handlers/telegram/callback-actions.ts
+++ b/apps/api/src/handlers/telegram/callback-actions.ts
@@ -29,7 +29,10 @@ import {
 
 import { apiLogger } from '../../logging.js';
 import { startAcceptedFastAgentTurn } from '../fast-agent-entry.js';
-import { launchClaimedSuggestedTask } from '../tasks/suggestion-launch.js';
+import {
+  launchClaimedSuggestedTask,
+  resolveSuggestionOriginSessionId,
+} from '../tasks/suggestion-launch.js';
 import {
   resolveSuggestedTaskLaunchTarget,
   resolveSuggestedTaskPinnedEnvironmentId,
@@ -383,11 +386,15 @@ async function handleSuggestionLaunchCallback(params: {
           threadId,
           forceNewTopic: true,
         });
+        const originSessionId = await resolveSuggestionOriginSessionId(
+          suggestion.sourceTaskId,
+        );
         let launchedRunId: number | null = null;
         const pinned = await launchPinnedFastSessionTask({
           userId: senderUserId,
           senderDisplayName: queuedMessage.user,
           conversation,
+          ...(originSessionId ? { originSessionId } : {}),
           launchId: `telegram-suggestion:${params.suggestionId}:${messageId}`,
           prompt: promptText,
           surface: 'telegram',

--- a/apps/api/src/handlers/telegram/setup-suggestions.ts
+++ b/apps/api/src/handlers/telegram/setup-suggestions.ts
@@ -166,6 +166,8 @@ export async function claimTelegramSuggestionLaunch(input: {
   /** The card's explicit launch target, kept even when its environment FK was cleared. */
   launchTarget?: string;
   usesRouterLaunch: boolean;
+  /** The scan or onboarding task that produced the suggestion. */
+  sourceTaskId: string | null;
   launchClaimedAt: Date;
 } | null> {
   // Scope: a suggestion card for this work item must have been posted in this
@@ -207,6 +209,7 @@ export async function claimTelegramSuggestionLaunch(input: {
       ? { launchTarget: trackedCard.metadata.launchTarget }
       : {}),
     usesRouterLaunch: routed,
+    sourceTaskId: claimed.sourceTaskId,
     launchClaimedAt: claimed.launchClaimedAt,
   };
 }

--- a/apps/docs/communications.mdx
+++ b/apps/docs/communications.mdx
@@ -54,7 +54,10 @@ the exact suggestion you want by reacting to its message:
 - on Telegram, add a new 👍 reaction or use the suggestion's **Start** button
 
 The person starting the suggestion must have a linked Roomote account. Roomote
-also needs an environment that can run the suggestion's target repository.
+also needs an environment that can run the suggestion's target repository. A
+suggestion with a pinned workspace starts its task inside the Session that
+produced the report, so the task, the report, and any follow-up conversation
+share one transcript.
 Configured **Call Roomote via emoji** automations are separate from these
 suggestion reactions.
 

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
@@ -111,6 +111,72 @@ describe('Fast conversation repository', () => {
     },
   );
 
+  it('binds a new conversation to the Session it was created for', async () => {
+    const user = await createUser();
+    const [origin] = await db
+      .insert(sessions)
+      .values({
+        title: 'Weekly scan',
+        ownerKind: 'user',
+        ownerUserId: user.id,
+        sourceSurface: 'web',
+        sourceTrigger: 'manual',
+        visibility: 'visible',
+        activityAt: Math.floor(Date.now() / 1000),
+        cachedStatus: 'ready',
+      })
+      .returning({ id: sessions.id });
+    const conversation = {
+      surface: 'slack' as const,
+      workspaceId: 'team-origin-test',
+      conversationId: `thread-origin-${origin!.id}`,
+      replyTarget: {
+        channelId: 'channel-origin-test',
+        threadId: `thread-origin-${origin!.id}`,
+      },
+    };
+
+    const created = await fastAgentConversationRepository.getOrCreate({
+      userId: user.id,
+      conversation,
+      sessionId: origin!.id,
+    });
+    const [bound] = await db
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(eq(sessions.fastConversationId, created.id));
+    expect(bound?.id).toBe(origin!.id);
+
+    // A second Session cannot claim a conversation that already exists.
+    const [other] = await db
+      .insert(sessions)
+      .values({
+        title: 'Another scan',
+        ownerKind: 'user',
+        ownerUserId: user.id,
+        sourceSurface: 'web',
+        sourceTrigger: 'manual',
+        visibility: 'visible',
+        activityAt: Math.floor(Date.now() / 1000),
+        cachedStatus: 'ready',
+      })
+      .returning({ id: sessions.id });
+    const reused = await fastAgentConversationRepository.getOrCreate({
+      userId: user.id,
+      conversation,
+      sessionId: other!.id,
+    });
+    expect(reused.id).toBe(created.id);
+    const [otherRow] = await db
+      .select({ fastConversationId: sessions.fastConversationId })
+      .from(sessions)
+      .where(eq(sessions.id, other!.id));
+    expect(otherRow?.fastConversationId).toBeNull();
+    await db
+      .delete(sessions)
+      .where(inArray(sessions.id, [origin!.id, other!.id]));
+  });
+
   it('converges concurrent creation on one provider-neutral row', async () => {
     const user = await createUser();
     const sessions = await Promise.all(

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
@@ -177,6 +177,56 @@ describe('Fast conversation repository', () => {
       .where(inArray(sessions.id, [origin!.id, other!.id]));
   });
 
+  it('converges concurrent launches into one Session on the conversation that bound first', async () => {
+    const user = await createUser();
+    const [origin] = await db
+      .insert(sessions)
+      .values({
+        title: 'Weekly scan',
+        ownerKind: 'user',
+        ownerUserId: user.id,
+        sourceSurface: 'web',
+        sourceTrigger: 'manual',
+        visibility: 'visible',
+        activityAt: Math.floor(Date.now() / 1000),
+        cachedStatus: 'ready',
+      })
+      .returning({ id: sessions.id });
+    const identity = (index: number) => ({
+      surface: 'slack' as const,
+      workspaceId: 'team-origin-race-test',
+      conversationId: `thread-origin-race-${origin!.id}-${index}`,
+      replyTarget: {
+        channelId: 'channel-origin-race-test',
+        threadId: `thread-origin-race-${origin!.id}-${index}`,
+      },
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 6 }, (_, index) =>
+        fastAgentConversationRepository.getOrCreate({
+          userId: user.id,
+          conversation: identity(index),
+          sessionId: origin!.id,
+        }),
+      ),
+    );
+
+    expect(new Set(results.map(({ id }) => id)).size).toBe(1);
+    expect(results.filter(({ created }) => created)).toHaveLength(1);
+    const [bound] = await db
+      .select({ fastConversationId: sessions.fastConversationId })
+      .from(sessions)
+      .where(eq(sessions.id, origin!.id));
+    expect(bound?.fastConversationId).toBe(results[0]!.id);
+    const rows = await db
+      .select({ id: fastAgentConversations.id })
+      .from(fastAgentConversations)
+      .where(eq(fastAgentConversations.workspaceId, 'team-origin-race-test'));
+    expect(rows).toHaveLength(1);
+    await db.delete(sessions).where(eq(sessions.id, origin!.id));
+  });
+
   it('converges concurrent creation on one provider-neutral row', async () => {
     const user = await createUser();
     const sessions = await Promise.all(

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-pinned-launch.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-pinned-launch.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   upsertFastAgentMessage: vi.fn(),
   findById: vi.fn(),
   taskRunsFindFirst: vi.fn(),
+  sessionsFindFirst: vi.fn(),
   getSessionForFastConversation: vi.fn(),
 }));
 
@@ -32,7 +33,12 @@ vi.mock('../fast-agent-conversation-repository', () => ({
 }));
 
 vi.mock('@roomote/db/server', () => ({
-  db: { query: { taskRuns: { findFirst: mocks.taskRunsFindFirst } } },
+  db: {
+    query: {
+      taskRuns: { findFirst: mocks.taskRunsFindFirst },
+      sessions: { findFirst: mocks.sessionsFindFirst },
+    },
+  },
   and: vi.fn((...parts: unknown[]) => ({ and: parts })),
   desc: vi.fn((column: unknown) => ({ desc: column })),
   eq: vi.fn((left: unknown, right: unknown) => ({ eq: [left, right] })),
@@ -51,6 +57,7 @@ vi.mock('@roomote/db/server', () => ({
     payload: 'task_runs.payload',
     canceledAt: 'task_runs.canceled_at',
   },
+  sessions: { id: 'sessions.id' },
   getSessionForFastConversation: mocks.getSessionForFastConversation,
 }));
 
@@ -104,6 +111,7 @@ describe('launchPinnedFastSessionTask', () => {
       },
     );
     mocks.taskRunsFindFirst.mockResolvedValue({ id: 7 });
+    mocks.sessionsFindFirst.mockResolvedValue(null);
     mocks.getSessionForFastConversation.mockResolvedValue({ id: 'session-1' });
     mocks.releaseLock.mockResolvedValue(undefined);
     mocks.acquireRedisLock.mockResolvedValue(mocks.releaseLock);
@@ -199,6 +207,117 @@ describe('launchPinnedFastSessionTask', () => {
       }),
       expect.objectContaining({ beforeEnqueue: expect.any(Function) }),
     );
+  });
+
+  it("launches in the origin Session's own Fast conversation when it has one", async () => {
+    mocks.sessionsFindFirst.mockResolvedValue({
+      id: 'session-origin',
+      fastConversationId: 'fast-origin',
+    });
+    mocks.findById.mockResolvedValue({
+      id: 'fast-origin',
+      userId: 'user-2',
+      conversation: {
+        surface: 'slack',
+        workspaceId: 'T1',
+        conversationId: '100.1',
+        replyTarget: { channelId: 'C1', threadId: '100.1' },
+      },
+    });
+    mocks.getSessionForFastConversation.mockResolvedValue({
+      id: 'session-origin',
+    });
+
+    const result = await launchPinnedFastSessionTask({
+      userId: 'user-1',
+      originSessionId: 'session-origin',
+      conversation: {
+        surface: 'slack',
+        workspaceId: 'T1',
+        conversationId: '200.1',
+        replyTarget: { channelId: 'C1', threadId: '200.1' },
+      },
+      launchId: 'launch-origin',
+      prompt: 'Fix the flaky test',
+      task,
+      surface: 'slack',
+      kickoffMessage: 'Started a task in Backend.',
+    });
+
+    expect(result).toMatchObject({
+      sessionId: 'session-origin',
+      fastConversationId: 'fast-origin',
+    });
+    expect(mocks.findById).toHaveBeenCalledWith({ id: 'fast-origin' });
+    expect(mocks.getOrCreateFastAgentSession).not.toHaveBeenCalled();
+    expect(mocks.upsertFastAgentMessage.mock.calls[0]?.[0]).toMatchObject({
+      sessionId: 'fast-origin',
+    });
+  });
+
+  it("binds the caller's conversation to an origin Session that has none", async () => {
+    mocks.sessionsFindFirst.mockResolvedValue({
+      id: 'session-origin',
+      fastConversationId: null,
+    });
+    const conversation = {
+      surface: 'slack' as const,
+      workspaceId: 'T1',
+      conversationId: '200.1',
+      replyTarget: { channelId: 'C1', threadId: '200.1' },
+    };
+    mocks.getOrCreateFastAgentSession.mockResolvedValue({
+      id: 'fast-bound',
+      created: true,
+      conversation,
+    });
+
+    await launchPinnedFastSessionTask({
+      userId: 'user-1',
+      originSessionId: 'session-origin',
+      conversation,
+      launchId: 'launch-origin',
+      prompt: 'Fix the flaky test',
+      task,
+      surface: 'slack',
+      kickoffMessage: 'Started a task in Backend.',
+    });
+
+    expect(mocks.getOrCreateFastAgentSession).toHaveBeenCalledWith({
+      userId: 'user-1',
+      conversation,
+      sessionId: 'session-origin',
+    });
+    expect(mocks.findById).not.toHaveBeenCalled();
+    expect(mocks.enqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            fastAgentParent: { sessionId: 'fast-bound', conversation },
+          }),
+        }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('falls back to a fresh Session when the origin Session is gone', async () => {
+    mocks.sessionsFindFirst.mockResolvedValue(null);
+
+    await launchPinnedFastSessionTask({
+      userId: 'user-1',
+      originSessionId: 'session-missing',
+      launchId: 'launch-origin',
+      prompt: 'Fix the flaky test',
+      task,
+      surface: 'web',
+      kickoffMessage: 'Started a task in Backend.',
+    });
+
+    expect(mocks.getOrCreateFastAgentSession).toHaveBeenCalledWith({
+      userId: 'user-1',
+      conversation: expect.objectContaining({ surface: 'web' }),
+    });
   });
 
   it('launches inside an existing Fast conversation and skips the request row for a blank workspace', async () => {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
@@ -719,6 +719,26 @@ export const fastAgentConversationRepository: FastAgentConversationRepository =
           });
         }
 
+        // Launches into one Session with different conversation identities
+        // must agree on a single conversation. Serialize on the Session and
+        // reuse the conversation a concurrent launch already bound to it.
+        if (!record && sessionId) {
+          await tx.execute(
+            sql`select pg_advisory_xact_lock(hashtextextended(${`fast-agent-session-binding:${sessionId}`}, 0))`,
+          );
+          const [bound] = await tx
+            .select({ fastConversationId: sessions.fastConversationId })
+            .from(sessions)
+            .where(eq(sessions.id, sessionId))
+            .limit(1);
+          if (bound?.fastConversationId) {
+            return {
+              ...(await loadConversationRecord(tx, bound.fastConversationId)),
+              created: false,
+            };
+          }
+        }
+
         if (!record) {
           const [inserted] = await tx
             .insert(fastAgentConversations)

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
@@ -10,6 +10,7 @@ import {
   fastAgentParentEvents,
   ensureSessionForFastConversation,
   advanceSessionNotifiedCursor,
+  attachFastConversationToSession,
   advanceSessionReadCursor,
   getSessionForFastConversation,
   gt,
@@ -555,6 +556,12 @@ export interface FastAgentConversationRepository {
   getOrCreate(input: {
     userId: string;
     conversation: FastAgentConversation;
+    /**
+     * Session to bind a newly created conversation to, when that Session has
+     * no conversation yet. A conversation that already exists keeps its own
+     * Session.
+     */
+    sessionId?: string;
   }): Promise<FastAgentConversationGetOrCreateResult>;
   findById(input: {
     id: string;
@@ -694,7 +701,7 @@ async function loadConversationRecord(
 
 export const fastAgentConversationRepository: FastAgentConversationRepository =
   {
-    async getOrCreate({ userId, conversation }) {
+    async getOrCreate({ userId, conversation, sessionId }) {
       return db.transaction(async (tx) => {
         await tx.execute(
           sql`select pg_advisory_xact_lock(hashtextextended(${buildIdentityKey(conversation)}, 0))`,
@@ -769,10 +776,20 @@ export const fastAgentConversationRepository: FastAgentConversationRepository =
           .where(eq(fastAgentConversations.id, record.id))
           .returning();
 
-        await ensureSessionForFastConversation(tx, updated?.id ?? record.id);
+        const conversationId = updated?.id ?? record.id;
+        const attached =
+          created && sessionId
+            ? await attachFastConversationToSession(tx, {
+                sessionId,
+                fastConversationId: conversationId,
+              })
+            : null;
+        if (!attached) {
+          await ensureSessionForFastConversation(tx, conversationId);
+        }
 
         return {
-          ...(await loadConversationRecord(tx, updated?.id ?? record.id)),
+          ...(await loadConversationRecord(tx, conversationId)),
           created,
         };
       });

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-pinned-launch.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-pinned-launch.ts
@@ -9,6 +9,7 @@ import {
   eq,
   getSessionForFastConversation,
   isNull,
+  sessions,
   sql,
   taskRuns,
 } from '@roomote/db/server';
@@ -47,6 +48,14 @@ export type PinnedFastSessionLaunchInput = {
    * surfaces that bind the Session to a channel or thread.
    */
   conversation?: FastAgentConversation;
+  /**
+   * The Session the request came from, for example the one that owns the
+   * scan that produced a suggestion. The launch lands there: in its Fast
+   * conversation when it has one, otherwise `conversation` becomes that
+   * Session's conversation. Ignored when `fastConversationId` is set, and
+   * when `conversation` already belongs to another Session.
+   */
+  originSessionId?: string | null;
   /**
    * Idempotency key for the launch. Replays with the same id reuse the task
    * the first attempt created and never write a second transcript entry.
@@ -140,6 +149,49 @@ async function findConversationTargetForLaunchKey(
   return target;
 }
 
+function defaultWebConversation(userId: string): FastAgentConversation {
+  return {
+    surface: 'web',
+    workspaceId: userId,
+    conversationId: randomUUID(),
+  };
+}
+
+/**
+ * The origin Session's own conversation when it has one; otherwise the
+ * caller's conversation identity is created and bound to that Session. A
+ * conversation that already exists elsewhere keeps its Session, so the
+ * launch still has a home even when the origin cannot take it.
+ */
+async function findOriginConversationTarget(
+  input: PinnedFastSessionLaunchInput,
+  originSessionId: string,
+): Promise<ConversationTarget | null> {
+  const session = await db.query.sessions.findFirst({
+    where: eq(sessions.id, originSessionId),
+    columns: { id: true, fastConversationId: true },
+  });
+  if (!session) {
+    return null;
+  }
+  if (session.fastConversationId) {
+    const target = await findConversationTargetById(session.fastConversationId);
+    if (target) {
+      return target;
+    }
+  }
+  const created = await getOrCreateFastAgentSession({
+    userId: input.userId,
+    conversation: input.conversation ?? defaultWebConversation(input.userId),
+    sessionId: session.id,
+  });
+  return {
+    id: created.id,
+    userId: input.userId,
+    conversation: created.conversation,
+  };
+}
+
 async function resolveConversationTarget(
   input: PinnedFastSessionLaunchInput,
   launchIdempotencyKey: string,
@@ -160,13 +212,19 @@ async function resolveConversationTarget(
     return replayed;
   }
 
+  if (input.originSessionId) {
+    const origin = await findOriginConversationTarget(
+      input,
+      input.originSessionId,
+    );
+    if (origin) {
+      return origin;
+    }
+  }
+
   const created = await getOrCreateFastAgentSession({
     userId: input.userId,
-    conversation: input.conversation ?? {
-      surface: 'web',
-      workspaceId: input.userId,
-      conversationId: randomUUID(),
-    },
+    conversation: input.conversation ?? defaultWebConversation(input.userId),
   });
   return {
     id: created.id,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-session.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-session.ts
@@ -36,11 +36,18 @@ export type FastAgentActiveTask = {
 export async function getOrCreateFastAgentSession({
   userId,
   conversation,
+  sessionId,
 }: {
   userId: string;
   conversation: FastAgentConversation;
+  /** Session to bind a newly created conversation to; see the repository. */
+  sessionId?: string;
 }): Promise<FastAgentSessionRecord> {
-  return fastAgentConversationRepository.getOrCreate({ userId, conversation });
+  return fastAgentConversationRepository.getOrCreate({
+    userId,
+    conversation,
+    ...(sessionId ? { sessionId } : {}),
+  });
 }
 
 export async function hasFastAgentSession(

--- a/packages/db/src/lib/sessions.ts
+++ b/packages/db/src/lib/sessions.ts
@@ -441,6 +441,30 @@ export async function ensureSessionForTask(
   return touchSessionActivity(tx, session.id, task.activityAt);
 }
 
+/**
+ * Binds a Fast conversation to a Session that has none yet, so a launch can
+ * land in the Session that produced the request instead of opening a new
+ * one. Returns null when the Session is missing or already has a
+ * conversation; the caller then keeps the conversation's own Session.
+ */
+export async function attachFastConversationToSession(
+  tx: DatabaseOrTransaction,
+  input: { sessionId: string; fastConversationId: string },
+): Promise<Session | null> {
+  const [updated] = await tx
+    .update(sessions)
+    .set({ fastConversationId: input.fastConversationId })
+    .where(
+      and(
+        eq(sessions.id, input.sessionId),
+        isNull(sessions.fastConversationId),
+      ),
+    )
+    .returning();
+
+  return updated ?? null;
+}
+
 export async function getSessionForTask(
   tx: DatabaseOrTransaction,
   taskId: string,


### PR DESCRIPTION
## What changed

- `launchPinnedFastSessionTask` accepts `originSessionId`. The launch lands in that Session's Fast conversation when it has one; otherwise the caller's conversation identity (the suggestion card's thread) is created and bound to that Session. A conversation that already belongs to another Session keeps it, and a missing origin falls back to the previous behavior.
- `fastAgentConversationRepository.getOrCreate` takes an optional `sessionId`, backed by a new `attachFastConversationToSession` db helper that binds a conversation only to a Session that has none.
- Suggestion claims on Discord, Telegram, Teams, and the shared current-thread reaction claim now return the work item's `sourceTaskId`; Slack reads it from the work item row. Each pinned launch resolves the origin Session through the new `resolveSuggestionOriginSessionId` helper.
- Docs: communications page notes that pinned suggestions start inside the Session that produced the report.

## Why

Suggestions come from a scan or report task that already lives in a Session. Starting the follow-up task in a fresh Session bound to the card's thread split the report, the task, and the conversation across two transcripts. Now they share one.

## Validation

- Repository test binds a new conversation to the Session it was created for and refuses to rebind an existing conversation.
- Pinned-launch tests cover an origin Session with a conversation, one without, and a missing origin.
- Provider tests (Discord, Telegram, Teams, Slack) assert the origin Session is resolved from the source task and passed to the launch.
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip`, and the api, cloud-agents, and db suites pass.