### PR TITLE
fix: treat Linear's delegation stub comment as work on the issue

### DIFF
--- a/packages/sdk/src/server/lib/linear-fast-session-turn.test.ts
+++ b/packages/sdk/src/server/lib/linear-fast-session-turn.test.ts
@@ -116,6 +116,18 @@ describe('buildLinearFastTurn', () => {
           id: 'comment-stub',
           body: 'This thread is for an agent session with roomoteroomoteroomote.',
         },
+        previousComments: [
+          {
+            id: 'c-stub',
+            body: 'This thread is for an agent session with roomoteroomoteroomote.',
+            user: { id: 'u-bot', name: 'roomote' },
+          },
+          {
+            id: 'c-real',
+            body: 'Seen in production twice.',
+            user: { id: 'u-2', name: 'Sam' },
+          },
+        ],
         createdAt: '2026-09-02T00:00:00.000Z',
         updatedAt: '2026-09-02T00:00:00.000Z',
       },
@@ -138,6 +150,8 @@ describe('buildLinearFastTurn', () => {
 
     expect(turn.question).toBe('Work on ENG-123: Fix API retries');
     expect(turn.agentContext).toContain('Retries never back off.');
+    expect(turn.agentContext).toContain('Seen in production twice.');
+    expect(turn.agentContext).not.toContain('agent session with');
   });
 
   it('describes a delegation with no comment as work on the issue', () => {

--- a/packages/sdk/src/server/lib/linear-fast-session-turn.test.ts
+++ b/packages/sdk/src/server/lib/linear-fast-session-turn.test.ts
@@ -107,6 +107,39 @@ describe('buildLinearFastTurn', () => {
     expect(turn.agentContext).toContain('Prefer small PRs.');
   });
 
+  it("treats Linear's delegation stub comment as work on the issue", () => {
+    const payload = makePayload({
+      agentSession: {
+        id: 'session-1',
+        issue,
+        comment: {
+          id: 'comment-stub',
+          body: 'This thread is for an agent session with roomoteroomoteroomote.',
+        },
+        createdAt: '2026-09-02T00:00:00.000Z',
+        updatedAt: '2026-09-02T00:00:00.000Z',
+      },
+      agentActivity: {
+        id: 'activity-1',
+        createdAt: '2026-09-02T00:00:00.000Z',
+        updatedAt: '2026-09-02T00:00:00.000Z',
+        agentSessionId: 'session-1',
+        content: {
+          type: 'prompt',
+          body: 'This thread is for an agent session with roomoteroomoteroomote.',
+        },
+      },
+    });
+
+    const turn = buildLinearFastTurn({
+      payload,
+      agentSession: payload.agentSession,
+    });
+
+    expect(turn.question).toBe('Work on ENG-123: Fix API retries');
+    expect(turn.agentContext).toContain('Retries never back off.');
+  });
+
   it('describes a delegation with no comment as work on the issue', () => {
     const payload = makePayload({
       agentSession: {

--- a/packages/sdk/src/server/lib/linear-fast-session-turn.ts
+++ b/packages/sdk/src/server/lib/linear-fast-session-turn.ts
@@ -20,6 +20,26 @@ function formatLinearComment(comment: {
  * What the Session reads with a Linear event: the issue, the discussion so
  * far on the first turn, and any agent guidance the workspace configured.
  */
+/**
+ * Assigning an issue to the agent makes Linear author a stub comment such as
+ * "This thread is for an agent session with @roomote." That is plumbing, not
+ * a request: a Session handed the stub would acknowledge the thread instead
+ * of working the issue, so it falls through to the work-on-issue prompt.
+ */
+function isLinearDelegationStub(text: string): boolean {
+  return /^this thread is for an agent session\b/i.test(text);
+}
+
+function normalizeLinearRequestText(
+  text: string | undefined,
+): string | undefined {
+  const trimmed = text?.trim();
+  if (!trimmed || isLinearDelegationStub(trimmed)) {
+    return undefined;
+  }
+  return trimmed;
+}
+
 export function buildLinearFastTurn(input: {
   payload: AgentSessionEventPayload;
   agentSession: AgentSessionEventPayload['agentSession'];
@@ -31,10 +51,14 @@ export function buildLinearFastTurn(input: {
 } {
   const { payload, agentSession } = input;
   const issue = agentSession.issue;
-  const promptBody = payload.agentActivity?.content?.body?.trim();
+  const promptBody = normalizeLinearRequestText(
+    payload.agentActivity?.content?.body,
+  );
   const firstTurn = payload.action !== 'prompted';
   const question =
-    (firstTurn ? agentSession.comment?.body?.trim() : promptBody) ||
+    (firstTurn
+      ? normalizeLinearRequestText(agentSession.comment?.body)
+      : promptBody) ||
     promptBody ||
     `Work on ${issue.identifier}: ${issue.title}`;
 

--- a/packages/sdk/src/server/lib/linear-fast-session-turn.ts
+++ b/packages/sdk/src/server/lib/linear-fast-session-turn.ts
@@ -70,9 +70,11 @@ export function buildLinearFastTurn(input: {
     ...(issue.project?.name ? [`Project: ${issue.project.name}`] : []),
     '</linear_issue>',
   ];
-  const previousComments = firstTurn
-    ? (agentSession.previousComments ?? [])
-    : [];
+  // Stub comments are plumbing on the issue too; keep them out of the
+  // discussion the Session reads.
+  const previousComments = (
+    firstTurn ? (agentSession.previousComments ?? []) : []
+  ).filter((comment) => !isLinearDelegationStub(comment.body.trim()));
   if (previousComments.length > 0) {
     contextParts.push(
       '<issue_comments>',


### PR DESCRIPTION
## What changed

Assigning an issue to the agent makes Linear author a stub comment ("This thread is for an agent session with @roomote."). `buildLinearFastTurn` took that stub as the request, so the Session replied "Understood, I'll keep this thread scoped..." instead of working the issue. Stub comments and stub prompt bodies now normalize to nothing and fall through to the `Work on <identifier>: <title>` question; the issue description, comments, and guidance context are unchanged.

## Why

First real dogfood of the Linear Fast surface: delegating an issue produced a useless acknowledgement because the only "request" text was Linear's own plumbing comment.

## Validation

Turn-builder test covering the stub in both the comment and the activity body; sdk suite, lint, and types pass.