### PR TITLE
fix: pinned launches render a task card in the Session transcript

### DIFF
--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-pinned-launch.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-pinned-launch.test.ts
@@ -176,6 +176,27 @@ describe('launchPinnedFastSessionTask', () => {
         payload: { purpose: 'progress', kickoff: true },
       }),
     });
+    // The launch_task tool result is what the transcript renders as the
+    // delegated-task card.
+    const launchWrite = mocks.upsertFastAgentMessage.mock.calls[2]?.[0] as {
+      sessionId: string;
+      message: { eventType: string; payload: Record<string, unknown> };
+    };
+    expect(launchWrite).toEqual({
+      sessionId: 'fast-1',
+      message: expect.objectContaining({
+        eventId: 'pinned-launch:launch-1:launch',
+        turnSeq: 2,
+        eventType: ACP_ENVELOPE_EVENT_TYPES.ToolResult,
+        role: 'tool',
+        payload: expect.objectContaining({
+          toolName: 'launch_task',
+          status: 'completed',
+          output: JSON.stringify({ success: true, taskId: 'task-1' }),
+          rawInput: { arguments: { prompt: 'Fix the flaky test' } },
+        }),
+      }),
+    });
 
     expect(mocks.enqueueTask).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -344,7 +365,17 @@ describe('launchPinnedFastSessionTask', () => {
 
     expect(result.fastConversationId).toBe('fast-parent');
     expect(mocks.getOrCreateFastAgentSession).not.toHaveBeenCalled();
-    expect(mocks.upsertFastAgentMessage).toHaveBeenCalledTimes(1);
+    // No user row for a blank workspace: only the kickoff and the task card.
+    expect(mocks.upsertFastAgentMessage).toHaveBeenCalledTimes(2);
+    expect(
+      mocks.upsertFastAgentMessage.mock.calls.map(
+        (call) =>
+          (call[0] as { message: { eventType: string } }).message.eventType,
+      ),
+    ).toEqual([
+      ACP_ENVELOPE_EVENT_TYPES.AssistantMessage,
+      ACP_ENVELOPE_EVENT_TYPES.ToolResult,
+    ]);
     expect(mocks.upsertFastAgentMessage.mock.calls[0]?.[0]).toEqual({
       sessionId: 'fast-parent',
       message: expect.objectContaining({

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-pinned-launch.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-pinned-launch.ts
@@ -390,6 +390,40 @@ async function launchInSession(
     throw new Error(launch.error);
   }
 
+  // The transcript renders delegated-task cards from `launch_task` tool
+  // results. A pinned launch spends no model turn, so it persists the same
+  // row a delegating turn would; without it the Session shows only the
+  // kickoff text and the task is invisible.
+  await upsertFastAgentMessage({
+    sessionId: target.id,
+    message: {
+      eventId: `${turnId}:launch`,
+      turnId,
+      turnSeq: 2,
+      ts: Date.now(),
+      eventType: ACP_ENVELOPE_EVENT_TYPES.ToolResult,
+      role: 'tool',
+      contentBlocks: [],
+      metadata: { visibleInTranscript: true },
+      payload: {
+        toolCallId: `${turnId}:tool:0`,
+        title: 'launch_task',
+        toolName: 'launch_task',
+        status: 'completed',
+        isExecute: false,
+        isRead: false,
+        isMcp: false,
+        isRoomoteNativeTool: true,
+        command: null,
+        exitCode: null,
+        output: JSON.stringify({ success: true, taskId: launch.taskId }),
+        rawInput: { arguments: prompt ? { prompt } : {} },
+      },
+      source: target.conversation.surface,
+      nativeSessionId: null,
+    },
+  });
+
   const [latestRun, session] = await Promise.all([
     db.query.taskRuns.findFirst({
       where: eq(taskRuns.taskId, launch.taskId),


### PR DESCRIPTION
## What changed

`launchPinnedFastSessionTask` now persists the same `launch_task` tool-result row a delegating Fast turn produces (stable event id under the launch's turn, so replays stay idempotent). The Session transcript renders delegated-task cards from exactly that row, so pinned launches — the New Task form, blank workspaces, suggestion cards, API launches — show a clickable task card under the kickoff line instead of nothing.

## Why

Dogfood: opening a blank workspace produced a Session containing only "Opened a workspace in Roomote." with no way to see or open the task. Before Fast-first, the placeholder task row on the task page filled this role.

## Validation

Pinned-launch tests assert the tool-result row (and that a blank workspace writes kickoff + card, no user row); api chat-provider suites and web fast-session commands pass; lint and types clean.