### PR TITLE
feat: GitHub pull request and issue mentions enter Fast Sessions

### DIFF
--- a/apps/api/src/handlers/github/__tests__/handleGitHubIssueComment.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handleGitHubIssueComment.test.ts
@@ -1,56 +1,13 @@
-const {
-  mockGetGitHubAutomationTargets,
-  mockGetInstallationOctokit,
-  mockEnqueueTask,
-  mockGetTaskUrl,
-  mockDbSelect,
-  mockFindReusableGitHubIssueTaskOwner,
-  mockSendMessageToTask,
-  mockSteerMessageToTask,
-  mockFindLatestTaskRun,
-} = vi.hoisted(() => ({
-  mockGetGitHubAutomationTargets: vi.fn(),
-  mockGetInstallationOctokit: vi.fn(),
-  mockEnqueueTask: vi.fn(),
-  mockGetTaskUrl: vi.fn(),
-  mockDbSelect: vi.fn(),
-  mockFindReusableGitHubIssueTaskOwner: vi.fn(),
-  mockSendMessageToTask: vi.fn(),
-  mockSteerMessageToTask: vi.fn(),
-  mockFindLatestTaskRun: vi.fn(),
-}));
-
-// Prompt-framing fakes use distinctive markers so tests can assert the
-// handler routes each piece of text through the right builder; the real
-// escaping/wrapping behavior is unit-tested in @roomote/cloud-agents.
-vi.mock('@roomote/cloud-agents/server', () => ({
-  enqueueTask: mockEnqueueTask,
-  getTaskUrl: mockGetTaskUrl,
-  buildMentionRequestBlock: (text: string) =>
-    `<mention_request>${text}</mention_request>`,
-  buildUntrustedExternalContentBlock: ({
-    source,
-    text,
-  }: {
-    source: string;
-    text: string;
-  }) =>
-    `<untrusted_external_content source="${source}">${text}</untrusted_external_content>`,
-  buildUntrustedContentPolicy: () => '<untrusted_content_policy/>',
-  escapeTaskContextText: (value: string) => value,
+const mocks = vi.hoisted(() => ({
+  getGitHubAutomationTargets: vi.fn(),
+  getInstallationOctokit: vi.fn(),
+  findReusableGitHubIssueTaskOwner: vi.fn(),
+  startSourceControlFastSessionTurn: vi.fn(),
+  fetchGitHubLinkedReferences: vi.fn(),
 }));
 
 vi.mock('@roomote/db/server', () => ({
-  db: {
-    select: mockDbSelect,
-  },
-  environmentRepositoryMappings: {
-    environmentId: 'environmentId',
-    repositoryId: 'repositoryId',
-  },
-  eq: vi.fn((...args: unknown[]) => args),
-  asc: vi.fn((value: unknown) => value),
-  findReusableGitHubIssueTaskOwner: mockFindReusableGitHubIssueTaskOwner,
+  findReusableGitHubIssueTaskOwner: mocks.findReusableGitHubIssueTaskOwner,
 }));
 
 vi.mock('@roomote/github', () => ({
@@ -59,20 +16,21 @@ vi.mock('@roomote/github', () => ({
   },
   getEffectiveGitHubAppSlug: vi.fn(() => 'roomote'),
   isGitHubRoomoteMentionEnabled: vi.fn(() => true),
-  getInstallationOctokit: mockGetInstallationOctokit,
+  getInstallationOctokit: mocks.getInstallationOctokit,
+}));
+
+vi.mock('@roomote/sdk/server', () => ({
+  startSourceControlFastSessionTurn: mocks.startSourceControlFastSessionTurn,
 }));
 
 vi.mock('../getGitHubAutomationTargets', () => ({
-  getGitHubAutomationTargets: mockGetGitHubAutomationTargets,
+  getGitHubAutomationTargets: mocks.getGitHubAutomationTargets,
 }));
 
-vi.mock('../../tasks/sendMessageToTask', () => ({
-  sendMessageToTask: mockSendMessageToTask,
-  steerMessageToTask: mockSteerMessageToTask,
-}));
-
-vi.mock('../../tasks/helpers', () => ({
-  findLatestTaskRun: mockFindLatestTaskRun,
+vi.mock('../linked-issue-pr-context', () => ({
+  fetchGitHubLinkedReferences: mocks.fetchGitHubLinkedReferences,
+  formatGitHubLinkedReferencesSection: (references: unknown[]) =>
+    references.length > 0 ? '<linked_references/>' : undefined,
 }));
 
 vi.mock('@roomote/env', () => ({
@@ -81,8 +39,6 @@ vi.mock('@roomote/env', () => ({
     R_APP_URL: 'https://app.roomote.dev',
   },
 }));
-
-import { RunStatus, TaskPayloadKind } from '@roomote/types';
 
 import { handleGitHubIssueComment } from '../handleGitHubIssueComment';
 import type { WebhookIssueCommentCreated } from '../types';
@@ -102,11 +58,7 @@ function makePayload(
       html_url: 'https://github.com/acme/api',
       default_branch: 'main',
     },
-    sender: {
-      id: 99,
-      login: 'alice',
-      type: 'User',
-    },
+    sender: { id: 99, login: 'alice', type: 'User' },
     issue: {
       number: 42,
       title: 'Ship it',
@@ -125,35 +77,30 @@ function makePayload(
 
 describe('handleGitHubIssueComment', () => {
   const createComment = vi.fn().mockResolvedValue({});
-  const timelineRequest = vi.fn().mockResolvedValue({ data: [] });
+  const createForIssueComment = vi.fn().mockResolvedValue({});
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useRealTimers();
-
-    timelineRequest.mockResolvedValue({ data: [] });
-    mockGetInstallationOctokit.mockResolvedValue({
+    mocks.getInstallationOctokit.mockResolvedValue({
       rest: {
-        issues: {
-          createComment,
-        },
+        issues: { createComment },
+        reactions: { createForIssueComment },
       },
-      request: timelineRequest,
     });
-    mockGetTaskUrl.mockReturnValue('https://app.roomote.dev/task/task-1');
-    mockEnqueueTask.mockResolvedValue({ id: 11, taskId: 'task-1' });
-    mockFindReusableGitHubIssueTaskOwner.mockResolvedValue(null);
-    mockSendMessageToTask.mockResolvedValue({ success: true, result: {} });
-    mockSteerMessageToTask.mockResolvedValue({ success: true, result: {} });
-    mockFindLatestTaskRun.mockResolvedValue(null);
-    mockGetGitHubAutomationTargets.mockResolvedValue({
+    mocks.findReusableGitHubIssueTaskOwner.mockResolvedValue(null);
+    mocks.fetchGitHubLinkedReferences.mockResolvedValue([]);
+    mocks.startSourceControlFastSessionTurn.mockResolvedValue({
+      status: 'queued',
+      fastConversationId: 'fast-1',
+    });
+    mocks.getGitHubAutomationTargets.mockResolvedValue({
       status: 'ok',
       targets: [
         {
           id: 'github:pr_conflict_resolve:repo-1',
           workflow: 'pr_conflict_resolve',
           settings: null,
-          repo: { id: 'repo-1', fullName: 'acme/api' },
+          repo: { id: 'repo-1', fullName: 'acme/api', host: null },
           collaborators: [],
           repositoryIds: ['repo-1'],
           properties: {
@@ -164,366 +111,91 @@ describe('handleGitHubIssueComment', () => {
         },
       ],
     });
-    mockDbSelect.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockResolvedValue([{ environmentId: 'env-1' }]),
-        }),
-      }),
-    });
   });
 
-  it('starts a standard task for a plain issue @mention', async () => {
+  it('enters an issue mention into the issue Session with the issue as context', async () => {
     const result = await handleGitHubIssueComment(makePayload());
 
     expect(result).toEqual({
       status: 'ok',
-      metadata: { ids: [11] },
+      message: 'fast_session_queued',
+      metadata: { fastConversationId: 'fast-1' },
     });
-    expect(mockFindReusableGitHubIssueTaskOwner).toHaveBeenCalledWith({
+    expect(createForIssueComment).toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 777, content: 'eyes' }),
+    );
+    expect(mocks.startSourceControlFastSessionTurn).toHaveBeenCalledWith({
+      discussion: {
+        provider: 'github',
+        host: 'github.com',
+        repositoryFullName: 'acme/api',
+        kind: 'issues',
+        number: 42,
+      },
+      userId: 'user-1',
+      senderDisplayName: 'alice',
+      question: '@roomote please take a look',
+      agentContext: expect.stringContaining('Issue: #42 - Ship it'),
+      currentMessageId: 'github:comment:777',
+      activeTasks: [],
+    });
+    const context = mocks.startSourceControlFastSessionTurn.mock.calls[0]?.[0]
+      .agentContext as string;
+    expect(context).toContain('> Please fix the bug');
+    expect(context).toContain('Author: @bob');
+    expect(createComment).not.toHaveBeenCalled();
+  });
+
+  it('hands the Session the task that already owns the issue', async () => {
+    mocks.findReusableGitHubIssueTaskOwner.mockResolvedValue({
+      taskId: 'task-owner',
+      runId: 5,
+      type: 'standard_task',
+      status: 'running',
+      taskPhase: null,
+      delivery: 'message',
+    });
+
+    await handleGitHubIssueComment(makePayload());
+
+    expect(mocks.findReusableGitHubIssueTaskOwner).toHaveBeenCalledWith({
       repoFullName: 'acme/api',
       issueNumber: 42,
+      host: null,
     });
-    expect(mockEnqueueTask).toHaveBeenCalledWith(
+    expect(mocks.startSourceControlFastSessionTurn).toHaveBeenCalledWith(
       expect.objectContaining({
-        task: expect.objectContaining({
-          type: TaskPayloadKind.StandardTask,
-          payload: expect.objectContaining({
-            repo: 'acme/api',
-            environmentId: 'env-1',
-            selectedRepositories: ['acme/api'],
-            linkedWorkItems: [
-              expect.objectContaining({
-                provider: 'github',
-                identifier: '42',
-                repository: 'acme/api',
-              }),
-            ],
-          }),
-        }),
-        surface: 'github',
-        workflow: 'standard',
-        initiator: { kind: 'user', userId: 'user-1' },
-      }),
-    );
-    expect(createComment).toHaveBeenCalledWith(
-      expect.objectContaining({
-        issue_number: 42,
-        body: expect.stringContaining('See task'),
+        activeTasks: [{ taskId: 'task-owner', status: 'running' }],
       }),
     );
   });
 
-  it('frames the mention comment and issue body as delimited untrusted content', async () => {
-    const result = await handleGitHubIssueComment(makePayload());
-
-    expect(result.status).toBe('ok');
-    const description = mockEnqueueTask.mock.calls[0]?.[0].task.payload
-      .description as string;
-    expect(description).toContain(
-      '<mention_request>@roomote please take a look</mention_request>',
-    );
-    expect(description).toContain(
-      '<untrusted_external_content source="github_issue_body">Please fix the bug</untrusted_external_content>',
-    );
-    expect(description).toContain('authored by @bob');
-    expect(description).toContain('<untrusted_content_policy/>');
-  });
-
-  it('includes linked pull requests and issues from the timeline in mention context', async () => {
-    timelineRequest.mockResolvedValue({
-      data: [
-        {
-          event: 'cross-referenced',
-          source: {
-            issue: {
-              number: 963,
-              title: 'feat: enable image support for DeepSeek V4 models',
-              html_url: 'https://github.com/acme/api/pull/963',
-              state: 'open',
-              pull_request: {},
-              repository: { full_name: 'acme/api' },
-            },
-          },
-        },
-      ],
-    });
-
-    const result = await handleGitHubIssueComment(makePayload());
-
-    expect(result.status).toBe('ok');
-    expect(timelineRequest).toHaveBeenCalledWith(
-      'GET /repos/{owner}/{repo}/issues/{issue_number}/timeline',
-      expect.objectContaining({
-        owner: 'acme',
-        repo: 'api',
-        issue_number: 42,
-      }),
-    );
-    const description = mockEnqueueTask.mock.calls[0]?.[0].task.payload
-      .description as string;
-    expect(description).toContain(
-      'Linked issues and pull requests (context only):',
-    );
-    expect(description).toContain('source="github_linked_references"');
-    expect(description).toContain(
-      'Pull request acme/api#963 — feat: enable image support for DeepSeek V4 models',
-    );
-  });
-
-  it('does not duplicate the issue body when the mention is the issue body itself', async () => {
-    const issueBody = 'Take a look at this crash please, @roomote';
+  it('does not repeat the issue body when the mention is the issue body itself', async () => {
     const base = makePayload();
-    // `issues.opened` shape: no comment object, the issue body is the mention.
-    const result = await handleGitHubIssueComment({
+    await handleGitHubIssueComment({
       installation: base.installation,
       repository: base.repository,
       sender: base.sender,
-      issue: {
-        number: 42,
-        title: 'Ship it',
-        body: issueBody,
-        html_url: 'https://github.com/acme/api/issues/42',
-        user: { login: 'alice' },
-      },
-      mentionBody: issueBody,
+      issue: { ...base.issue, body: '@roomote please investigate this' },
+      mentionBody: '@roomote please investigate this',
     });
 
-    expect(result.status).toBe('ok');
-    const description = mockEnqueueTask.mock.calls[0]?.[0].task.payload
-      .description as string;
-    expect(description).toContain(
-      `<mention_request>${issueBody}</mention_request>`,
-    );
-    expect(description).not.toContain('source="github_issue_body"');
-    expect(description).toContain('<untrusted_content_policy/>');
-  });
-
-  it('routes a second issue @mention into the existing task', async () => {
-    mockFindReusableGitHubIssueTaskOwner.mockResolvedValue({
-      runId: 9,
-      taskId: 'task-existing',
-      type: TaskPayloadKind.StandardTask,
-      status: RunStatus.Running,
-      taskPhase: 'running',
-      delivery: 'attach',
-    });
-    mockGetTaskUrl.mockReturnValue(
-      'https://app.roomote.dev/task/task-existing',
-    );
-
-    const result = await handleGitHubIssueComment(
-      makePayload({
-        comment: {
-          id: 778,
-          body: '@roomote also fix the tests',
-          user: { login: 'alice' },
-        } as WebhookIssueCommentCreated['comment'],
-      }),
-    );
-
-    expect(result).toEqual({
-      status: 'ok',
-      message: 'active_issue_owner_routed',
-    });
-    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+    expect(mocks.startSourceControlFastSessionTurn).toHaveBeenCalledWith(
       expect.objectContaining({
-        taskId: 'task-existing',
-        userId: 'user-1',
-        message: expect.stringContaining(
-          '<mention_request>@roomote also fix the tests</mention_request>',
-        ),
-        senderMode: 'github_pr_follow_up',
-      }),
-    );
-    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining('<untrusted_content_policy/>'),
-      }),
-    );
-    expect(mockEnqueueTask).not.toHaveBeenCalled();
-    expect(createComment).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: expect.stringContaining('existing task for this issue'),
-      }),
-    );
-  });
-
-  it('includes linked references on follow-up issue mentions', async () => {
-    mockFindReusableGitHubIssueTaskOwner.mockResolvedValue({
-      runId: 9,
-      taskId: 'task-existing',
-      type: TaskPayloadKind.StandardTask,
-      status: RunStatus.Running,
-      taskPhase: 'running',
-      delivery: 'attach',
-    });
-    timelineRequest.mockResolvedValue({
-      data: [
-        {
-          event: 'cross-referenced',
-          source: {
-            issue: {
-              number: 963,
-              title: 'Linked PR',
-              html_url: 'https://github.com/acme/api/pull/963',
-              state: 'open',
-              pull_request: {},
-              repository: { full_name: 'acme/api' },
-            },
-          },
-        },
-      ],
-    });
-
-    const result = await handleGitHubIssueComment(makePayload());
-
-    expect(result).toEqual({
-      status: 'ok',
-      message: 'active_issue_owner_routed',
-    });
-    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining(
-          'Pull request acme/api#963 — Linked PR',
+        question: '@roomote please investigate this',
+        currentMessageId: 'github:issue:acme/api#42',
+        agentContext: expect.stringContaining(
+          'mentioned Roomote in the issue body',
         ),
       }),
     );
-  });
-
-  it('queues a second issue @mention onto a non-running owner via sendMessage', async () => {
-    mockFindReusableGitHubIssueTaskOwner.mockResolvedValue({
-      runId: 9,
-      taskId: 'task-existing',
-      type: TaskPayloadKind.StandardTask,
-      status: RunStatus.Idle,
-      taskPhase: 'waiting_for_prompt',
-      delivery: 'attach',
-    });
-
-    const result = await handleGitHubIssueComment(makePayload());
-
-    expect(result).toEqual({
-      status: 'ok',
-      message: 'active_issue_owner_routed',
-    });
-    expect(mockSendMessageToTask).toHaveBeenCalledWith(
-      expect.objectContaining({
-        taskId: 'task-existing',
-        userId: 'user-1',
-      }),
-    );
-    expect(mockSteerMessageToTask).not.toHaveBeenCalled();
-    expect(mockEnqueueTask).not.toHaveBeenCalled();
-  });
-
-  it('waits for a booting issue task to accept messages before falling back', async () => {
-    vi.useFakeTimers();
-    mockFindReusableGitHubIssueTaskOwner.mockResolvedValue({
-      runId: 9,
-      taskId: 'task-existing',
-      type: TaskPayloadKind.StandardTask,
-      status: RunStatus.Pending,
-      taskPhase: null,
-      delivery: 'attach',
-    });
-    mockSteerMessageToTask
-      .mockResolvedValueOnce({
-        success: false,
-        error: 'no active sandbox',
-        status: 409,
-      })
-      .mockResolvedValueOnce({ success: true, result: {} });
-    mockFindLatestTaskRun
-      .mockResolvedValueOnce({
-        id: 9,
-        status: RunStatus.Pending,
-        taskPhase: null,
-        sandboxServerUrl: null,
-      })
-      .mockResolvedValueOnce({
-        id: 9,
-        status: RunStatus.Running,
-        taskPhase: 'running',
-        sandboxServerUrl: 'https://sandbox.example',
-      });
-
-    const resultPromise = handleGitHubIssueComment(makePayload());
-    await vi.advanceTimersByTimeAsync(500);
-    const result = await resultPromise;
-
-    expect(result).toEqual({
-      status: 'ok',
-      message: 'active_issue_owner_routed',
-    });
-    expect(mockSteerMessageToTask).toHaveBeenCalledTimes(2);
-    expect(mockEnqueueTask).not.toHaveBeenCalled();
-  });
-
-  it('retries when sandbox URL exists but the RPC is still booting', async () => {
-    vi.useFakeTimers();
-    mockFindReusableGitHubIssueTaskOwner.mockResolvedValue({
-      runId: 9,
-      taskId: 'task-existing',
-      type: TaskPayloadKind.StandardTask,
-      status: RunStatus.Running,
-      taskPhase: 'running',
-      delivery: 'attach',
-    });
-    mockSteerMessageToTask
-      .mockResolvedValueOnce({
-        success: false,
-        error:
-          "The task hasn't started yet — the sandbox is still booting. Try again in a few seconds.",
-        status: 409,
-      })
-      .mockResolvedValueOnce({ success: true, result: {} });
-    mockFindLatestTaskRun.mockResolvedValue({
-      id: 9,
-      status: RunStatus.Running,
-      taskPhase: 'running',
-      sandboxServerUrl: 'https://sandbox.example',
-    });
-
-    const resultPromise = handleGitHubIssueComment(makePayload());
-    await vi.advanceTimersByTimeAsync(500);
-    const result = await resultPromise;
-
-    expect(result).toEqual({
-      status: 'ok',
-      message: 'active_issue_owner_routed',
-    });
-    expect(mockSteerMessageToTask).toHaveBeenCalledTimes(2);
-    expect(mockEnqueueTask).not.toHaveBeenCalled();
-  });
-
-  it('falls back to starting a new task when follow-up delivery fails', async () => {
-    mockFindReusableGitHubIssueTaskOwner.mockResolvedValue({
-      runId: 9,
-      taskId: 'task-existing',
-      type: TaskPayloadKind.StandardTask,
-      status: RunStatus.Running,
-      taskPhase: 'running',
-      delivery: 'attach',
-    });
-    mockSteerMessageToTask.mockResolvedValue({
-      success: false,
-      error: 'permanent failure',
-      status: 500,
-    });
-
-    const result = await handleGitHubIssueComment(makePayload());
-
-    expect(result).toEqual({
-      status: 'ok',
-      metadata: { ids: [11] },
-    });
-    expect(mockEnqueueTask).toHaveBeenCalled();
-    expect(mockFindLatestTaskRun).not.toHaveBeenCalled();
+    const context = mocks.startSourceControlFastSessionTurn.mock.calls[0]?.[0]
+      .agentContext as string;
+    expect(context).not.toContain('Body (context only)');
   });
 
   it('prompts the commenter to link GitHub before starting work', async () => {
-    mockGetGitHubAutomationTargets.mockResolvedValue({
+    mocks.getGitHubAutomationTargets.mockResolvedValue({
       status: 'error',
       code: 'account_link_required',
       message: 'GitHub user alice is not linked',
@@ -532,7 +204,7 @@ describe('handleGitHubIssueComment', () => {
     const result = await handleGitHubIssueComment(makePayload());
 
     expect(result).toEqual({ status: 'ok', message: 'account_link_required' });
-    expect(mockEnqueueTask).not.toHaveBeenCalled();
+    expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
     expect(createComment).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.stringContaining('GitHub account linked'),
@@ -540,22 +212,18 @@ describe('handleGitHubIssueComment', () => {
     );
   });
 
-  it('requires an environment mapped to the repository', async () => {
-    mockDbSelect.mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockResolvedValue([]),
-        }),
-      }),
+  it('tells the commenter when the Session cannot start', async () => {
+    mocks.startSourceControlFastSessionTurn.mockResolvedValue({
+      status: 'unavailable',
     });
 
     const result = await handleGitHubIssueComment(makePayload());
 
-    expect(result).toEqual({ status: 'ok', message: 'environment_required' });
-    expect(mockEnqueueTask).not.toHaveBeenCalled();
+    expect(result).toEqual({ status: 'error', message: 'fast_unavailable' });
     expect(createComment).toHaveBeenCalledWith(
       expect.objectContaining({
-        body: expect.stringContaining('no Roomote environment is mapped'),
+        issue_number: 42,
+        body: expect.stringContaining("couldn't start a conversation"),
       }),
     );
   });
@@ -572,26 +240,7 @@ describe('handleGitHubIssueComment', () => {
     );
 
     expect(result).toEqual({ status: 'ok', message: 'no_mention' });
-    expect(mockEnqueueTask).not.toHaveBeenCalled();
+    expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
     expect(createComment).not.toHaveBeenCalled();
-  });
-
-  it('starts a task from an issue body mention when no comment is present', async () => {
-    const result = await handleGitHubIssueComment({
-      installation: { id: 123 } as WebhookIssueCommentCreated['installation'],
-      repository: makePayload().repository,
-      sender: makePayload().sender,
-      issue: {
-        ...makePayload().issue,
-        body: '@roomote please investigate this',
-      },
-      mentionBody: '@roomote please investigate this',
-    });
-
-    expect(result).toEqual({
-      status: 'ok',
-      metadata: { ids: [11] },
-    });
-    expect(mockEnqueueTask).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
@@ -184,6 +184,12 @@ describe('handlePrComment', () => {
     expect(createForIssueComment).toHaveBeenCalledWith(
       expect.objectContaining({ comment_id: 777, content: 'eyes' }),
     );
+    expect(mocks.getGitHubAutomationTargets).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflow: 'pr_conflict_resolve',
+        requireLinkedSenderAccount: true,
+      }),
+    );
     expect(mocks.startSourceControlFastSessionTurn).toHaveBeenCalledWith({
       discussion: {
         provider: 'github',
@@ -253,6 +259,23 @@ describe('handlePrComment', () => {
         ],
       }),
     );
+  });
+
+  it('reports a setup gap instead of asking to link when the repository is not active', async () => {
+    mocks.getGitHubAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [],
+    });
+
+    const result = await handlePrComment(makeIssueCommentPayload());
+
+    expect(result).toEqual({ status: 'ok', message: 'reviewer_gate_miss' });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.stringContaining('could not start work on this PR'),
+      }),
+    );
+    expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
   });
 
   it('prompts the commenter to link GitHub before starting work', async () => {

--- a/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
@@ -1,39 +1,15 @@
-const {
-  mockGetGitHubAutomationTargets,
-  mockGetInstallationOctokit,
-  mockEnqueueTask,
-  mockFindLatestTaskRun,
-  mockGetTaskChannelBindings,
-  mockPublishGithubPrReviewCheck,
-  mockAcquireGithubPrReviewLifecycleLock,
-  mockReleaseGithubPrReviewLifecycleLock,
-  MockSnapshotResumeAlreadyExistsError,
-} = vi.hoisted(() => ({
-  mockGetGitHubAutomationTargets: vi.fn(),
-  mockGetInstallationOctokit: vi.fn(),
-  mockEnqueueTask: vi.fn(),
-  mockFindLatestTaskRun: vi.fn(),
-  mockGetTaskChannelBindings: vi.fn(),
-  mockPublishGithubPrReviewCheck: vi.fn(),
-  mockAcquireGithubPrReviewLifecycleLock: vi.fn(),
-  mockReleaseGithubPrReviewLifecycleLock: Object.assign(vi.fn(), {
-    signal: new AbortController().signal,
-  }),
-  MockSnapshotResumeAlreadyExistsError: class extends Error {},
-}));
-
-vi.mock('@roomote/cloud-agents/server', () => ({
-  buildGitHubExistingTaskFollowUpMessage: vi.fn(),
-  buildGitHubRoutingContext: vi.fn(),
-  enqueueTask: mockEnqueueTask,
-  getTaskUrl: vi.fn(),
-  routeGitHubTask: vi.fn(),
-  SnapshotResumeAlreadyExistsError: MockSnapshotResumeAlreadyExistsError,
+const mocks = vi.hoisted(() => ({
+  getGitHubAutomationTargets: vi.fn(),
+  getInstallationOctokit: vi.fn(),
+  findActiveGitHubPrReviewTask: vi.fn(),
+  findReusableGitHubPrFollowUpOwner: vi.fn(),
+  startSourceControlFastSessionTurn: vi.fn(),
+  fetchGitHubLinkedReferences: vi.fn(),
 }));
 
 vi.mock('@roomote/db/server', () => ({
-  findActiveGitHubPrReviewTask: vi.fn(),
-  findReusableGitHubPrFollowUpOwner: vi.fn(),
+  findActiveGitHubPrReviewTask: mocks.findActiveGitHubPrReviewTask,
+  findReusableGitHubPrFollowUpOwner: mocks.findReusableGitHubPrFollowUpOwner,
 }));
 
 vi.mock('@roomote/github', () => ({
@@ -42,35 +18,21 @@ vi.mock('@roomote/github', () => ({
   },
   getEffectiveGitHubAppSlug: vi.fn(() => 'roomote'),
   isGitHubRoomoteMentionEnabled: vi.fn(() => true),
-  getInstallationOctokit: mockGetInstallationOctokit,
+  getInstallationOctokit: mocks.getInstallationOctokit,
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
-  acquireGithubPrReviewLifecycleLock: mockAcquireGithubPrReviewLifecycleLock,
-  ensureSnapshotResumeGitHubFollowUpFallback: vi.fn(),
-  publishGithubPrReviewCheck: mockPublishGithubPrReviewCheck,
+  startSourceControlFastSessionTurn: mocks.startSourceControlFastSessionTurn,
 }));
 
-vi.mock('../getGitHubAutomationTargets', async () => {
-  const actual = await vi.importActual<
-    typeof import('../getGitHubAutomationTargets')
-  >('../getGitHubAutomationTargets');
-
-  return {
-    ...actual,
-    getGitHubAutomationTargets: mockGetGitHubAutomationTargets,
-  };
-});
-
-vi.mock('../../tasks/helpers', () => ({
-  findLatestTaskRun: mockFindLatestTaskRun,
-  getTaskChannelBindings: mockGetTaskChannelBindings,
+vi.mock('../getGitHubAutomationTargets', () => ({
+  getGitHubAutomationTargets: mocks.getGitHubAutomationTargets,
 }));
 
-vi.mock('../../tasks/sendMessageToTask', () => ({
-  getTrackedUserDisplayName: vi.fn(),
-  sendMessageToTask: vi.fn(),
-  steerMessageToTask: vi.fn(),
+vi.mock('../linked-issue-pr-context', () => ({
+  fetchGitHubLinkedReferences: mocks.fetchGitHubLinkedReferences,
+  formatGitHubLinkedReferencesSection: (references: unknown[]) =>
+    references.length > 0 ? '<linked_references/>' : undefined,
 }));
 
 vi.mock('@roomote/env', () => ({
@@ -80,38 +42,35 @@ vi.mock('@roomote/env', () => ({
   },
 }));
 
-import {
-  handlePrComment,
-  resumeExistingTaskAndDeliverFollowUp,
-} from '../handlePrComment';
-import type { WebhookIssueCommentCreated } from '../types';
+import { handlePrComment } from '../handlePrComment';
+import type {
+  WebhookIssueCommentCreated,
+  WebhookPullRequestCommentCreated,
+} from '../types';
 
-function makePayload(): WebhookIssueCommentCreated {
+const repository = {
+  id: 456,
+  full_name: 'acme/api',
+  name: 'api',
+  owner: { login: 'acme' },
+  private: true,
+  html_url: 'https://github.com/acme/api',
+  default_branch: 'main',
+};
+const sender = { id: 99, login: 'alice', type: 'User' };
+
+function makeIssueCommentPayload(): WebhookIssueCommentCreated {
   return {
     action: 'created',
     installation: { id: 123 },
-    repository: {
-      id: 456,
-      full_name: 'acme/api',
-      name: 'api',
-      owner: { login: 'acme' },
-      private: true,
-      html_url: 'https://github.com/acme/api',
-      default_branch: 'main',
-    },
-    sender: {
-      id: 99,
-      login: 'alice',
-      type: 'User',
-    },
+    repository,
+    sender,
     issue: {
       number: 42,
       title: 'Ship it',
       body: 'Please review',
       user: { login: 'bob' },
-      pull_request: {
-        html_url: 'https://github.com/acme/api/pull/42',
-      },
+      pull_request: { html_url: 'https://github.com/acme/api/pull/42' },
     },
     comment: {
       id: 777,
@@ -121,78 +80,222 @@ function makePayload(): WebhookIssueCommentCreated {
   } as WebhookIssueCommentCreated;
 }
 
+function makeReviewCommentPayload(): WebhookPullRequestCommentCreated {
+  return {
+    action: 'created',
+    installation: { id: 123 },
+    repository,
+    sender,
+    pull_request: {
+      number: 42,
+      title: 'Ship it',
+      body: 'Please review',
+      html_url: 'https://github.com/acme/api/pull/42',
+      user: { login: 'bob' },
+      head: { ref: 'feature/ship', sha: 'abc123' },
+    },
+    comment: {
+      id: 900,
+      in_reply_to_id: 800,
+      body: '@roomote can you address this?',
+      user: { login: 'alice' },
+    },
+  } as unknown as WebhookPullRequestCommentCreated;
+}
+
 describe('handlePrComment', () => {
+  const createComment = vi.fn().mockResolvedValue({ data: { id: 1 } });
+  const createForIssueComment = vi.fn().mockResolvedValue({});
+  const createForPullRequestReviewComment = vi.fn().mockResolvedValue({});
+  const request = vi.fn();
+  const pullsGet = vi.fn();
+  const listComments = vi.fn().mockResolvedValue({ data: [] });
+  const listReviewComments = vi.fn().mockResolvedValue({ data: [] });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    request.mockImplementation(async (route: string) => {
+      if (route.startsWith('GET /repos/{owner}/{repo}/pulls/comments/')) {
+        return {
+          data: {
+            id: 800,
+            body: 'This loop never terminates.',
+            path: 'src/retry.ts',
+            diff_hunk: '@@ -1 +1 @@\n-old\n+new',
+            user: { login: 'carol' },
+          },
+        };
+      }
+      return { data: {} };
+    });
+    pullsGet.mockResolvedValue({
+      data: {
+        head: { ref: 'feature/ship', sha: 'abc123' },
+        html_url: 'https://github.com/acme/api/pull/42',
+      },
+    });
+    mocks.getInstallationOctokit.mockResolvedValue({
+      rest: {
+        issues: { createComment, listComments },
+        pulls: { get: pullsGet, listReviewComments },
+        reactions: { createForIssueComment, createForPullRequestReviewComment },
+      },
+      request,
+    });
+    mocks.getGitHubAutomationTargets.mockResolvedValue({
+      status: 'ok',
+      targets: [
+        {
+          id: 'github:pr_review:repo-1',
+          workflow: 'pr_review',
+          settings: null,
+          repo: { id: 'repo-1', fullName: 'acme/api', host: null },
+          collaborators: [],
+          repositoryIds: ['repo-1'],
+          properties: {
+            userId: 'user-1',
+            githubLogin: 'alice',
+            githubUserId: 99,
+          },
+        },
+      ],
+    });
+    mocks.findActiveGitHubPrReviewTask.mockResolvedValue(null);
+    mocks.findReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
+    mocks.fetchGitHubLinkedReferences.mockResolvedValue([]);
+    mocks.startSourceControlFastSessionTurn.mockResolvedValue({
+      status: 'queued',
+      fastConversationId: 'fast-1',
+    });
+  });
 
-    mockGetGitHubAutomationTargets.mockResolvedValue({
+  it('enters a PR comment mention into the pull request Session with the discussion as context', async () => {
+    listComments.mockResolvedValueOnce({
+      data: [{ user: { login: 'bob' }, body: 'Earlier note.' }],
+    });
+
+    const result = await handlePrComment(makeIssueCommentPayload());
+
+    expect(result).toEqual({
+      status: 'ok',
+      message: 'fast_session_queued',
+      metadata: { fastConversationId: 'fast-1' },
+    });
+    expect(createForIssueComment).toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 777, content: 'eyes' }),
+    );
+    expect(mocks.startSourceControlFastSessionTurn).toHaveBeenCalledWith({
+      discussion: {
+        provider: 'github',
+        host: 'github.com',
+        repositoryFullName: 'acme/api',
+        kind: 'pull',
+        number: 42,
+      },
+      userId: 'user-1',
+      senderDisplayName: 'alice',
+      question: '@roomote please take a look',
+      agentContext: expect.stringContaining('Earlier note.'),
+      currentMessageId: 'github:comment:777',
+      activeTasks: [],
+    });
+    const context = mocks.startSourceControlFastSessionTurn.mock.calls[0]?.[0]
+      .agentContext as string;
+    expect(context).toContain('Pull request: #42 - Ship it');
+    expect(context).toContain('Head branch: feature/ship');
+    expect(createComment).not.toHaveBeenCalled();
+  });
+
+  it('threads review-comment mentions under their thread and quotes the parent comment', async () => {
+    await handlePrComment(makeReviewCommentPayload());
+
+    expect(createForPullRequestReviewComment).toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 900, content: 'eyes' }),
+    );
+    expect(mocks.startSourceControlFastSessionTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        discussion: expect.objectContaining({
+          kind: 'pull',
+          number: 42,
+          reviewCommentId: '800',
+        }),
+        currentMessageId: 'github:comment:900',
+        agentContext: expect.stringContaining('This loop never terminates.'),
+      }),
+    );
+  });
+
+  it('hands the Session the task that already owns the pull request and any running review', async () => {
+    mocks.findReusableGitHubPrFollowUpOwner.mockResolvedValue({
+      taskId: 'task-owner',
+      runId: 5,
+      status: 'running',
+      taskPhase: null,
+      delivery: 'message',
+    });
+    mocks.findActiveGitHubPrReviewTask.mockResolvedValue({
+      taskId: 'task-review',
+      status: 'processing',
+    });
+
+    await handlePrComment(makeIssueCommentPayload());
+
+    expect(mocks.findReusableGitHubPrFollowUpOwner).toHaveBeenCalledWith({
+      repoFullName: 'acme/api',
+      prNumber: 42,
+      branchName: 'feature/ship',
+    });
+    expect(mocks.startSourceControlFastSessionTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeTasks: [
+          { taskId: 'task-owner', status: 'running' },
+          { taskId: 'task-review', status: 'processing' },
+        ],
+      }),
+    );
+  });
+
+  it('prompts the commenter to link GitHub before starting work', async () => {
+    mocks.getGitHubAutomationTargets.mockResolvedValue({
       status: 'error',
       code: 'account_link_required',
       message: 'GitHub user alice is not linked',
     });
-    mockGetInstallationOctokit.mockResolvedValue({
-      rest: {
-        issues: {
-          createComment: vi.fn().mockResolvedValue({}),
-        },
-      },
-      request: vi.fn(),
-    });
-    mockGetTaskChannelBindings.mockResolvedValue(null);
-    mockAcquireGithubPrReviewLifecycleLock.mockResolvedValue(
-      mockReleaseGithubPrReviewLifecycleLock,
-    );
-  });
 
-  it('returns a normal delivery failure when another GitHub resume wins', async () => {
-    mockFindLatestTaskRun.mockResolvedValue({
-      id: 42,
-      status: 'completed',
-      taskPhase: null,
-      snapshotId: 'snapshot-1',
-      snapshotCreatedAt: new Date(),
-      payload: { repo: 'acme/api' },
-      port: null,
-      actingUserId: 'user-1',
-    });
-    mockEnqueueTask.mockRejectedValueOnce(
-      new MockSnapshotResumeAlreadyExistsError(),
-    );
-
-    const result = await resumeExistingTaskAndDeliverFollowUp({
-      taskId: 'task-1',
-      userId: 'user-1',
-      sourceRunId: 42,
-      message: 'Handle the second comment.',
-      resumePromptFallbackTask: {
-        type: 'github_pr_review_follow_up',
-        userId: 'user-1',
-        payload: {
-          repo: 'acme/api',
-          prNumber: 42,
-          prTitle: 'Ship it',
-          commentBody: 'Handle the second comment.',
-          followUpSource: 'github_mention',
-        },
-      },
-    });
-
-    expect(result).toEqual({
-      success: false,
-      error: 'Reusable PR owner is already resuming',
-      status: 409,
-    });
-  });
-
-  it('prompts the commenter to link GitHub before starting work', async () => {
-    const result = await handlePrComment(makePayload());
+    const result = await handlePrComment(makeIssueCommentPayload());
 
     expect(result).toEqual({ status: 'ok', message: 'account_link_required' });
-    const octokit = await mockGetInstallationOctokit.mock.results[0]?.value;
-    expect(octokit.rest.issues.createComment).toHaveBeenCalledWith(
+    expect(createComment).toHaveBeenCalledWith(
       expect.objectContaining({
         body: expect.stringContaining('GitHub account linked'),
       }),
     );
+    expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
+  });
+
+  it('tells the commenter when the Session cannot start', async () => {
+    mocks.startSourceControlFastSessionTurn.mockResolvedValue({
+      status: 'unavailable',
+    });
+
+    const result = await handlePrComment(makeIssueCommentPayload());
+
+    expect(result).toEqual({ status: 'error', message: 'fast_unavailable' });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        issue_number: 42,
+        body: expect.stringContaining("couldn't start a conversation"),
+      }),
+    );
+  });
+
+  it('ignores comments without a mention', async () => {
+    const payload = makeIssueCommentPayload();
+    payload.comment.body = 'just a note';
+
+    const result = await handlePrComment(payload);
+
+    expect(result).toEqual({ status: 'ok', message: 'no_mention' });
+    expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/github/handleGitHubIssueComment.ts
+++ b/apps/api/src/handlers/github/handleGitHubIssueComment.ts
@@ -1,10 +1,14 @@
-import { getTaskUrl } from '@roomote/cloud-agents/server';
+import type { FastAgentActiveTask } from '@roomote/cloud-agents/server';
+import { findReusableGitHubIssueTaskOwner } from '@roomote/db/server';
 import { getInstallationOctokit } from '@roomote/github';
+import {
+  startSourceControlFastSessionTurn,
+  type SourceControlFastDiscussion,
+} from '@roomote/sdk/server';
 import { PRODUCT_NAME } from '@roomote/types';
 
 import type { WebhookResponse } from '../../types';
 import { buildSourceControlAccountLinkRequiredMessage } from '../source-control-account-linking';
-import { orchestrateIssueMention } from '../shared/issue-mention-orchestration';
 import { getGitHubAutomationTargets } from './getGitHubAutomationTargets';
 import { isMention } from './isMention';
 import {
@@ -40,6 +44,9 @@ type IssueMentionPayload = {
   mentionBody?: string;
 };
 
+const FAST_UNAVAILABLE_COMMENT =
+  "I saw the mention, but I couldn't start a conversation right now. Please try again in a moment.";
+
 async function postIssueComment({
   installationId,
   repositoryFullName,
@@ -74,59 +81,101 @@ async function postIssueComment({
   }
 }
 
-function tryBuildTaskLink({
-  taskId,
-  campaign,
+async function acknowledgeIssueMentionBestEffort({
+  installationId,
+  repositoryFullName,
+  commentId,
 }: {
-  taskId: string;
-  campaign: string;
-}): string | null {
+  installationId: number;
+  repositoryFullName: string;
+  commentId: number | undefined;
+}): Promise<void> {
+  const [owner, repo] = repositoryFullName.split('/');
+  if (!owner || !repo || commentId === undefined) {
+    return;
+  }
   try {
-    return getTaskUrl({
-      taskId,
-      utm: {
-        source: 'github-comment',
-        campaign,
-      },
+    const octokit = await getInstallationOctokit({ installationId });
+    await octokit.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      content: 'eyes',
     });
   } catch (error) {
     console.warn(
-      `[handleGitHubIssueComment] failed to build task link: ${
+      `[handleGitHubIssueComment] failed to acknowledge mention on ${repositoryFullName}: ${
         error instanceof Error ? error.message : String(error)
       }`,
     );
-    return null;
   }
-}
-
-function formatStartedReply(taskLink: string | null): string {
-  if (taskLink) {
-    return `I'm on it. I started a task for this issue, and I'll keep updates here.\n\n[See task](${taskLink})`;
-  }
-
-  return `I'm on it. I started a task for this issue, and I'll keep updates here.`;
-}
-
-function formatFollowUpReply(taskLink: string | null): string {
-  if (taskLink) {
-    return `I'm on it. I routed this request into the existing task for this issue so follow-up work stays on one Roomote thread, and I'll keep updates here.\n\n[See task](${taskLink})`;
-  }
-
-  return `I'm on it. I routed this request into the existing task for this issue so follow-up work stays on one Roomote thread, and I'll keep updates here.`;
 }
 
 function buildGateMissComment(): string {
   return `I saw the mention, but I could not start work on this issue with the current ${PRODUCT_NAME} GitHub setup.`;
 }
 
-function buildStartFailedComment(): string {
-  return `I saw the mention, but I could not start a task for this issue right now. Please try again in a moment.`;
+function formatQuotedText(text: string): string {
+  return text
+    .trim()
+    .split('\n')
+    .map((line) => `> ${line}`)
+    .join('\n');
 }
 
 /**
- * Handle @mentions on plain GitHub issues (not pull requests).
- * Starts a standard task against the issue's repository, or continues an
- * existing task already linked to the same issue.
+ * What the Session reads with an issue mention: the issue, the comment that
+ * mentioned Roomote (or the issue body when the mention is in it), and any
+ * linked pull requests or issues.
+ */
+function buildIssueMentionContext({
+  repositoryFullName,
+  issueNumber,
+  issueTitle,
+  issueBody,
+  issueUrl,
+  issueAuthorLogin,
+  commenterLogin,
+  commentBody,
+  mentionIsIssueBody,
+  linkedReferencesSection,
+}: {
+  repositoryFullName: string;
+  issueNumber: number;
+  issueTitle: string;
+  issueBody: string | null;
+  issueUrl: string;
+  issueAuthorLogin: string | null;
+  commenterLogin: string;
+  commentBody: string;
+  mentionIsIssueBody: boolean;
+  linkedReferencesSection?: string;
+}): string {
+  const author = issueAuthorLogin ? `@${issueAuthorLogin}` : 'an unknown user';
+  return [
+    `<github_issue url="${issueUrl}">`,
+    `Repository: ${repositoryFullName}`,
+    `Issue: #${issueNumber} - ${issueTitle}`,
+    `Author: ${author}`,
+    ...(issueBody?.trim() && !mentionIsIssueBody
+      ? ['', 'Body (context only):', formatQuotedText(issueBody)]
+      : []),
+    '</github_issue>',
+    '<triggering_comment>',
+    mentionIsIssueBody
+      ? `${commenterLogin} mentioned Roomote in the issue body:`
+      : `${commenterLogin} mentioned Roomote in a comment on the issue:`,
+    formatQuotedText(commentBody),
+    '</triggering_comment>',
+    ...(linkedReferencesSection ? [linkedReferencesSection] : []),
+    'This conversation is a GitHub issue discussion. Your replies post as comments on the issue, so keep them concise. Delegated tasks run in the environment mapped to this repository and link the issue.',
+  ].join('\n');
+}
+
+/**
+ * Every @mention on an issue enters the issue's Fast Session. The Session
+ * reads the issue, replies as a comment, and delegates work when the request
+ * needs a task.
  */
 export async function handleGitHubIssueComment(
   eventPayload: IssueMentionPayload,
@@ -204,47 +253,71 @@ export async function handleGitHubIssueComment(
     return { status: 'ok', message: 'account_link_required' };
   }
 
+  await acknowledgeIssueMentionBestEffort({
+    installationId: githubInstallationId,
+    repositoryFullName,
+    commentId: eventPayload.comment?.id,
+  });
+
   const issueUrl =
     issue.html_url ??
     `https://github.com/${repositoryFullName}/issues/${issueNumber}`;
   const issueTitle = issue.title ?? `Issue #${issueNumber}`;
-  const issueBody = issue.body ?? null;
-  const commenterUserId = target.properties.userId;
-  const issueAuthorLogin = issue.user?.login ?? null;
-  const linkedReferences = await fetchGitHubLinkedReferences({
-    installationId: githubInstallationId,
-    repositoryFullName,
-    issueOrPrNumber: issueNumber,
-  });
-  const linkedReferencesSection =
-    formatGitHubLinkedReferencesSection(linkedReferences);
-
-  return orchestrateIssueMention({
+  const [linkedReferences, existingOwner] = await Promise.all([
+    fetchGitHubLinkedReferences({
+      installationId: githubInstallationId,
+      repositoryFullName,
+      issueOrPrNumber: issueNumber,
+    }),
+    findReusableGitHubIssueTaskOwner({
+      repoFullName: repositoryFullName,
+      issueNumber,
+      host: target.repo.host ?? null,
+    }).catch(() => null),
+  ]);
+  const activeTasks: FastAgentActiveTask[] = existingOwner?.taskId
+    ? [{ taskId: existingOwner.taskId, status: existingOwner.status }]
+    : [];
+  const discussion: SourceControlFastDiscussion = {
     provider: 'github',
-    logPrefix: '[handleGitHubIssueComment]',
-    repositoryId: target.repo.id,
+    host: target.repo.host ?? 'github.com',
     repositoryFullName,
-    issueNumber,
-    issueTitle,
-    issueBody,
-    issueUrl,
-    commentBody,
-    commenterLogin: sender.login,
-    commenterUserId,
-    githubLogin: target.properties.githubLogin ?? undefined,
-    githubUserId: target.properties.githubUserId ?? undefined,
-    followUpCommenterDisplayName: target.properties.githubLogin ?? sender.login,
-    retrySandboxBoot: true,
-    providerDisplayName: 'GitHub',
-    issueBodySource: 'github_issue_body',
-    issueBodyContextLabel: `Issue body (context only, authored by ${
-      issueAuthorLogin ? `@${issueAuthorLogin}` : 'an unknown user'
-    }):`,
-    linkedReferencesSection,
-    postComment: (body) => postIssueComment({ ...replyTarget, body }),
-    formatFollowUpReply,
-    formatStartedReply,
-    formatStartFailed: buildStartFailedComment,
-    tryBuildTaskLink,
+    kind: 'issues',
+    number: issueNumber,
+  };
+
+  const started = await startSourceControlFastSessionTurn({
+    discussion,
+    userId: target.properties.userId,
+    senderDisplayName: sender.login,
+    question: commentBody,
+    agentContext: buildIssueMentionContext({
+      repositoryFullName,
+      issueNumber,
+      issueTitle,
+      issueBody: issue.body ?? null,
+      issueUrl,
+      issueAuthorLogin: issue.user?.login ?? null,
+      commenterLogin: sender.login,
+      commentBody,
+      mentionIsIssueBody: eventPayload.mentionBody !== undefined,
+      linkedReferencesSection:
+        formatGitHubLinkedReferencesSection(linkedReferences),
+    }),
+    currentMessageId: eventPayload.comment
+      ? `github:comment:${eventPayload.comment.id}`
+      : `github:issue:${repositoryFullName}#${issueNumber}`,
+    activeTasks,
   });
+
+  if (started.status !== 'queued') {
+    await postIssueComment({ ...replyTarget, body: FAST_UNAVAILABLE_COMMENT });
+    return { status: 'error', message: 'fast_unavailable' };
+  }
+
+  return {
+    status: 'ok',
+    message: 'fast_session_queued',
+    metadata: { fastConversationId: started.fastConversationId },
+  };
 }

--- a/apps/api/src/handlers/github/handlePrComment.ts
+++ b/apps/api/src/handlers/github/handlePrComment.ts
@@ -178,10 +178,6 @@ function buildReviewerGateMissComment(): string {
   return `I saw the mention, but I could not start work on this PR with the current ${PRODUCT_NAME} GitHub setup.`;
 }
 
-function buildInternalErrorComment(): string {
-  return `I saw the mention, but something went wrong on the ${PRODUCT_NAME} side. Please try again in a moment.`;
-}
-
 async function fetchReviewCommentSnapshot({
   installationId,
   repositoryFullName,
@@ -686,26 +682,16 @@ export async function handlePrComment(
   }
 
   const pr = 'issue' in rest ? rest.issue : rest.pull_request;
-  const prAuthorLogin = pr.user?.login?.toLowerCase();
-
-  if (!prAuthorLogin) {
-    await postMentionResponseComment({
-      installationId: githubInstallationId,
-      target: mentionResponseTarget,
-      body: buildInternalErrorComment(),
-    });
-
-    return { status: 'ok', message: 'no_pr_author' };
-  }
 
   // The commenter must be a linked Roomote user: the Session runs as them.
+  // The non-review workflow resolves the repository and the linked account
+  // without the Review Code automation gates, which do not apply to a
+  // conversation.
   const reviewerGate = await getGitHubAutomationTargets({
-    workflow: 'pr_review',
+    workflow: 'pr_conflict_resolve',
     installation,
     repository,
     sender,
-    author: prAuthorLogin,
-    ignoreRoomoteAuthorRequirement: true,
     requireLinkedSenderAccount: true,
   });
 
@@ -731,7 +717,17 @@ export async function handlePrComment(
   const commenter = reviewerGate.targets[0];
   const commenterUserId = commenter?.properties.userId;
 
-  if (!commenter || !commenterUserId) {
+  if (!commenter) {
+    await postMentionResponseComment({
+      installationId: githubInstallationId,
+      target: mentionResponseTarget,
+      body: buildReviewerGateMissComment(),
+    });
+
+    return { status: 'ok', message: 'reviewer_gate_miss' };
+  }
+
+  if (!commenterUserId) {
     await postMentionResponseComment({
       installationId: githubInstallationId,
       target: mentionResponseTarget,

--- a/apps/api/src/handlers/github/handlePrComment.ts
+++ b/apps/api/src/handlers/github/handlePrComment.ts
@@ -1,43 +1,17 @@
 import {
-  buildGitHubExistingTaskFollowUpMessage,
-  buildGitHubRoutingContext,
-  enqueueTask,
-  getTaskUrl,
-  routeGitHubTask,
-  SnapshotResumeAlreadyExistsError,
-} from '@roomote/cloud-agents/server';
-import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
 } from '@roomote/db/server';
 import { getInstallationOctokit } from '@roomote/github';
 import {
-  acquireGithubPrReviewLifecycleLock,
-  ensureSnapshotResumeGitHubFollowUpFallback,
-  publishGithubPrReviewCheck,
+  startSourceControlFastSessionTurn,
+  type SourceControlFastDiscussion,
 } from '@roomote/sdk/server';
-import {
-  type TaskPayload,
-  RunStatus,
-  TaskPayloadKind,
-  EXPIRED_SNAPSHOT_RESUME_ERROR,
-  PRODUCT_NAME,
-  type SnapshotResumePromptFallbackTask,
-  isActivelyRunningTask,
-  isExitedRunStatus,
-  populateSnapshotResumeSlackMetadata,
-  isSnapshotResumable,
-  restoreSnapshotResumeVisiblePromptFields,
-} from '@roomote/types';
+import type { FastAgentActiveTask } from '@roomote/cloud-agents/server';
+import { PRODUCT_NAME } from '@roomote/types';
 
 import type { WebhookResponse } from '../../types';
 import { toHostFromUrl } from '../utils';
-import { findLatestTaskRun, getTaskChannelBindings } from '../tasks/helpers';
-import {
-  getTrackedUserDisplayName,
-  sendMessageToTask,
-  steerMessageToTask,
-} from '../tasks/sendMessageToTask';
 
 import type {
   WebhookPullRequestCommentCreated,
@@ -50,8 +24,12 @@ import {
   fetchGitHubLinkedReferences,
   formatGitHubLinkedReferencesSection,
 } from './linked-issue-pr-context';
-import { getReviewTaskRelayPayload } from './reviewTaskRelayPayload';
 import { buildSourceControlAccountLinkRequiredMessage } from '../source-control-account-linking';
+
+type PullRequestMentionEvent =
+  | WebhookPullRequestCommentCreated
+  | WebhookIssueCommentCreated
+  | WebhookPullRequestReviewSubmitted;
 
 type MentionResponseTarget = {
   repositoryFullName: string;
@@ -67,20 +45,21 @@ type ReviewCommentSnapshot = {
   userLogin: string;
 };
 
-type GitHubPrMentionReplyLink = { kind: 'task'; url: string };
-
-type GitHubPrMentionReplyOutcome =
-  | { kind: 'active_follow_up' }
-  | { kind: 'active_review' }
-  | { kind: 'dedicated_follow_up' }
-  | { kind: 'review_started'; count: number; partial: boolean };
-
-type GitHubPrMentionReplyLinkRequest = {
-  kind: 'task';
-  taskId: string;
-  utm: Parameters<typeof getTaskUrl>[0]['utm'];
-  warning: string;
+type GitHubRoutingHistoryContext = {
+  issueComments: Array<{ author: string; body: string }>;
+  reviewComments: Array<{ author: string; body: string; path?: string }>;
 };
+
+type PullRequestRoutingDetails = {
+  branchName: string;
+  prUrl: string;
+  headSha: string;
+};
+
+const GITHUB_ROUTING_HISTORY_PAGE_SIZE = 100;
+
+const FAST_UNAVAILABLE_COMMENT =
+  "I saw the mention, but I couldn't start a conversation right now. Please try again in a moment.";
 
 async function postMentionResponseComment({
   installationId,
@@ -129,11 +108,51 @@ async function postMentionResponseComment({
   }
 }
 
+/**
+ * Acknowledges the mention the way chat surfaces do, with an eyes reaction
+ * on the comment. Submitted reviews have no reaction API; the reply itself
+ * is the acknowledgement there.
+ */
+async function acknowledgeMentionBestEffort({
+  installationId,
+  eventPayload,
+}: {
+  installationId: number;
+  eventPayload: PullRequestMentionEvent;
+}): Promise<void> {
+  if (!('comment' in eventPayload)) {
+    return;
+  }
+  const [owner, repo] = eventPayload.repository.full_name.split('/');
+  if (!owner || !repo) {
+    return;
+  }
+  try {
+    const octokit = await getInstallationOctokit({ installationId });
+    if ('pull_request' in eventPayload) {
+      await octokit.rest.reactions.createForPullRequestReviewComment({
+        owner,
+        repo,
+        comment_id: eventPayload.comment.id,
+        content: 'eyes',
+      });
+      return;
+    }
+    await octokit.rest.reactions.createForIssueComment({
+      owner,
+      repo,
+      comment_id: eventPayload.comment.id,
+      content: 'eyes',
+    });
+  } catch (error) {
+    console.warn(
+      `[handlePrComment] failed to acknowledge mention on ${eventPayload.repository.full_name}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
 function getMentionResponseTarget(
-  eventPayload:
-    | WebhookPullRequestCommentCreated
-    | WebhookIssueCommentCreated
-    | WebhookPullRequestReviewSubmitted,
+  eventPayload: PullRequestMentionEvent,
 ): MentionResponseTarget {
   if ('comment' in eventPayload && 'pull_request' in eventPayload) {
     return {
@@ -159,99 +178,8 @@ function buildReviewerGateMissComment(): string {
   return `I saw the mention, but I could not start work on this PR with the current ${PRODUCT_NAME} GitHub setup.`;
 }
 
-function tryBuildGitHubPrMentionReplyLink(
-  request: GitHubPrMentionReplyLinkRequest,
-): GitHubPrMentionReplyLink | null {
-  try {
-    return {
-      kind: 'task',
-      url: getTaskUrl({
-        taskId: request.taskId,
-        utm: request.utm,
-      }),
-    };
-  } catch (error) {
-    console.warn(
-      `${request.warning}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-
-    return null;
-  }
-}
-
-function formatGitHubPrMentionReply(
-  outcome: GitHubPrMentionReplyOutcome,
-  link: GitHubPrMentionReplyLink | null,
-): string {
-  const replyCopy = (() => {
-    switch (outcome.kind) {
-      case 'active_follow_up':
-        return {
-          intro:
-            "I'm on it. I routed this request into the existing PR task so follow-up work stays on one Roomote thread for this PR, and I'll keep updates here.",
-          taskLinkText: 'See task',
-          fallback:
-            'I could not generate the task link for the PR comment, but the follow-up was delivered.',
-        };
-      case 'active_review':
-        return {
-          intro: 'I found an active PR review already running for this PR.',
-          taskLinkText: 'See task',
-          fallback:
-            'I could not generate the task link for the PR comment, but the review is already in progress.',
-        };
-      case 'dedicated_follow_up':
-        return {
-          intro:
-            "I'm on it. I started a dedicated PR follow-up task for this request, and I'll keep updates here.",
-          taskLinkText: 'See task',
-          fallback:
-            'I could not generate the task link for the PR comment, but the follow-up task is already running.',
-        };
-      case 'review_started':
-        if (outcome.partial) {
-          return {
-            intro:
-              'I started PR review tasks for part of this request, but at least one reviewer could not be started right now.',
-            taskLinkText: 'See one task',
-            fallback:
-              'I could not generate the task link for the PR comment, but one or more review tasks are already running.',
-          };
-        }
-
-        return outcome.count === 1
-          ? {
-              intro: 'I started a PR review task for this request.',
-              taskLinkText: 'See task',
-              fallback:
-                'I could not generate the task link for the PR comment, but the review task is already running.',
-            }
-          : {
-              intro: 'I started PR review tasks for this request.',
-              taskLinkText: 'See one task',
-              fallback:
-                'I could not generate the task link for the PR comment, but the review tasks are already running.',
-            };
-    }
-  })();
-
-  if (!link) {
-    return `${replyCopy.intro} ${replyCopy.fallback}`;
-  }
-
-  return `${replyCopy.intro} [${replyCopy.taskLinkText}](${link.url})`;
-}
-
-function buildDedicatedTaskStartFailedComment(): string {
-  return 'I saw the mention, but I could not start the PR follow-up task right now. Please try again in a moment.';
-}
-
-function buildReviewTaskStartFailedComment(): string {
-  return 'I saw the mention, but I could not start the PR review task right now. Please try again in a moment.';
-}
-
-function buildFollowUpSafetyCheckFailedComment(): string {
-  return 'I saw the mention, but I could not safely start PR follow-up on this PR right now because I could not verify the active PR branch. Please try again in a moment.';
+function buildInternalErrorComment(): string {
+  return `I saw the mention, but something went wrong on the ${PRODUCT_NAME} side. Please try again in a moment.`;
 }
 
 async function fetchReviewCommentSnapshot({
@@ -495,106 +423,6 @@ async function buildTriggeringCommentContext({
   return buildCompactTriggeringComment({ commenter, commentBody });
 }
 
-function buildActiveTaskFollowUpMessage({
-  repository,
-  prNumber,
-  prTitle,
-  prBody,
-  headRefName,
-  prAuthorLogin,
-  commentId,
-  commentBody,
-  triggeringComment,
-  reasoning,
-  issueComments,
-  reviewComments,
-  linkedReferencesSection,
-}: {
-  repository: string;
-  prNumber: number;
-  prTitle: string;
-  prBody?: string;
-  headRefName?: string;
-  prAuthorLogin?: string;
-  commentId?: number;
-  commentBody: string;
-  triggeringComment: string;
-  reasoning: string;
-  issueComments: Array<{ author: string; body: string }>;
-  reviewComments: Array<{ author: string; body: string; path?: string }>;
-  linkedReferencesSection?: string;
-}): string {
-  return buildGitHubExistingTaskFollowUpMessage({
-    routingReason: reasoning,
-    commentBody,
-    taskContext: {
-      repository,
-      pull_request_number: prNumber,
-      pull_request_details: buildCompactPullRequestDetails({
-        repository,
-        prNumber,
-        prTitle,
-        prBody,
-        headRefName,
-        prAuthorLogin,
-      }),
-      ...(commentId ? { triggering_comment_id: commentId } : {}),
-      triggering_comment: triggeringComment,
-      existing_review_comments:
-        formatCompactGitHubReviewComments(reviewComments),
-      issue_comments: formatCompactGitHubIssueComments(issueComments),
-      ...(linkedReferencesSection
-        ? { linked_issues_and_pull_requests: linkedReferencesSection }
-        : {}),
-    },
-  });
-}
-
-function buildRouterFailedComment(): string {
-  return 'I saw the mention, but I could not route it into follow-up work right now. Please try again in a moment.';
-}
-
-function buildInternalErrorComment(): string {
-  return 'I saw the mention, but I could not process it right now because the GitHub follow-up context was incomplete. Please try again in a moment.';
-}
-
-type PullRequestRoutingDetails = {
-  branchName: string;
-  prUrl: string;
-  headSha: string;
-};
-
-type GitHubRoutingHistoryContext = {
-  issueComments: Array<{ author: string; body: string }>;
-  reviewComments: Array<{ author: string; body: string; path?: string }>;
-};
-
-const EXISTING_TASK_WAIT_TIMEOUT_MS = 15_000;
-const EXISTING_TASK_WAIT_POLL_MS = 500;
-const GITHUB_ROUTING_HISTORY_PAGE_SIZE = 100;
-
-function asString(value: unknown): string | undefined {
-  return typeof value === 'string' ? value : undefined;
-}
-
-function getSelectedRepositories(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-
-  const repositories = value.filter(
-    (repository): repository is string => typeof repository === 'string',
-  );
-
-  return repositories.length > 0 ? repositories : undefined;
-}
-
-function getSlackOriginMessageTs(
-  value: Record<string, unknown>,
-): string | undefined {
-  return asString(value.slackOriginMessageTs) ?? asString(value.ts);
-}
-
 async function listGitHubRoutingHistoryPages<T>(
   fetchPage: (page: number) => Promise<T[]>,
 ): Promise<T[]> {
@@ -696,418 +524,6 @@ async function getGitHubRoutingHistoryContext({
   }
 }
 
-async function waitForTaskToAcceptMessages({
-  taskId,
-  timeoutMs = EXISTING_TASK_WAIT_TIMEOUT_MS,
-}: {
-  taskId: string;
-  timeoutMs?: number;
-}) {
-  const deadline = Date.now() + timeoutMs;
-
-  while (Date.now() < deadline) {
-    const latestRun = await findLatestTaskRun(taskId, {
-      id: true,
-      status: true,
-      taskPhase: true,
-      sandboxServerUrl: true,
-    });
-
-    if (!latestRun || isExitedRunStatus(latestRun.status)) {
-      return null;
-    }
-
-    if (latestRun.sandboxServerUrl) {
-      return latestRun;
-    }
-
-    await new Promise((resolve) =>
-      setTimeout(resolve, EXISTING_TASK_WAIT_POLL_MS),
-    );
-  }
-
-  return null;
-}
-
-function getDeferredResumePromptAccepted(result: unknown): boolean | null {
-  if (!result || typeof result !== 'object' || Array.isArray(result)) {
-    return null;
-  }
-
-  const accepted = (result as Record<string, unknown>)
-    .deferredResumePromptAccepted;
-
-  return typeof accepted === 'boolean' ? accepted : null;
-}
-
-async function waitForResumeRunToAcceptDeferredPrompt({
-  taskId,
-  resumeRunId,
-  timeoutMs = EXISTING_TASK_WAIT_TIMEOUT_MS,
-}: {
-  taskId: string;
-  resumeRunId: number;
-  timeoutMs?: number;
-}) {
-  const deadline = Date.now() + timeoutMs;
-  let latestRun:
-    | {
-        id: number;
-        status: RunStatus;
-        result: unknown;
-      }
-    | null
-    | undefined = null;
-
-  while (Date.now() < deadline) {
-    latestRun = await findLatestTaskRun(taskId, {
-      id: true,
-      status: true,
-      result: true,
-    });
-
-    if (!latestRun) {
-      return false;
-    }
-
-    if (latestRun.id === resumeRunId) {
-      const accepted = getDeferredResumePromptAccepted(latestRun.result);
-
-      if (accepted === true) {
-        return true;
-      }
-
-      if (accepted === false || isExitedRunStatus(latestRun.status)) {
-        return false;
-      }
-    }
-
-    await new Promise((resolve) =>
-      setTimeout(resolve, EXISTING_TASK_WAIT_POLL_MS),
-    );
-  }
-
-  if (!latestRun || latestRun.id !== resumeRunId) {
-    return false;
-  }
-
-  const accepted = getDeferredResumePromptAccepted(latestRun.result);
-
-  if (accepted === true) {
-    return true;
-  }
-
-  if (accepted === false || isExitedRunStatus(latestRun.status)) {
-    return false;
-  }
-
-  return null;
-}
-
-async function resolveReusableTaskSenderUserId({
-  taskId,
-  preferredUserId,
-}: {
-  taskId: string;
-  preferredUserId?: string | null;
-}): Promise<string | null> {
-  if (preferredUserId) {
-    return preferredUserId;
-  }
-
-  const latestRun = await findLatestTaskRun(taskId, {
-    id: true,
-    actingUserId: true,
-  });
-
-  if (!latestRun) {
-    return null;
-  }
-
-  // No forged fallback: when the run has no acting human, the follow-up has
-  // no deliverable human and callers handle null.
-  return latestRun.actingUserId ?? null;
-}
-
-/**
- * Resolve a display name for the Slack reply quote attribution so the quote
- * names the actual commenter rather than the reusable task owner (which
- * `resolveReusableTaskSenderUserId` falls back to when the commenter has no
- * linked account). Uses the linked Roomote user's name when available, the
- * GitHub login as a fallback, and returns undefined when neither is known.
- */
-async function resolveCommenterDisplayName({
-  commenterUserId,
-  commenterGithubLogin,
-}: {
-  commenterUserId: string | null | undefined;
-  commenterGithubLogin: string | null | undefined;
-}): Promise<string | undefined> {
-  if (commenterUserId) {
-    try {
-      return await getTrackedUserDisplayName(commenterUserId);
-    } catch {
-      // Fall through to the GitHub login fallback below.
-    }
-  }
-
-  const login = commenterGithubLogin?.trim();
-  return login ? login : undefined;
-}
-
-async function deliverFollowUpToExistingTask({
-  taskId,
-  userId,
-  message,
-  quoteText = message,
-  status,
-  taskPhase,
-  commenterDisplayName,
-}: {
-  taskId: string;
-  userId?: string | null;
-  message: string;
-  quoteText?: string;
-  status: RunStatus;
-  taskPhase: string | null;
-  commenterDisplayName?: string;
-}) {
-  const senderUserId = await resolveReusableTaskSenderUserId({
-    taskId,
-    preferredUserId: userId,
-  });
-
-  if (!senderUserId) {
-    return {
-      success: false as const,
-      error: 'Reusable PR owner has no delivery user',
-      status: 409 as const,
-    };
-  }
-
-  const deliver = ({
-    status,
-    taskPhase,
-  }: {
-    status: RunStatus;
-    taskPhase: string | null;
-  }) =>
-    isActivelyRunningTask(status, taskPhase)
-      ? steerMessageToTask({
-          taskId,
-          userId: senderUserId,
-          message,
-          quoteText,
-          senderMode: 'github_pr_follow_up',
-          ...(commenterDisplayName
-            ? { workerQuoteUserName: commenterDisplayName }
-            : {}),
-        })
-      : sendMessageToTask({
-          taskId,
-          userId: senderUserId,
-          message,
-          quoteText,
-          senderMode: 'github_pr_follow_up',
-          ...(commenterDisplayName
-            ? { workerQuoteUserName: commenterDisplayName }
-            : {}),
-        });
-
-  const initialAttempt = await deliver({ status, taskPhase });
-
-  if (
-    initialAttempt.success ||
-    initialAttempt.status !== 409 ||
-    !initialAttempt.error.includes('no active sandbox')
-  ) {
-    return initialAttempt;
-  }
-
-  const readyRun = await waitForTaskToAcceptMessages({ taskId });
-
-  if (!readyRun) {
-    return initialAttempt;
-  }
-
-  return deliver({
-    status: readyRun.status,
-    taskPhase: readyRun.taskPhase,
-  });
-}
-
-export async function resumeExistingTaskAndDeliverFollowUp({
-  taskId,
-  userId,
-  sourceRunId,
-  message,
-  quoteText = message,
-  resumePromptFallbackTask,
-}: {
-  taskId: string;
-  userId?: string | null;
-  sourceRunId: number;
-  message: string;
-  quoteText?: string;
-  resumePromptFallbackTask: SnapshotResumePromptFallbackTask;
-}) {
-  const sourceRun = await findLatestTaskRun(taskId, {
-    id: true,
-    status: true,
-    taskPhase: true,
-    snapshotId: true,
-    snapshotCreatedAt: true,
-    payload: true,
-    port: true,
-    actingUserId: true,
-  });
-
-  if (!sourceRun) {
-    return { success: false as const, error: 'Task not found', status: 404 };
-  }
-
-  if (sourceRun.id !== sourceRunId) {
-    return {
-      success: false as const,
-      error: 'Reusable PR owner changed before follow-up delivery',
-      status: 409,
-    };
-  }
-
-  if (!sourceRun.snapshotId) {
-    return {
-      success: false as const,
-      error: 'Reusable PR owner has no snapshot to resume',
-      status: 409,
-    };
-  }
-
-  if (!isSnapshotResumable(sourceRun.snapshotCreatedAt)) {
-    return {
-      success: false as const,
-      error: EXPIRED_SNAPSHOT_RESUME_ERROR,
-      status: 409,
-    };
-  }
-
-  if (!isExitedRunStatus(sourceRun.status)) {
-    return deliverFollowUpToExistingTask({
-      taskId,
-      userId,
-      message,
-      quoteText,
-      status: sourceRun.status,
-      taskPhase: sourceRun.taskPhase,
-    });
-  }
-
-  if (!sourceRun.snapshotId) {
-    return {
-      success: false as const,
-      error: 'Reusable PR owner has no snapshot to resume',
-      status: 409,
-    };
-  }
-
-  // Prefer the linked commenter, then the run's acting user. No forged
-  // fallback: a run without an acting human and an unlinked commenter has no
-  // delivery user and is rejected below.
-  const senderUserId = userId ?? sourceRun.actingUserId;
-
-  if (!senderUserId) {
-    return {
-      success: false as const,
-      error: 'Reusable PR owner has no delivery user',
-      status: 409,
-    };
-  }
-
-  const sourcePayload = (sourceRun.payload ?? {}) as Record<string, unknown>;
-  const selectedRepositories = getSelectedRepositories(
-    sourcePayload.selectedRepositories,
-  );
-  const slackOriginMessageTs = getSlackOriginMessageTs(sourcePayload);
-  const channelBindings = await getTaskChannelBindings(taskId);
-
-  const resumePayload = {
-    repo: asString(sourcePayload.repo) ?? '',
-    environmentId: asString(sourcePayload.environmentId),
-    port: sourceRun.port ?? undefined,
-    sourceSnapshotId: sourceRun.snapshotId,
-    sourceRunId: sourceRun.id,
-    ...(selectedRepositories ? { selectedRepositories } : {}),
-    ...(slackOriginMessageTs ? { slackOriginMessageTs } : {}),
-    // Carry the follow-up on the resume run itself so the resumed worker can
-    // send it after the harness session is actually ready.
-    resumePrompt: message,
-    resumeQuoteText: quoteText,
-    resumePromptSource: 'github',
-    resumePromptFallbackTask,
-  } satisfies TaskPayload<typeof TaskPayloadKind.SnapshotResume>;
-  populateSnapshotResumeSlackMetadata(resumePayload, {
-    sourcePayload,
-    channel: channelBindings?.slackChannelId,
-    threadTs: channelBindings?.slackThreadTs,
-  });
-  restoreSnapshotResumeVisiblePromptFields(resumePayload, sourcePayload);
-
-  // Resumes never create tasks and never re-attribute; the resuming human
-  // becomes the new run's acting user.
-  let resumeLaunch: Awaited<ReturnType<typeof enqueueTask>>;
-  try {
-    resumeLaunch = await enqueueTask(
-      {
-        task: {
-          type: TaskPayloadKind.SnapshotResume,
-          sourceSnapshotId: sourceRun.snapshotId,
-          sourceRunId: sourceRun.id,
-          payload: resumePayload,
-        },
-        actingUserId: senderUserId,
-      },
-      {},
-    );
-  } catch (error) {
-    if (error instanceof SnapshotResumeAlreadyExistsError) {
-      // Continue through the normal fallback path so this distinct instruction
-      // gets its own linked follow-up task and response instead of being lost.
-      return {
-        success: false as const,
-        error: 'Reusable PR owner is already resuming',
-        status: 409,
-      };
-    }
-    throw error;
-  }
-
-  const accepted = await waitForResumeRunToAcceptDeferredPrompt({
-    taskId,
-    resumeRunId: resumeLaunch.id,
-  });
-
-  if (accepted === false) {
-    const fallbackTaskRun = await ensureSnapshotResumeGitHubFollowUpFallback({
-      resumeRunId: resumeLaunch.id,
-    });
-
-    return {
-      success: false as const,
-      error: 'Resumed PR owner did not accept the deferred follow-up prompt',
-      status: 409,
-      fallbackTaskRun,
-    };
-  }
-
-  return {
-    success: true as const,
-    result: {
-      accepted: true,
-      queuedToResumeRunId: resumeLaunch.id,
-      ...(accepted === null ? { pendingResumePromptAcceptance: true } : {}),
-    },
-  };
-}
-
 async function getPullRequestRoutingDetails({
   eventPayload,
   installationId,
@@ -1159,11 +575,95 @@ async function getPullRequestRoutingDetails({
   }
 }
 
+/**
+ * What the Session reads with a pull request mention: the pull request, the
+ * comment that mentioned Roomote (with the review thread it replies to), the
+ * discussion so far, and any linked issues or pull requests.
+ */
+function buildPullRequestMentionContext({
+  details,
+  triggeringComment,
+  history,
+  linkedReferencesSection,
+}: {
+  details: string;
+  triggeringComment: string;
+  history: GitHubRoutingHistoryContext;
+  linkedReferencesSection?: string;
+}): string {
+  return [
+    '<github_pull_request>',
+    details,
+    '</github_pull_request>',
+    '<triggering_comment>',
+    triggeringComment,
+    '</triggering_comment>',
+    ...(history.issueComments.length > 0
+      ? [
+          '<pull_request_discussion>',
+          formatCompactGitHubIssueComments(history.issueComments) ?? '',
+          '</pull_request_discussion>',
+        ]
+      : []),
+    ...(history.reviewComments.length > 0
+      ? [
+          '<pull_request_review_comments>',
+          formatCompactGitHubReviewComments(history.reviewComments) ?? '',
+          '</pull_request_review_comments>',
+        ]
+      : []),
+    ...(linkedReferencesSection ? [linkedReferencesSection] : []),
+    'This conversation is a GitHub pull request discussion. Your replies post as comments on the pull request, so keep them concise. Delegated tasks check out the head branch of this pull request.',
+  ].join('\n');
+}
+
+/**
+ * Tasks the Session may steer on this turn: a task that already owns this
+ * pull request, and an in-flight review of the current head.
+ */
+async function resolvePullRequestActiveTasks({
+  repositoryFullName,
+  prNumber,
+  branchName,
+  headSha,
+}: {
+  repositoryFullName: string;
+  prNumber: number;
+  branchName: string;
+  headSha: string;
+}): Promise<FastAgentActiveTask[]> {
+  const [owner, review] = await Promise.all([
+    findReusableGitHubPrFollowUpOwner({
+      repoFullName: repositoryFullName,
+      prNumber,
+      branchName,
+    }).catch(() => null),
+    headSha
+      ? findActiveGitHubPrReviewTask({
+          repoFullName: repositoryFullName,
+          prNumber,
+          headSha,
+          sourceControlProvider: 'github',
+        }).catch(() => null)
+      : Promise.resolve(null),
+  ]);
+  const tasks = new Map<string, FastAgentActiveTask>();
+  if (owner?.taskId) {
+    tasks.set(owner.taskId, { taskId: owner.taskId, status: owner.status });
+  }
+  if (review?.taskId) {
+    tasks.set(review.taskId, { taskId: review.taskId, status: review.status });
+  }
+  return [...tasks.values()];
+}
+
+/**
+ * Every @mention on a pull request enters the pull request's Fast Session.
+ * The Session reads the discussion, replies as a comment, and delegates work
+ * to a task on the pull request's branch when the request needs one.
+ */
 export async function handlePrComment(
-  eventPayload:
-    | WebhookPullRequestCommentCreated
-    | WebhookIssueCommentCreated
-    | WebhookPullRequestReviewSubmitted,
+  eventPayload: PullRequestMentionEvent,
 ): Promise<WebhookResponse> {
   const { installation, repository, sender, ...rest } = eventPayload;
   const isSubmittedReview = 'review' in rest;
@@ -1198,6 +698,7 @@ export async function handlePrComment(
     return { status: 'ok', message: 'no_pr_author' };
   }
 
+  // The commenter must be a linked Roomote user: the Session runs as them.
   const reviewerGate = await getGitHubAutomationTargets({
     workflow: 'pr_review',
     installation,
@@ -1227,506 +728,114 @@ export async function handlePrComment(
     };
   }
 
-  const reviewers = reviewerGate.targets;
-  const reviewer = reviewers[0];
+  const commenter = reviewerGate.targets[0];
+  const commenterUserId = commenter?.properties.userId;
 
-  if (!reviewer) {
+  if (!commenter || !commenterUserId) {
     await postMentionResponseComment({
       installationId: githubInstallationId,
       target: mentionResponseTarget,
-      body: buildInternalErrorComment(),
+      body: await buildSourceControlAccountLinkRequiredMessage('github'),
     });
 
-    return { status: 'error', message: 'no_reviewer_context' };
+    return { status: 'ok', message: 'account_link_required' };
   }
 
-  const routingDetails = await getPullRequestRoutingDetails({
-    eventPayload,
+  await acknowledgeMentionBestEffort({
     installationId: githubInstallationId,
+    eventPayload,
+  });
+
+  const [details, history, linkedReferences, triggeringComment] =
+    await Promise.all([
+      getPullRequestRoutingDetails({
+        eventPayload,
+        installationId: githubInstallationId,
+        repositoryFullName: repository.full_name,
+        prNumber: pr.number,
+      }),
+      getGitHubRoutingHistoryContext({
+        installationId: githubInstallationId,
+        repositoryFullName: repository.full_name,
+        prNumber: pr.number,
+      }),
+      fetchGitHubLinkedReferences({
+        installationId: githubInstallationId,
+        repositoryFullName: repository.full_name,
+        issueOrPrNumber: pr.number,
+      }),
+      buildTriggeringCommentContext({
+        eventPayload,
+        installationId: githubInstallationId,
+        repositoryFullName: repository.full_name,
+        commenter: sender.login,
+        commentBody: mention.body ?? '',
+      }),
+    ]);
+
+  const host =
+    commenter.repo.host ??
+    toHostFromUrl(
+      details.prUrl ||
+        `https://github.com/${repository.full_name}/pull/${pr.number}`,
+    ) ??
+    'github.com';
+  const discussion: SourceControlFastDiscussion = {
+    provider: 'github',
+    host,
+    repositoryFullName: repository.full_name,
+    kind: 'pull',
+    number: pr.number,
+    ...(mentionResponseTarget.reviewCommentId
+      ? { reviewCommentId: String(mentionResponseTarget.reviewCommentId) }
+      : {}),
+  };
+  const activeTasks = await resolvePullRequestActiveTasks({
     repositoryFullName: repository.full_name,
     prNumber: pr.number,
+    branchName: details.branchName,
+    headSha: details.headSha,
   });
+  const currentMessageId = isSubmittedReview
+    ? `github:review:${rest.review.id}`
+    : `github:comment:${rest.comment.id}`;
 
-  const routingContext = buildGitHubRoutingContext({
-    taskDescription: mention.body ?? '',
-    repository: repository.full_name,
-    headRefName: routingDetails.branchName || undefined,
-    prAuthorLogin: pr.user?.login ?? undefined,
-    issueOrPrTitle: pr.title,
-    issueOrPrBody: pr.body ?? undefined,
-    commentBody: mention.body ?? '',
-  });
-
-  const routingDecision = await routeGitHubTask(routingContext);
-
-  if (routingDecision.status === 'fallback') {
-    await postMentionResponseComment({
-      installationId: githubInstallationId,
-      target: mentionResponseTarget,
-      body: buildRouterFailedComment(),
-    });
-
-    return {
-      status: 'error',
-      message: `router_failed:${routingDecision.reason}`,
-    };
-  }
-
-  const routingReason = routingDecision.result.reasoning;
-
-  if (routingDecision.result.followUpMode === 'review') {
-    const { branchName, prUrl, headSha } = routingDetails;
-
-    if (!branchName || !prUrl || !headSha) {
-      await postMentionResponseComment({
-        installationId: githubInstallationId,
-        target: mentionResponseTarget,
-        body: buildReviewTaskStartFailedComment(),
-      });
-
-      return {
-        status: 'error',
-        message: 'review_start_context_incomplete',
-      };
-    }
-
-    const activeReviewTask = await findActiveGitHubPrReviewTask({
-      repoFullName: repository.full_name,
-      prNumber: pr.number,
-      headSha,
-    });
-
-    if (activeReviewTask?.taskId) {
-      const taskCommentBody = formatGitHubPrMentionReply(
-        { kind: 'active_review' },
-        tryBuildGitHubPrMentionReplyLink({
-          kind: 'task',
-          taskId: activeReviewTask.taskId,
-          utm: {
-            source: 'github-comment',
-            campaign: 'github.pr.mention.review.active',
-          },
-          warning: `[handlePrComment] failed to build active PR review task link for ${repository.full_name}#${pr.number}`,
-        }),
-      );
-
-      await postMentionResponseComment({
-        installationId: githubInstallationId,
-        target: mentionResponseTarget,
-        body: taskCommentBody,
-      });
-
-      return { status: 'ok', message: 'active_pr_review_linked' };
-    }
-
-    const reviewPayloadBase = {
-      repo: repository.full_name,
-      prNumber: pr.number,
-      prTitle: pr.title,
-      prUrl,
-      headSha,
-      branchName,
-    };
-
-    const reviewLaunches: Array<Awaited<ReturnType<typeof enqueueTask>>> = [];
-    const failedReviewerIds: string[] = [];
-
-    for (const reviewer of reviewers) {
-      const relayPayload = await getReviewTaskRelayPayload({
+  const started = await startSourceControlFastSessionTurn({
+    discussion,
+    userId: commenterUserId,
+    senderDisplayName: sender.login,
+    question: mention.body ?? '',
+    agentContext: buildPullRequestMentionContext({
+      details: buildCompactPullRequestDetails({
         repository: repository.full_name,
         prNumber: pr.number,
-        branchName,
-        prBody: pr.body ?? null,
-        reviewerSettings: reviewer.settings,
-      });
-      const reviewPayload = {
-        ...reviewPayloadBase,
-        ...relayPayload,
-      } satisfies TaskPayload<typeof TaskPayloadKind.GithubPrReview>;
-
-      try {
-        if (!reviewer.properties.userId) {
-          throw new Error(
-            'PR mention review requires a linked commenter account.',
-          );
-        }
-
-        const releaseLifecycleLock = await acquireGithubPrReviewLifecycleLock(
-          repository.full_name,
-          pr.number,
-        );
-        if (!releaseLifecycleLock) {
-          throw new Error(
-            `Timed out serializing PR review launch for ${repository.full_name}#${pr.number}`,
-          );
-        }
-
-        try {
-          releaseLifecycleLock.signal.throwIfAborted();
-          const reviewLaunch = await enqueueTask({
-            task: {
-              type: TaskPayloadKind.GithubPrReview,
-              githubLogin: reviewer.properties.githubLogin,
-              githubUserId: reviewer.properties.githubUserId,
-              payload: reviewPayload,
-            },
-            // A human @roomote mention started this review.
-            initiator: { kind: 'user', userId: reviewer.properties.userId },
-            workflow: 'pr_review',
-            surface: 'github',
-            trigger: 'message',
-            prLinkage: {
-              provider: 'github',
-              host: reviewer.repo.host ?? toHostFromUrl(prUrl) ?? 'github.com',
-              repositoryId: reviewer.repo.id,
-              repository: repository.full_name,
-              prNumber: pr.number,
-              prUrl,
-              prTitle: pr.title,
-              prSha: headSha,
-            },
-          });
-          if (reviewer.settings?.publishGithubCheck) {
-            releaseLifecycleLock.signal.throwIfAborted();
-            await publishGithubPrReviewCheck({
-              installationId: githubInstallationId,
-              repository: repository.full_name,
-              prNumber: pr.number,
-              headSha,
-              taskId: reviewLaunch.taskId,
-              runId: reviewLaunch.id,
-              signal: releaseLifecycleLock.signal,
-            });
-          }
-          reviewLaunches.push(reviewLaunch);
-        } finally {
-          await releaseLifecycleLock();
-        }
-      } catch (error) {
-        failedReviewerIds.push(reviewer.id);
-        console.warn(
-          `[handlePrComment] failed to start PR review task for reviewer ${reviewer.id} on ${repository.full_name}#${pr.number}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    }
-
-    if (reviewLaunches.length === 0) {
-      await postMentionResponseComment({
-        installationId: githubInstallationId,
-        body: buildReviewTaskStartFailedComment(),
-        target: mentionResponseTarget,
-      });
-
-      return {
-        status: 'error',
-        message: failedReviewerIds.length
-          ? `review_start_failed:failed_reviewers=${failedReviewerIds.join(',')}`
-          : 'review_start_failed:No PR review tasks were enqueued',
-      };
-    }
-
-    try {
-      const directReviewLaunches = reviewLaunches;
-      const firstDirectReviewLaunch = directReviewLaunches[0];
-      const taskCommentBody = formatGitHubPrMentionReply(
-        {
-          kind: 'review_started',
-          count: reviewLaunches.length,
-          partial: failedReviewerIds.length > 0,
-        },
-        firstDirectReviewLaunch
-          ? tryBuildGitHubPrMentionReplyLink({
-              kind: 'task',
-              taskId: firstDirectReviewLaunch.taskId,
-              utm: {
-                source: 'github-comment',
-                campaign: 'github.pr.mention.review',
-              },
-              warning: `[handlePrComment] failed to build PR review task link for ${repository.full_name}#${pr.number}`,
-            })
-          : null,
-      );
-
-      await postMentionResponseComment({
-        installationId: githubInstallationId,
-        target: mentionResponseTarget,
-        body: taskCommentBody,
-      });
-
-      const metadata = {
-        ...(directReviewLaunches.length > 0
-          ? {
-              ids: directReviewLaunches.map((launch) => launch.id),
-            }
-          : {}),
-      };
-
-      return {
-        status: 'ok',
-        ...(failedReviewerIds.length > 0
-          ? {
-              message: `review_start_partial:failed_reviewers=${failedReviewerIds.join(',')}`,
-            }
-          : {}),
-        metadata,
-      };
-    } catch (error) {
-      console.warn(
-        `[handlePrComment] failed to start PR review task for ${repository.full_name}#${pr.number}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-
-      await postMentionResponseComment({
-        installationId: githubInstallationId,
-        body: buildReviewTaskStartFailedComment(),
-        target: mentionResponseTarget,
-      });
-
-      return {
-        status: 'error',
-        message: `review_start_failed:${error instanceof Error ? error.message : String(error)}`,
-      };
-    }
-  }
-
-  const branchName = routingDetails.branchName;
-
-  const activePrOwner = await findReusableGitHubPrFollowUpOwner({
-    repoFullName: repository.full_name,
-    prNumber: pr.number,
-    branchName,
-  });
-
-  if (activePrOwner?.taskId) {
-    const [routingHistory, linkedReferences, triggeringComment] =
-      await Promise.all([
-        getGitHubRoutingHistoryContext({
-          installationId: githubInstallationId,
-          repositoryFullName: repository.full_name,
-          prNumber: pr.number,
-        }),
-        fetchGitHubLinkedReferences({
-          installationId: githubInstallationId,
-          repositoryFullName: repository.full_name,
-          issueOrPrNumber: pr.number,
-        }),
-        buildTriggeringCommentContext({
-          eventPayload,
-          installationId: githubInstallationId,
-          repositoryFullName: repository.full_name,
-          commenter: sender.login,
-          commentBody: mention.body ?? '',
-        }),
-      ]);
-    const followUpMessage = buildActiveTaskFollowUpMessage({
-      repository: repository.full_name,
-      prNumber: pr.number,
-      prTitle: pr.title,
-      prBody: pr.body ?? undefined,
-      headRefName: branchName || undefined,
-      prAuthorLogin: pr.user?.login ?? undefined,
-      commentId: !isSubmittedReview ? rest.comment.id : undefined,
-      commentBody: mention.body ?? '',
+        prTitle: pr.title,
+        prBody: pr.body ?? undefined,
+        headRefName: details.branchName || undefined,
+        prAuthorLogin: pr.user?.login ?? undefined,
+      }),
       triggeringComment,
-      reasoning: routingReason,
-      issueComments: routingHistory.issueComments,
-      reviewComments: routingHistory.reviewComments,
+      history,
       linkedReferencesSection:
         formatGitHubLinkedReferencesSection(linkedReferences),
-    });
-    const resumePromptFallbackTask = {
-      type: TaskPayloadKind.GithubPrReviewFollowUp,
-      userId: reviewer.properties.userId ?? undefined,
-      githubLogin: reviewer.properties.githubLogin ?? undefined,
-      githubUserId: reviewer.properties.githubUserId ?? undefined,
-      payload: {
-        repo: repository.full_name,
-        prNumber: pr.number,
-        prTitle: pr.title,
-        ...(!isSubmittedReview ? { commentId: rest.comment.id } : {}),
-        commentBody: mention.body ?? '',
-        followUpSource: 'github_mention',
-      },
-    } satisfies SnapshotResumePromptFallbackTask;
-    const commenterDisplayName = await resolveCommenterDisplayName({
-      commenterUserId: reviewer.properties.userId,
-      commenterGithubLogin: reviewer.properties.githubLogin,
-    });
-    const followUpResult =
-      activePrOwner.delivery === 'resume'
-        ? await resumeExistingTaskAndDeliverFollowUp({
-            taskId: activePrOwner.taskId,
-            userId: reviewer.properties.userId,
-            sourceRunId: activePrOwner.runId,
-            message: followUpMessage,
-            quoteText: mention.body ?? '',
-            resumePromptFallbackTask,
-          })
-        : await deliverFollowUpToExistingTask({
-            taskId: activePrOwner.taskId,
-            userId: reviewer.properties.userId,
-            message: followUpMessage,
-            quoteText: mention.body ?? '',
-            status: activePrOwner.status,
-            taskPhase: activePrOwner.taskPhase,
-            commenterDisplayName,
-          });
+    }),
+    currentMessageId,
+    activeTasks,
+  });
 
-    if (followUpResult.success) {
-      const taskCommentBody = formatGitHubPrMentionReply(
-        { kind: 'active_follow_up' },
-        tryBuildGitHubPrMentionReplyLink({
-          kind: 'task',
-          taskId: activePrOwner.taskId,
-          utm: {
-            source: 'github-comment',
-            campaign: 'github.pr.mention.active-owner',
-          },
-          warning: `[handlePrComment] failed to build active PR owner task link for ${repository.full_name}#${pr.number}`,
-        }),
-      );
-
-      await postMentionResponseComment({
-        installationId: githubInstallationId,
-        target: mentionResponseTarget,
-        body: taskCommentBody,
-      });
-
-      return { status: 'ok', message: 'active_pr_owner_routed' };
-    }
-
-    console.warn(
-      `[handlePrComment] failed to deliver routed PR mention to reusable task ${activePrOwner.taskId}: ${followUpResult.error}`,
-    );
-
-    const fallbackTaskRun =
-      'fallbackTaskRun' in followUpResult
-        ? followUpResult.fallbackTaskRun
-        : null;
-
-    if (fallbackTaskRun) {
-      const taskCommentBody = formatGitHubPrMentionReply(
-        { kind: 'dedicated_follow_up' },
-        fallbackTaskRun.taskId
-          ? tryBuildGitHubPrMentionReplyLink({
-              kind: 'task',
-              taskId: fallbackTaskRun.taskId,
-              utm: {
-                source: 'github-comment',
-                campaign: 'github.pr.mention',
-              },
-              warning: `[handlePrComment] failed to build fallback PR follow-up task link for ${repository.full_name}#${pr.number}`,
-            })
-          : null,
-      );
-
-      await postMentionResponseComment({
-        installationId: githubInstallationId,
-        target: mentionResponseTarget,
-        body: taskCommentBody,
-      });
-
-      return { status: 'ok', metadata: { ids: [fallbackTaskRun.id] } };
-    }
-  }
-
-  if (!branchName) {
+  if (started.status !== 'queued') {
     await postMentionResponseComment({
       installationId: githubInstallationId,
       target: mentionResponseTarget,
-      body: buildFollowUpSafetyCheckFailedComment(),
+      body: FAST_UNAVAILABLE_COMMENT,
     });
 
-    return {
-      status: 'error',
-      message: 'active_pr_owner_branch_unknown',
-    };
+    return { status: 'error', message: 'fast_unavailable' };
   }
 
-  const payload = {
-    repo: repository.full_name,
-    prNumber: pr.number,
-    prTitle: pr.title,
-    ...(!isSubmittedReview ? { commentId: rest.comment.id } : {}),
-    commentBody: mention.body ?? '',
-    followUpSource: 'github_mention',
-  } satisfies TaskPayload<typeof TaskPayloadKind.GithubPrReviewFollowUp>;
-
-  try {
-    if (!reviewer.properties.userId) {
-      throw new Error(
-        'PR mention follow-up requires a linked commenter account.',
-      );
-    }
-
-    const followUpLaunch = await enqueueTask({
-      task: {
-        type: TaskPayloadKind.GithubPrReviewFollowUp,
-        githubLogin: reviewer.properties.githubLogin,
-        githubUserId: reviewer.properties.githubUserId,
-        payload,
-      },
-      // A human @roomote mention started this follow-up.
-      initiator: { kind: 'user', userId: reviewer.properties.userId },
-      workflow: 'pr_review',
-      surface: 'github',
-      trigger: 'message',
-      prLinkage: {
-        provider: 'github',
-        host:
-          reviewer.repo.host ??
-          toHostFromUrl(
-            routingDetails.prUrl ||
-              `https://github.com/${repository.full_name}/pull/${pr.number}`,
-          ) ??
-          'github.com',
-        repositoryId: reviewer.repo.id,
-        repository: repository.full_name,
-        prNumber: pr.number,
-        prUrl:
-          routingDetails.prUrl ||
-          `https://github.com/${repository.full_name}/pull/${pr.number}`,
-        prTitle: pr.title,
-        ...(routingDetails.headSha ? { prSha: routingDetails.headSha } : {}),
-      },
-    });
-
-    const taskCommentBody = formatGitHubPrMentionReply(
-      { kind: 'dedicated_follow_up' },
-      tryBuildGitHubPrMentionReplyLink({
-        kind: 'task',
-        taskId: followUpLaunch.taskId,
-        utm: {
-          source: 'github-comment',
-          campaign: 'github.pr.mention',
-        },
-        warning: `[handlePrComment] failed to build dedicated PR follow-up task link for ${repository.full_name}#${pr.number}`,
-      }),
-    );
-
-    await postMentionResponseComment({
-      installationId: githubInstallationId,
-      target: mentionResponseTarget,
-      body: taskCommentBody,
-    });
-
-    return {
-      status: 'ok',
-      metadata: { ids: [followUpLaunch.id] },
-    };
-  } catch (error) {
-    console.warn(
-      `[handlePrComment] failed to start dedicated PR follow-up task for ${repository.full_name}#${pr.number}: ${error instanceof Error ? error.message : String(error)}`,
-    );
-
-    await postMentionResponseComment({
-      installationId: githubInstallationId,
-      body: buildDedicatedTaskStartFailedComment(),
-      target: mentionResponseTarget,
-    });
-
-    return {
-      status: 'error',
-      message: `followup_start_failed:${error instanceof Error ? error.message : String(error)}`,
-    };
-  }
+  return {
+    status: 'ok',
+    message: 'fast_session_queued',
+    metadata: { fastConversationId: started.fastConversationId },
+  };
 }

--- a/apps/api/src/handlers/tasks/sendMessageToTask.ts
+++ b/apps/api/src/handlers/tasks/sendMessageToTask.ts
@@ -207,9 +207,7 @@ async function fetchSandboxRpcResponseOrThrowIfNotReady(
   });
 }
 
-export async function getTrackedUserDisplayName(
-  userId: string,
-): Promise<string> {
+async function getTrackedUserDisplayName(userId: string): Promise<string> {
   const user = await db.query.users.findFirst({
     where: eq(users.id, userId),
     columns: {

--- a/apps/docs/providers/source-control/github.mdx
+++ b/apps/docs/providers/source-control/github.mdx
@@ -217,14 +217,17 @@ issue-search URL, but it does not represent that URL as a saved GitHub view.
 Once the app is installed and an environment maps the repository:
 
 - mention `@roomote` (or your deployment's GitHub App slug) in a pull request
-  comment to start PR review or follow-up work
+  comment, review comment, or review to talk to Roomote about that pull request
 - mention the same handle in a GitHub issue comment, or in a new issue body, to
-  start a standard task against that repository
+  talk to Roomote about that issue
 - link your GitHub account under Settings -> Linked Accounts so Roomote can
-  attribute the task to you
+  run the conversation as you
 
-Issue mentions use the environment mapped to the repository. Map the repository
-to an environment before mentioning Roomote on issues.
+Each pull request or issue is a Roomote Session. Roomote reads the discussion,
+answers as a comment when no workspace is needed, and otherwise starts a task
+on the pull request's branch (or the issue's repository) and reports back in
+the same discussion. Mention it again to redirect it, ask a follow-up, or
+steer a running task. Replies to a review comment stay in that review thread.
 
 When a Roomote task opens a pull request, actionable review feedback returns to
 the owning Session and appears in both Fast and standard web task transcripts.

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
@@ -165,9 +165,19 @@ export function buildFastAgentSystemPrompt({
             ? 'Telegram'
             : surface === 'linear'
               ? 'a Linear agent session'
-              : surface === 'web'
-                ? 'the Roomote web app'
-                : 'a stored automation conversation';
+              : surface === 'github'
+                ? 'a GitHub pull request or issue discussion'
+                : surface === 'gitlab'
+                  ? 'a GitLab merge request or issue discussion'
+                  : surface === 'bitbucket'
+                    ? 'a Bitbucket pull request discussion'
+                    : surface === 'ado'
+                      ? 'an Azure DevOps pull request or work item discussion'
+                      : surface === 'gitea'
+                        ? 'a Gitea pull request or issue discussion'
+                        : surface === 'web'
+                          ? 'the Roomote web app'
+                          : 'a stored automation conversation';
   const reactionGuidance =
     surface === 'slack' && currentMessageReactable
       ? '- Use `send_chat_reaction` only for an optional reaction or an emoji-only terminal answer. It does not satisfy the turn-start acknowledgement required before continuing work. Put the Slack emoji name without colons in `name`. Reserve "eyes" for actively looking, use "thumbsup" for acknowledgement or agreement, and "white_check_mark" for completion.'

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
@@ -10,7 +10,11 @@ import {
   type TaskTrigger,
 } from '@roomote/types';
 
-import { enqueueTask, type TaskChannelBindings } from '../task-run-queue';
+import {
+  enqueueTask,
+  type TaskChannelBindings,
+  type TaskPrLinkage,
+} from '../task-run-queue';
 import { getTaskUrl } from '../task-url';
 import type { LaunchFastAgentTask } from './fast-agent-conversation';
 
@@ -39,6 +43,8 @@ export function createFastAgentTaskLauncher(
     taskUrlCampaign: string;
     /** Provider bindings recorded on the task, for example a Linear session. */
     channels?: TaskChannelBindings;
+    /** Pull request the task works on, recorded with the task at launch. */
+    prLinkage?: TaskPrLinkage;
     buildTask: (input: {
       prompt: string;
       environmentId: string | null;
@@ -101,6 +107,7 @@ export function createFastAgentTaskLauncher(
         surface: params.surface,
         trigger: params.trigger ?? 'message',
         ...(params.channels ? { channels: params.channels } : {}),
+        ...(params.prLinkage ? { prLinkage: params.prLinkage } : {}),
       },
       {
         beforeEnqueue: async (taskRun) => {

--- a/packages/communication/src/fast-session-footer.ts
+++ b/packages/communication/src/fast-session-footer.ts
@@ -21,7 +21,12 @@ export type FastSessionFooterProvider =
   | 'slack'
   | 'discord'
   | 'teams'
-  | 'telegram';
+  | 'telegram'
+  | 'github'
+  | 'gitlab'
+  | 'bitbucket'
+  | 'ado'
+  | 'gitea';
 
 export type FastSessionPullRequestReference = {
   number: number | null;

--- a/packages/db/src/lib/pr-review-notification-units.ts
+++ b/packages/db/src/lib/pr-review-notification-units.ts
@@ -7,6 +7,7 @@ import {
   getFastAgentParentFromPayload,
   RunStatus,
   type SourceControlProvider,
+  isFastAgentSourceControlConversation,
 } from '@roomote/types';
 
 import { db, type DatabaseOrTransaction } from '../db';
@@ -248,7 +249,8 @@ function fastDestination(
   if (
     conversation.surface === 'automation' ||
     conversation.surface === 'web' ||
-    conversation.surface === 'linear'
+    conversation.surface === 'linear' ||
+    isFastAgentSourceControlConversation(conversation)
   ) {
     // Surfaces without a chat route (identity-only, or a Linear agent
     // session) have no reply channel; delivery resolves the Fast

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -316,6 +316,8 @@ export * from './lib/task-runs/pr-review-follow-up-dispatch';
 export * from './lib/fast-agent-surface-reply';
 export * from './lib/linear-fast-session';
 export * from './lib/linear-fast-session-turn';
+export * from './lib/source-control-fast-delivery';
+export * from './lib/source-control-fast-session';
 export * from './lib/fast-agent-slack-reply-stream';
 export * from './lib/fast-agent-provider-message';
 export * from './lib/task-runs/notify-fast-agent-parent-on-pr-feedback';

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -59,6 +59,7 @@ import {
   type TaskRunErrorCode,
   type SourceControlProvider,
   type StandardTask,
+  isFastAgentSourceControlConversation,
 } from '@roomote/types';
 
 import { resolveUserMcpServerConfigs } from '../routers/mcp-connections';
@@ -67,6 +68,10 @@ import {
   createFastAgentLinearTaskLauncher,
   resolveLinearFastSessionClient,
 } from './linear-fast-session';
+import {
+  buildSourceControlFastAdapter,
+  buildSourceControlFastDelivery,
+} from './source-control-fast-delivery';
 import { buildCustomAutomationSlackMessage } from './manager-slack';
 import {
   appendFastAutomationSuggestionInstruction,
@@ -1569,6 +1574,56 @@ async function createLinearFastAgentParentTurn(params: {
   };
 }
 
+/**
+ * A pull request or issue discussion: child outcomes post as comments the
+ * same way the Session's own replies do.
+ */
+async function createSourceControlFastAgentParentTurn(params: {
+  parent: FastAgentParent;
+  event: FastAgentParentEvent;
+  actorUserId?: string;
+  onReplyPosted: () => void;
+}): Promise<FastAgentParentTurn> {
+  const fallbackConversation = params.parent.conversation;
+  if (!isFastAgentSourceControlConversation(fallbackConversation)) {
+    throw new Error('Expected a source-control Fast parent conversation.');
+  }
+  const session = await fastAgentConversationRepository.findById({
+    id: params.parent.sessionId,
+    fallbackConversation,
+  });
+  const conversation = session?.conversation;
+  if (
+    !session ||
+    !conversation ||
+    !isFastAgentSourceControlConversation(conversation)
+  ) {
+    throw new FastAgentParentEventDeliveryError(
+      'Fast source-control parent session was not found.',
+      { replyPosted: false, permanent: true },
+    );
+  }
+  const delivery = await buildSourceControlFastDelivery(conversation);
+  if (!delivery) {
+    throw new FastAgentParentEventDeliveryError(
+      'The repository for this Fast parent session is not connected.',
+      { replyPosted: false, permanent: true },
+    );
+  }
+  const actorUserId = params.actorUserId ?? session.userId;
+  return {
+    userId: actorUserId,
+    conversation,
+    adapter: buildSourceControlFastAdapter({
+      conversation,
+      delivery,
+      userId: actorUserId,
+      sessionId: session.id,
+      onReplyPosted: params.onReplyPosted,
+    }),
+  };
+}
+
 async function createFastAgentParentTurn(params: {
   parent: FastAgentParent;
   event: FastAgentParentEvent;
@@ -1583,6 +1638,9 @@ async function createFastAgentParentTurn(params: {
   }
   if (params.parent.conversation.surface === 'linear') {
     return createLinearFastAgentParentTurn(params);
+  }
+  if (isFastAgentSourceControlConversation(params.parent.conversation)) {
+    return createSourceControlFastAgentParentTurn(params);
   }
 
   const pullRequest =

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
   resolveLinearClient: vi.fn(),
   linearEmitResponse: vi.fn(),
   linearGetIssue: vi.fn(),
+  buildSourceControlDelivery: vi.fn(),
+  sourceControlPostComment: vi.fn(),
 }));
 
 vi.mock('@roomote/slack', () => ({
@@ -52,6 +54,15 @@ vi.mock('./linear-fast-session', async (importOriginal) => {
   };
 });
 
+vi.mock('./source-control-fast-delivery', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('./source-control-fast-delivery')>();
+  return {
+    ...actual,
+    buildSourceControlFastDelivery: mocks.buildSourceControlDelivery,
+  };
+});
+
 vi.mock('./fast-agent-human-follow-up', () => ({
   admitFastAgentHumanFollowUp: mocks.admitHumanFollowUp,
 }));
@@ -75,7 +86,14 @@ import {
 
 async function createConversation(input: {
   userId: string;
-  surface: 'web' | 'automation' | 'slack' | 'teams' | 'telegram' | 'linear';
+  surface:
+    | 'web'
+    | 'automation'
+    | 'slack'
+    | 'teams'
+    | 'telegram'
+    | 'linear'
+    | 'github';
   title?: string;
   replyTarget?: { channelId: string; threadId?: string };
 }) {
@@ -269,6 +287,50 @@ describe('buildFastAgentSurfaceReplyDelivery', () => {
     expect(handle).toMatchObject({
       messageId: expect.stringMatching(/^linear-response:/),
     });
+    expect(delivery?.adapter.launchTask).toEqual(expect.any(Function));
+  });
+
+  it('posts GitHub replies as discussion comments and launches PR-bound tasks', async () => {
+    mocks.buildSourceControlDelivery.mockResolvedValue({
+      postComment: mocks.sourceControlPostComment,
+      resolveTarget: async () => ({}),
+    });
+    mocks.sourceControlPostComment.mockResolvedValue({ messageId: '5001' });
+    const user = await userFactory.create();
+    const [row] = await db
+      .insert(fastAgentConversations)
+      .values({
+        userId: user.id,
+        surface: 'github',
+        workspaceId: `github.com/acme/api-${Date.now()}`,
+        conversationId: 'pull/42',
+        currentReplyChannelId: 'pull/42',
+        currentReplyThreadId: null,
+      })
+      .returning();
+
+    const delivery = await buildFastAgentSurfaceReplyDelivery({
+      sessionId: row!.id,
+      userId: user.id,
+      senderDisplayName: 'alice',
+      question: 'Address the review',
+      currentMessageId: 'github:comment:777',
+    });
+
+    expect(delivery?.conversation).toMatchObject({
+      surface: 'github',
+      conversationId: 'pull/42',
+    });
+    const handle = await delivery!.adapter.postReply({
+      message: 'On it.',
+    } as never);
+    expect(handle).toEqual({ messageId: '5001' });
+    expect(mocks.sourceControlPostComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        discussion: expect.objectContaining({ kind: 'pull', number: 42 }),
+        body: expect.stringContaining('On it.'),
+      }),
+    );
     expect(delivery?.adapter.launchTask).toEqual(expect.any(Function));
   });
 

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
@@ -6,11 +6,13 @@ import {
   fastAgentConversationRepository,
   getActiveFastAgentTasks,
   resolveApiBaseUrl,
+  type FastAgentActiveTask,
   type FastAgentConversation,
   type FastAgentReactionExternalInput,
   type FastAgentTurnAdapter,
 } from '@roomote/cloud-agents/server';
 import { and, db, eq, slackInstallations } from '@roomote/db/server';
+import { isFastAgentSourceControlConversation } from '@roomote/types';
 import {
   buildFastSessionReplyFooterText,
   deliverManagedThreadReplyFooter,
@@ -56,6 +58,10 @@ import {
   createFastAgentLinearTaskLauncher,
   resolveLinearFastSessionClient,
 } from './linear-fast-session';
+import {
+  buildSourceControlFastAdapter,
+  buildSourceControlFastDelivery,
+} from './source-control-fast-delivery';
 
 const SLACK_QUOTE_MAX_LENGTH = 100;
 const DISCORD_QUOTE_MAX_LENGTH = 280;
@@ -139,6 +145,11 @@ type FastAgentSurfaceReplyParams = {
   currentMessageId: string;
   replyToMessageId?: string;
   images?: string[];
+  /**
+   * Tasks the Session may steer on this turn beyond the ones it delegated,
+   * for example the task that already owns the pull request a comment is on.
+   */
+  activeTasks?: FastAgentActiveTask[];
   externalInput?: FastAgentReactionExternalInput;
   /**
    * Admission-time hooks for callers that must not block on the whole turn
@@ -504,6 +515,22 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
     };
   }
 
+  if (isFastAgentSourceControlConversation(conversation)) {
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    if (!delivery) {
+      return null;
+    }
+    return {
+      conversation,
+      adapter: buildSourceControlFastAdapter({
+        conversation,
+        delivery,
+        userId: params.userId,
+        sessionId: session.id,
+      }),
+    };
+  }
+
   if (conversation.surface === 'telegram') {
     const provider =
       await createTelegramCommunicationProviderFromRuntimeCredentials();
@@ -620,8 +647,11 @@ async function runFastAgentSurfaceReply(
   const apiBaseUrl = resolveApiBaseUrl() ?? undefined;
   try {
     const activeTasks = params.externalInput
-      ? await getActiveFastAgentTasks(params.sessionId)
-      : undefined;
+      ? [
+          ...(params.activeTasks ?? []),
+          ...(await getActiveFastAgentTasks(params.sessionId)),
+        ]
+      : params.activeTasks;
     // Durable admission for human turns (reactions are not replayable
     // requests): persisted under this owner's claim before the turn runs.
     const durableTurn = params.externalInput

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -1,0 +1,315 @@
+const mocks = vi.hoisted(() => ({
+  createFastAgentTaskLauncher: vi.fn(),
+  repositoriesFindMany: vi.fn(),
+  getInstallationOctokit: vi.fn(),
+}));
+
+vi.mock('@roomote/cloud-agents/server', () => ({
+  createFastAgentTaskLauncher: mocks.createFastAgentTaskLauncher,
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  and: vi.fn((...parts: unknown[]) => parts),
+  db: { query: { repositories: { findMany: mocks.repositoriesFindMany } } },
+  eq: vi.fn((left: unknown, right: unknown) => [left, right]),
+  repositories: {},
+}));
+
+vi.mock('@roomote/communication', () => ({
+  buildFastSessionReplyFooterText: ({ provider }: { provider: string }) =>
+    `[footer:${provider}]`,
+}));
+
+vi.mock('@roomote/github', () => ({
+  getInstallationOctokit: mocks.getInstallationOctokit,
+}));
+
+import { ALL_REPOSITORIES, TaskPayloadKind } from '@roomote/types';
+
+import {
+  buildSourceControlFastAdapter,
+  buildSourceControlFastConversation,
+  buildSourceControlFastDelivery,
+  createFastAgentSourceControlTaskLauncher,
+  parseSourceControlFastConversation,
+} from './source-control-fast-delivery';
+
+describe('source-control Fast conversations', () => {
+  it('round-trips a pull request discussion with its review thread', () => {
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+      reviewCommentId: '800',
+    });
+
+    expect(conversation).toEqual({
+      surface: 'github',
+      workspaceId: 'github.com/acme/api',
+      conversationId: 'pull/42',
+      replyTarget: { channelId: 'pull/42', threadId: '800' },
+    });
+    expect(parseSourceControlFastConversation(conversation)).toEqual({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+      reviewCommentId: '800',
+    });
+  });
+
+  it('rejects identities that are not discussions', () => {
+    expect(
+      parseSourceControlFastConversation({
+        surface: 'github',
+        workspaceId: 'github.com/acme/api',
+        conversationId: 'thread/1',
+        replyTarget: { channelId: 'thread/1' },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('createFastAgentSourceControlTaskLauncher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createFastAgentTaskLauncher.mockImplementation(() => async () => ({
+      success: true,
+      taskId: 'task-1',
+    }));
+  });
+
+  it('binds a pull request child to the PR branch and linkage, resolving the target once', async () => {
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+    });
+    const resolveTarget = vi.fn().mockResolvedValue({
+      repositoryId: 'repo-1',
+      branch: 'feature/ship',
+      pullRequest: {
+        url: 'https://github.com/acme/api/pull/42',
+        title: 'Ship it',
+        sha: 'abc123',
+      },
+    });
+    const launch = createFastAgentSourceControlTaskLauncher({
+      userId: 'user-1',
+      conversation,
+      resolveTarget,
+    });
+    const input = {
+      prompt: 'Address the review',
+      environmentId: 'env-1',
+      parentSessionId: 'fast-1',
+      postKickoff: vi.fn(),
+    };
+
+    await launch(input);
+    await launch(input);
+
+    expect(resolveTarget).toHaveBeenCalledTimes(1);
+    const params = mocks.createFastAgentTaskLauncher.mock.calls[0]?.[0] as {
+      surface: string;
+      prLinkage: Record<string, unknown>;
+      buildTask: (input: Record<string, unknown>) => {
+        type: string;
+        payload: Record<string, unknown>;
+      };
+    };
+    expect(params.surface).toBe('github');
+    expect(params.prLinkage).toEqual({
+      provider: 'github',
+      host: 'github.com',
+      repositoryId: 'repo-1',
+      repository: 'acme/api',
+      prNumber: 42,
+      prUrl: 'https://github.com/acme/api/pull/42',
+      prTitle: 'Ship it',
+      prSha: 'abc123',
+    });
+    const task = params.buildTask({
+      prompt: 'Address the review',
+      environmentId: 'env-1',
+      parentSessionId: 'fast-1',
+    });
+    expect(task.type).toBe(TaskPayloadKind.StandardTask);
+    expect(task.payload).toMatchObject({
+      repo: 'acme/api',
+      branch: 'feature/ship',
+      description: 'Address the review',
+      environmentId: 'env-1',
+      sourceControlProvider: 'github',
+      sourceControlHost: 'github.com',
+      reportConsumer: 'orchestrator',
+      fastAgentParent: { sessionId: 'fast-1', conversation },
+    });
+    expect(task.payload).not.toHaveProperty('linkedWorkItems');
+  });
+
+  it('links an issue child to the issue without PR linkage', async () => {
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'issues',
+      number: 7,
+    });
+    const launch = createFastAgentSourceControlTaskLauncher({
+      userId: 'user-1',
+      conversation,
+      resolveTarget: vi.fn().mockResolvedValue({
+        repositoryId: 'repo-1',
+        issue: {
+          identifier: '7',
+          url: 'https://github.com/acme/api/issues/7',
+          title: 'Bug',
+        },
+      }),
+    });
+
+    await launch({
+      prompt: 'Fix the bug',
+      environmentId: null,
+      parentSessionId: 'fast-1',
+      postKickoff: vi.fn(),
+    });
+
+    const params = mocks.createFastAgentTaskLauncher.mock.calls[0]?.[0] as {
+      prLinkage?: unknown;
+      buildTask: (input: Record<string, unknown>) => {
+        payload: Record<string, unknown>;
+      };
+    };
+    expect(params.prLinkage).toBeUndefined();
+    const payload = params.buildTask({
+      prompt: 'Fix the bug',
+      environmentId: ALL_REPOSITORIES,
+      parentSessionId: 'fast-1',
+    }).payload;
+    expect(payload.linkedWorkItems).toEqual([
+      {
+        provider: 'github',
+        identifier: '7',
+        repository: 'acme/api',
+        url: 'https://github.com/acme/api/issues/7',
+        title: 'Bug',
+      },
+    ]);
+    expect(payload).not.toHaveProperty('environmentId');
+    expect(payload).not.toHaveProperty('branch');
+  });
+});
+
+describe('GitHub Fast delivery', () => {
+  const createComment = vi.fn();
+  const request = vi.fn();
+  const pullsGet = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createComment.mockResolvedValue({ data: { id: 5001 } });
+    request.mockResolvedValue({ data: { id: 5002 } });
+    pullsGet.mockResolvedValue({
+      data: {
+        head: { ref: 'feature/ship', sha: 'abc123' },
+        html_url: 'https://github.com/acme/api/pull/42',
+        title: 'Ship it',
+      },
+    });
+    mocks.getInstallationOctokit.mockResolvedValue({
+      rest: { issues: { createComment }, pulls: { get: pullsGet } },
+      request,
+    });
+    mocks.repositoriesFindMany.mockResolvedValue([
+      {
+        id: 'repo-1',
+        host: null,
+        githubInstallation: { installationId: 123 },
+      },
+    ]);
+  });
+
+  it('returns null for a repository that is not connected', async () => {
+    mocks.repositoriesFindMany.mockResolvedValue([]);
+
+    await expect(
+      buildSourceControlFastDelivery({
+        surface: 'github',
+        workspaceId: 'github.com/acme/api',
+        conversationId: 'pull/42',
+        replyTarget: { channelId: 'pull/42' },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('posts replies as PR comments with the Session footer and resolves the PR target', async () => {
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    expect(delivery).not.toBeNull();
+    const adapter = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+    });
+
+    await expect(adapter.postReply({ message: 'On it.' })).resolves.toEqual({
+      messageId: '5001',
+    });
+    expect(createComment).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'api',
+      issue_number: 42,
+      body: 'On it.\n\n[footer:github]',
+    });
+    await expect(delivery!.resolveTarget()).resolves.toEqual({
+      repositoryId: 'repo-1',
+      branch: 'feature/ship',
+      pullRequest: {
+        url: 'https://github.com/acme/api/pull/42',
+        title: 'Ship it',
+        sha: 'abc123',
+      },
+    });
+  });
+
+  it('threads replies under the review comment the mention came from', async () => {
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+      reviewCommentId: '800',
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    const adapter = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+    });
+
+    await expect(adapter.postReply({ message: 'Fixed.' })).resolves.toEqual({
+      messageId: '5002',
+    });
+    expect(request).toHaveBeenCalledWith(
+      'POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies',
+      expect.objectContaining({ pull_number: 42, comment_id: 800 }),
+    );
+    expect(createComment).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -153,6 +153,36 @@ describe('createFastAgentSourceControlTaskLauncher', () => {
     expect(task.payload).not.toHaveProperty('linkedWorkItems');
   });
 
+  it('refuses to launch a pull request child when the head branch is unknown', async () => {
+    const launch = createFastAgentSourceControlTaskLauncher({
+      userId: 'user-1',
+      conversation: buildSourceControlFastConversation({
+        provider: 'github',
+        host: 'github.com',
+        repositoryFullName: 'acme/api',
+        kind: 'pull',
+        number: 42,
+      }),
+      resolveTarget: vi.fn().mockResolvedValue({
+        repositoryId: 'repo-1',
+        pullRequest: { url: 'https://github.com/acme/api/pull/42' },
+      }),
+    });
+
+    await expect(
+      launch({
+        prompt: 'Address the review',
+        environmentId: 'env-1',
+        parentSessionId: 'fast-1',
+        postKickoff: vi.fn(),
+      }),
+    ).resolves.toEqual({
+      success: false,
+      error: expect.stringContaining('head branch could not be resolved'),
+    });
+    expect(mocks.createFastAgentTaskLauncher).not.toHaveBeenCalled();
+  });
+
   it('links an issue child to the issue without PR linkage', async () => {
     const conversation = buildSourceControlFastConversation({
       provider: 'github',

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -1,0 +1,343 @@
+import {
+  createFastAgentTaskLauncher,
+  type LaunchFastAgentTask,
+} from '@roomote/cloud-agents/server';
+import { and, db, eq, repositories } from '@roomote/db/server';
+import { buildFastSessionReplyFooterText } from '@roomote/communication';
+import {
+  ALL_REPOSITORIES,
+  buildFastAgentChildTaskMetadata,
+  linkedWorkItemProviderSchema,
+  TaskPayloadKind,
+  type FastAgentSourceControlConversation,
+  type FastAgentSourceControlSurface,
+} from '@roomote/types';
+
+export type SourceControlDiscussionKind = 'pull' | 'issues';
+
+export type SourceControlFastDiscussion = {
+  provider: FastAgentSourceControlSurface;
+  host: string;
+  repositoryFullName: string;
+  kind: SourceControlDiscussionKind;
+  number: number;
+  /** Review comment a reply threads under, when the mention came from one. */
+  reviewCommentId?: string;
+};
+
+/**
+ * A pull request or issue discussion is one Fast conversation per provider:
+ * the repository (with its host) is the workspace and the discussion is the
+ * conversation. The review thread a reply should land in is a mutable reply
+ * target, not part of the identity.
+ */
+export function buildSourceControlFastConversation(
+  discussion: SourceControlFastDiscussion,
+): FastAgentSourceControlConversation {
+  const discussionId = `${discussion.kind}/${discussion.number}`;
+  return {
+    surface: discussion.provider,
+    workspaceId: `${discussion.host}/${discussion.repositoryFullName}`,
+    conversationId: discussionId,
+    replyTarget: {
+      channelId: discussionId,
+      ...(discussion.reviewCommentId
+        ? { threadId: discussion.reviewCommentId }
+        : {}),
+    },
+  };
+}
+
+export function parseSourceControlFastConversation(
+  conversation: FastAgentSourceControlConversation,
+): SourceControlFastDiscussion | null {
+  const separator = conversation.workspaceId.indexOf('/');
+  const host = conversation.workspaceId.slice(0, separator);
+  const repositoryFullName = conversation.workspaceId.slice(separator + 1);
+  const match = /^(pull|issues)\/(\d+)$/.exec(conversation.conversationId);
+  if (separator <= 0 || !repositoryFullName || !match) {
+    return null;
+  }
+  return {
+    provider: conversation.surface,
+    host,
+    repositoryFullName,
+    kind: match[1] as SourceControlDiscussionKind,
+    number: Number(match[2]),
+    ...(conversation.replyTarget.threadId
+      ? { reviewCommentId: conversation.replyTarget.threadId }
+      : {}),
+  };
+}
+
+/** The pull request or issue a delegated task is bound to. */
+export type SourceControlFastLaunchTarget = {
+  repositoryId?: string | null;
+  branch?: string;
+  pullRequest?: {
+    url: string;
+    title?: string | null;
+    sha?: string | null;
+  };
+  issue?: {
+    identifier: string;
+    url?: string;
+    title?: string;
+  };
+};
+
+/**
+ * Delegated work from a discussion is a standard task on that repository:
+ * on a pull request it checks out the head branch and is linked to the PR,
+ * on an issue it links the issue. The Session owns every reply into the
+ * discussion; the child only reports to its orchestrator.
+ */
+export function createFastAgentSourceControlTaskLauncher(params: {
+  userId: string;
+  conversation: FastAgentSourceControlConversation;
+  resolveTarget: () => Promise<SourceControlFastLaunchTarget>;
+}): LaunchFastAgentTask {
+  const discussion = parseSourceControlFastConversation(params.conversation);
+  let targetPromise: Promise<SourceControlFastLaunchTarget> | undefined;
+  const loadTarget = () => (targetPromise ??= params.resolveTarget());
+
+  return async (input) => {
+    if (!discussion) {
+      return {
+        success: false,
+        error: 'The discussion for this Session could not be resolved.',
+      };
+    }
+    const target = await loadTarget();
+    // Only providers whose issues can be linked as work items record one.
+    const linkedProvider = linkedWorkItemProviderSchema.safeParse(
+      discussion.provider,
+    );
+    const linkedIssue =
+      target.issue && linkedProvider.success
+        ? {
+            provider: linkedProvider.data,
+            identifier: target.issue.identifier,
+            repository: discussion.repositoryFullName,
+            ...(target.issue.url ? { url: target.issue.url } : {}),
+            ...(target.issue.title ? { title: target.issue.title } : {}),
+          }
+        : null;
+    const launch = createFastAgentTaskLauncher({
+      userId: params.userId,
+      surface: discussion.provider,
+      taskUrlCampaign: 'fast-delegation',
+      ...(target.pullRequest
+        ? {
+            prLinkage: {
+              provider: discussion.provider,
+              host: discussion.host,
+              ...(target.repositoryId
+                ? { repositoryId: target.repositoryId }
+                : {}),
+              repository: discussion.repositoryFullName,
+              prNumber: discussion.number,
+              prUrl: target.pullRequest.url,
+              prTitle: target.pullRequest.title ?? null,
+              prSha: target.pullRequest.sha ?? null,
+            },
+          }
+        : {}),
+      buildTask: ({
+        prompt,
+        environmentId,
+        branch,
+        model,
+        reasoningEffort,
+        parentSessionId,
+      }) => ({
+        type: TaskPayloadKind.StandardTask,
+        payload: {
+          repo: discussion.repositoryFullName,
+          description: prompt,
+          sourceControlProvider: discussion.provider,
+          sourceControlHost: discussion.host,
+          ...((branch ?? target.branch)
+            ? { branch: branch ?? target.branch }
+            : {}),
+          ...(linkedIssue ? { linkedWorkItems: [linkedIssue] } : {}),
+          ...buildFastAgentChildTaskMetadata({
+            sessionId: parentSessionId,
+            conversation: params.conversation,
+          }),
+          ...(environmentId && environmentId !== ALL_REPOSITORIES
+            ? { environmentId }
+            : {}),
+          ...(model
+            ? { harnessModelOverrides: { 'opencode-server': model } }
+            : {}),
+          ...(reasoningEffort ? { reasoningEffort } : {}),
+        },
+      }),
+    });
+    return launch(input);
+  };
+}
+
+export type SourceControlFastReplyPoster = (input: {
+  discussion: SourceControlFastDiscussion;
+  body: string;
+}) => Promise<{ messageId: string }>;
+
+/**
+ * Delivery for one discussion: how replies post and how delegated tasks
+ * find their target. Each provider supplies both from its own client.
+ */
+export type SourceControlFastDelivery = {
+  postComment: SourceControlFastReplyPoster;
+  resolveTarget: () => Promise<SourceControlFastLaunchTarget>;
+};
+
+async function findGitHubRepository(discussion: SourceControlFastDiscussion) {
+  const rows = await db.query.repositories.findMany({
+    where: and(
+      eq(repositories.sourceControlProvider, 'github'),
+      eq(repositories.fullName, discussion.repositoryFullName),
+      eq(repositories.isActive, true),
+    ),
+    with: { githubInstallation: true },
+  });
+  return (
+    rows.find((row) => (row.host ?? 'github.com') === discussion.host) ??
+    rows.find((row) => !row.host) ??
+    null
+  );
+}
+
+async function buildGitHubFastDelivery(
+  discussion: SourceControlFastDiscussion,
+): Promise<SourceControlFastDelivery | null> {
+  const repository = await findGitHubRepository(discussion);
+  if (!repository?.githubInstallation) {
+    return null;
+  }
+  const { getInstallationOctokit } = await import('@roomote/github');
+  const octokit = await getInstallationOctokit(repository.githubInstallation);
+  const [owner, repo] = discussion.repositoryFullName.split('/');
+  if (!owner || !repo) {
+    return null;
+  }
+
+  return {
+    postComment: async ({ discussion: target, body }) => {
+      if (target.kind === 'pull' && target.reviewCommentId) {
+        const response = await octokit.request(
+          'POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies',
+          {
+            owner,
+            repo,
+            pull_number: target.number,
+            comment_id: Number(target.reviewCommentId),
+            body,
+          },
+        );
+        return { messageId: String(response.data.id) };
+      }
+      const response = await octokit.rest.issues.createComment({
+        owner,
+        repo,
+        issue_number: target.number,
+        body,
+      });
+      return { messageId: String(response.data.id) };
+    },
+    resolveTarget: async () => {
+      if (discussion.kind === 'issues') {
+        const issue = await octokit.rest.issues
+          .get({ owner, repo, issue_number: discussion.number })
+          .then((response) => response.data)
+          .catch(() => null);
+        return {
+          repositoryId: repository.id,
+          issue: {
+            identifier: String(discussion.number),
+            url:
+              issue?.html_url ??
+              `https://${discussion.host}/${discussion.repositoryFullName}/issues/${discussion.number}`,
+            ...(issue?.title ? { title: issue.title } : {}),
+          },
+        };
+      }
+      const pullRequest = await octokit.rest.pulls
+        .get({ owner, repo, pull_number: discussion.number })
+        .then((response) => response.data)
+        .catch(() => null);
+      return {
+        repositoryId: repository.id,
+        ...(pullRequest?.head?.ref ? { branch: pullRequest.head.ref } : {}),
+        pullRequest: {
+          url:
+            pullRequest?.html_url ??
+            `https://${discussion.host}/${discussion.repositoryFullName}/pull/${discussion.number}`,
+          title: pullRequest?.title ?? null,
+          sha: pullRequest?.head?.sha ?? null,
+        },
+      };
+    },
+  };
+}
+
+/**
+ * Resolves the provider client for a discussion. Null when the repository is
+ * not connected on this deployment or the provider has no Fast delivery yet.
+ */
+export async function buildSourceControlFastDelivery(
+  conversation: FastAgentSourceControlConversation,
+): Promise<SourceControlFastDelivery | null> {
+  const discussion = parseSourceControlFastConversation(conversation);
+  if (!discussion) {
+    return null;
+  }
+  switch (discussion.provider) {
+    case 'github':
+      return buildGitHubFastDelivery(discussion);
+    default:
+      return null;
+  }
+}
+
+/**
+ * The reply surface a Session uses in a discussion: replies post as comments
+ * with the Session footer, and tasks launch against the discussion's target.
+ */
+export function buildSourceControlFastAdapter(params: {
+  conversation: FastAgentSourceControlConversation;
+  delivery: SourceControlFastDelivery;
+  userId: string;
+  sessionId: string;
+  onReplyPosted?: () => void;
+}): {
+  launchTask: LaunchFastAgentTask;
+  postReply: (reply: { message: string }) => Promise<{ messageId: string }>;
+} {
+  const discussion = parseSourceControlFastConversation(params.conversation);
+  return {
+    launchTask: createFastAgentSourceControlTaskLauncher({
+      userId: params.userId,
+      conversation: params.conversation,
+      resolveTarget: params.delivery.resolveTarget,
+    }),
+    postReply: async ({ message }) => {
+      if (!discussion) {
+        throw new Error(
+          'The discussion for this Session could not be resolved.',
+        );
+      }
+      const footer = buildFastSessionReplyFooterText({
+        provider: discussion.provider,
+        sessionId: params.sessionId,
+      });
+      const posted = await params.delivery.postComment({
+        discussion,
+        body: `${message}\n\n${footer}`,
+      });
+      params.onReplyPosted?.();
+      return posted;
+    },
+  };
+}

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -109,6 +109,15 @@ export function createFastAgentSourceControlTaskLauncher(params: {
       };
     }
     const target = await loadTarget();
+    // A pull request child must check out the PR head; without a resolved
+    // branch it would edit the environment's default branch instead.
+    if (target.pullRequest && !target.branch) {
+      return {
+        success: false,
+        error:
+          'The pull request head branch could not be resolved, so the task was not started.',
+      };
+    }
     // Only providers whose issues can be linked as work items record one.
     const linkedProvider = linkedWorkItemProviderSchema.safeParse(
       discussion.provider,

--- a/packages/sdk/src/server/lib/source-control-fast-session.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-session.ts
@@ -1,0 +1,46 @@
+import {
+  getOrCreateFastAgentSession,
+  type FastAgentActiveTask,
+} from '@roomote/cloud-agents/server';
+
+import { queueFastAgentSurfaceReply } from './fast-agent-surface-reply';
+import {
+  buildSourceControlFastConversation,
+  type SourceControlFastDiscussion,
+} from './source-control-fast-delivery';
+
+export type StartSourceControlFastSessionTurnResult =
+  | { status: 'queued'; fastConversationId: string }
+  | { status: 'unavailable' };
+
+/**
+ * Enters a mention into the discussion's Fast Session. Turns are queued so
+ * a busy Session steers or replays them instead of dropping them.
+ */
+export async function startSourceControlFastSessionTurn(input: {
+  discussion: SourceControlFastDiscussion;
+  userId: string;
+  senderDisplayName: string | null;
+  question: string;
+  agentContext: string;
+  currentMessageId: string;
+  activeTasks?: FastAgentActiveTask[];
+}): Promise<StartSourceControlFastSessionTurnResult> {
+  const conversation = buildSourceControlFastConversation(input.discussion);
+  const fastSession = await getOrCreateFastAgentSession({
+    userId: input.userId,
+    conversation,
+  });
+  const queued = await queueFastAgentSurfaceReply({
+    sessionId: fastSession.id,
+    userId: input.userId,
+    senderDisplayName: input.senderDisplayName,
+    question: input.question,
+    agentContext: input.agentContext,
+    currentMessageId: input.currentMessageId,
+    ...(input.activeTasks?.length ? { activeTasks: input.activeTasks } : {}),
+  });
+  return queued
+    ? { status: 'queued', fastConversationId: fastSession.id }
+    : { status: 'unavailable' };
+}

--- a/packages/types/src/fast-agent.ts
+++ b/packages/types/src/fast-agent.ts
@@ -6,6 +6,11 @@ export const fastAgentSurfaces = [
   'teams',
   'telegram',
   'linear',
+  'github',
+  'gitlab',
+  'bitbucket',
+  'ado',
+  'gitea',
   'automation',
   'web',
 ] as const;
@@ -60,6 +65,37 @@ export const fastAgentConversationSchema = z.discriminatedUnion('surface', [
      */
     replyTarget: fastAgentReplyTargetSchema,
   }),
+  /**
+   * Source-control surfaces: a pull request or issue discussion.
+   * `workspaceId` is `<host>/<owner>/<repo>`, `conversationId` and
+   * `replyTarget.channelId` are `pull/<number>` or `issues/<number>`, and
+   * `replyTarget.threadId` is the review comment a reply threads under.
+   */
+  z.object({
+    surface: z.literal('github'),
+    ...fastAgentConversationIdentitySchema,
+    replyTarget: fastAgentReplyTargetSchema,
+  }),
+  z.object({
+    surface: z.literal('gitlab'),
+    ...fastAgentConversationIdentitySchema,
+    replyTarget: fastAgentReplyTargetSchema,
+  }),
+  z.object({
+    surface: z.literal('bitbucket'),
+    ...fastAgentConversationIdentitySchema,
+    replyTarget: fastAgentReplyTargetSchema,
+  }),
+  z.object({
+    surface: z.literal('ado'),
+    ...fastAgentConversationIdentitySchema,
+    replyTarget: fastAgentReplyTargetSchema,
+  }),
+  z.object({
+    surface: z.literal('gitea'),
+    ...fastAgentConversationIdentitySchema,
+    replyTarget: fastAgentReplyTargetSchema,
+  }),
   z.object({
     surface: z.literal('automation'),
     ...fastAgentConversationIdentitySchema,
@@ -71,6 +107,30 @@ export const fastAgentConversationSchema = z.discriminatedUnion('surface', [
 ]);
 
 export type FastAgentConversation = z.infer<typeof fastAgentConversationSchema>;
+
+export const fastAgentSourceControlSurfaces = [
+  'github',
+  'gitlab',
+  'bitbucket',
+  'ado',
+  'gitea',
+] as const;
+
+export type FastAgentSourceControlSurface =
+  (typeof fastAgentSourceControlSurfaces)[number];
+
+export type FastAgentSourceControlConversation = Extract<
+  FastAgentConversation,
+  { surface: FastAgentSourceControlSurface }
+>;
+
+export function isFastAgentSourceControlConversation(
+  conversation: FastAgentConversation,
+): conversation is FastAgentSourceControlConversation {
+  return (fastAgentSourceControlSurfaces as readonly string[]).includes(
+    conversation.surface,
+  );
+}
 
 export type FastAgentCommunicationConversation = Extract<
   FastAgentConversation,


### PR DESCRIPTION
Phase 3, source-control half, part 1 of 3 (GitHub). GitLab, Bitbucket, Azure DevOps, and Gitea follow on top of this branch, then the router deletion.

## What changed

- **Source-control Fast surfaces.** `fastAgentConversationSchema` gains `github`, `gitlab`, `bitbucket`, `ado`, and `gitea`: the repository (with host) is the workspace, `pull/<n>` or `issues/<n>` is the conversation, and the review comment a reply threads under is the mutable reply target. `isFastAgentSourceControlConversation` and friends live in `@roomote/types`.
- **Delivery** (`source-control-fast-delivery.ts`): `buildSourceControlFastDelivery` resolves a provider client per discussion (GitHub via the repository's installation), `buildSourceControlFastAdapter` posts replies as comments (review-thread replies when the mention came from one) with the Session footer, and `createFastAgentSourceControlTaskLauncher` builds standard children on the discussion's repository with `prLinkage` and the PR head branch, or `linkedWorkItems` for an issue. Both surface replies and parent-event delivery use it.
- **GitHub handlers.** `handlePrComment` and `handleGitHubIssueComment` acknowledge with an eyes reaction and enter the discussion's Session through `startSourceControlFastSessionTurn`, with the PR or issue, triggering comment (with the parent review comment and diff hunk), discussion history, and linked references as context. The task that already owns the PR or issue and any in-flight review are passed as `activeTasks` so the Session can steer them. The router, review pipeline launch on mention, follow-up delivery, and snapshot resume on mention are removed from these handlers.
- **Plumbing:** the Fast task launcher accepts `channels` and `prLinkage`; surface-reply params accept `agentContext` and `activeTasks`; the Fast prompt names the new surfaces; the session footer supports them.
- **Docs:** GitHub source-control page.

## Not in this PR

- A mention asking for a review no longer starts the structured review pipeline; the Session delegates a task that reviews with the PR tools. Reaching the pipeline from a Session is a follow-up if wanted.
- The other four providers still start tasks directly until part 2.

## Validation

- Handler tests: PR comment, review-thread comment, active owner and review passed as active tasks, account linking, Fast outage, no mention; issue comment, issue owner, issue-body mention, account linking, outage, no mention.
- sdk tests: conversation round-trip, PR-bound and issue-bound launchers, GitHub delivery (comment, review reply, target resolution), surface-reply GitHub branch.
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip`, and the sdk, cloud-agents, api, db, types, communication, and web suites pass. The two worker `opencode-server-bootstrap` tests and web `sessions.test.ts` are order-dependent in full runs and pass alone (same on develop).