### PR TITLE
feat: collate live previews from tasks into the parent Session

### DIFF
--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.client.test.tsx
@@ -102,7 +102,34 @@ vi.mock('@/trpc/client', () => ({
         }),
       },
     },
+    previewSettings: {
+      taskStatus: {
+        queryOptions: (
+          input: { taskId: string },
+          options?: Record<string, unknown>,
+        ) => ({
+          queryKey: ['previewSettings', 'taskStatus', input],
+          queryFn: async () => null,
+          ...options,
+        }),
+        queryKey: (input: { taskId: string }) => [
+          'previewSettings',
+          'taskStatus',
+          input,
+        ],
+      },
+      startSetupTask: {
+        mutationOptions: (options?: Record<string, unknown>) => ({
+          mutationFn: async () => ({ taskId: 'task-1', alreadyRunning: false }),
+          ...options,
+        }),
+      },
+    },
   }),
+}));
+
+vi.mock('@/hooks/useUser', () => ({
+  useAuthorizedUser: () => ({ isAdmin: true }),
 }));
 
 vi.mock('@/components/tasks/ArtifactViewerContent', () => ({
@@ -187,6 +214,7 @@ const singleTask: SessionInfo['tasks'][number] = {
   canAccessDetails: true,
   latestRun: null,
   artifacts: [],
+  previews: [],
   pullRequests: [],
 };
 
@@ -849,6 +877,68 @@ describe('SessionWorkspace', () => {
     ).toBeVisible();
   });
 
+  it('disables the Live Preview control until a linked task has a live preview', () => {
+    renderWorkspace({
+      isMobile: false,
+      sessionOverride: { tasks: [singleTask] },
+    });
+
+    expect(screen.getByRole('button', { name: 'Live Preview' })).toBeDisabled();
+  });
+
+  it('collates live previews across tasks into the embedded preview panel', () => {
+    const firstTask = {
+      ...singleTask,
+      title: 'First execution',
+      previews: [
+        {
+          serviceName: 'WEB_APP',
+          url: 'https://task-1-web-app.preview.test/dashboard',
+          isPrimary: true,
+          runId: 11,
+        },
+      ],
+    };
+    const secondTask = {
+      ...singleTask,
+      taskId: 'task-2',
+      title: 'Second execution',
+      previews: [
+        {
+          serviceName: 'API',
+          url: 'https://task-2-api.preview.test/',
+          isPrimary: true,
+          runId: 22,
+        },
+      ],
+    };
+
+    renderWorkspace({
+      isMobile: false,
+      sessionOverride: { tasks: [firstTask, secondTask] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Live Preview' }));
+
+    // The first task's primary preview opens by default, with the task title
+    // folded into the service picker since several tasks expose previews.
+    expect(
+      screen.getByRole('button', {
+        name: /Live Preview: Web App - First execution/,
+      }),
+    ).toBeVisible();
+    const iframe = screen.getByTitle('Live Preview');
+    expect(iframe).toHaveAttribute(
+      'src',
+      `/api/auth/preview-iframe?${new URLSearchParams({
+        preview_url: 'https://task-1-web-app.preview.test/dashboard',
+        task_run_id: '11',
+      }).toString()}`,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close panel' }));
+    expect(screen.queryByTitle('Live Preview')).toBeNull();
+  });
+
   it('enables and populates the Tasks panel from refreshed session tasks', async () => {
     const delegatedTask = {
       taskId: 'task-2',
@@ -861,6 +951,7 @@ describe('SessionWorkspace', () => {
       canAccessDetails: true,
       latestRun: null,
       artifacts: [],
+      previews: [],
       pullRequests: [],
     };
     renderWorkspace({
@@ -895,6 +986,7 @@ describe('SessionWorkspace', () => {
             taskPhase: 'running',
           },
           artifacts: [],
+          previews: [],
         },
       ],
     });
@@ -928,6 +1020,7 @@ describe('SessionWorkspace', () => {
             taskPhase: 'running',
           },
           artifacts: [],
+          previews: [],
         },
         {
           taskId: 'task-3',
@@ -937,6 +1030,7 @@ describe('SessionWorkspace', () => {
             taskPhase: null,
           },
           artifacts: [],
+          previews: [],
         },
       ],
     });
@@ -972,6 +1066,7 @@ describe('SessionWorkspace', () => {
             taskPhase: 'running',
           },
           artifacts: [],
+          previews: [],
         },
       ],
     });
@@ -992,6 +1087,7 @@ describe('SessionWorkspace', () => {
               taskPhase: 'running',
             },
             artifacts: [],
+            previews: [],
           },
           {
             taskId: 'task-3',
@@ -1001,6 +1097,7 @@ describe('SessionWorkspace', () => {
               taskPhase: null,
             },
             artifacts: [],
+            previews: [],
           },
         ],
       );
@@ -1022,6 +1119,7 @@ describe('SessionWorkspace', () => {
           taskId: 'fast-task-1',
           title: 'Fast execution',
           latestRun: null,
+          previews: [],
           artifacts: [
             {
               id: 'fast-artifact-1',
@@ -1060,6 +1158,7 @@ describe('SessionWorkspace', () => {
         taskPhase,
       },
       artifacts: [],
+      previews: [],
     });
     const { queryClient } = renderWorkspace({
       isMobile: false,

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.tsx
@@ -39,6 +39,7 @@ import { useTRPC } from '@/trpc/client';
 import { FramedSurface, WorkspaceSurface } from '@/components/layout';
 import { SideNavItem } from '@/components/layout/side-nav/SideNavItem';
 import {
+  AppWindow,
   ArrowLeftFromLine,
   ArrowLeft,
   Avatar,
@@ -86,6 +87,12 @@ import {
 } from './session-task-panel-context';
 import { DelegatedTaskCard } from '../../task/[taskId]/messages/acp/DelegatedTaskCard';
 import { useArtifactByPath } from '../../task/[taskId]/hooks/use-artifact-by-path';
+import { PreviewPaneProvider } from '../../task/[taskId]/hooks/use-preview-pane';
+import { humanizePortName } from '../../task/[taskId]/preview-port-utils';
+import {
+  PreviewSidePanel,
+  type PreviewEntry,
+} from '../../task/[taskId]/sidebar-panels/PreviewSidePanel';
 
 const ArtifactViewerContent = dynamic(
   () =>
@@ -122,6 +129,7 @@ type SessionTaskSummary = {
     result: unknown;
   } | null;
   artifacts: SessionArtifact[];
+  previews: SessionTaskPreview[];
   pullRequests: Array<{
     id: string;
     url: string;
@@ -142,6 +150,14 @@ type SessionArtifact = {
   createdAt: Date;
   thumbnailUrl?: string;
   previewUrl?: string;
+};
+
+/** A live preview URL from a session-linked task, collated server-side. */
+type SessionTaskPreview = {
+  serviceName: string;
+  url: string;
+  isPrimary: boolean;
+  runId: number;
 };
 
 export type SessionInfo = {
@@ -165,7 +181,7 @@ export type SessionInfo = {
   tasks: SessionTaskSummary[];
   taskSource?: 'unified' | 'fast';
   taskCards?: Array<
-    Pick<SessionTaskSummary, 'taskId' | 'title' | 'artifacts'> & {
+    Pick<SessionTaskSummary, 'taskId' | 'title' | 'artifacts' | 'previews'> & {
       inferenceCostMicroUsd?: number;
       latestRun: Pick<
         NonNullable<SessionTaskSummary['latestRun']>,
@@ -476,6 +492,68 @@ function SessionArtifactsPanel({
   );
 }
 
+type SessionPreviewEntry = {
+  taskId: string;
+  taskTitle: string;
+  preview: SessionTaskPreview;
+};
+
+type SessionPreviewTask = Pick<
+  SessionTaskSummary,
+  'taskId' | 'title' | 'previews'
+>;
+
+function getSessionPreviews(
+  tasks: SessionPreviewTask[],
+): SessionPreviewEntry[] {
+  // Cached payloads written before previews existed may omit the field.
+  return tasks.flatMap((task) =>
+    (task.previews ?? []).map((preview) => ({
+      taskId: task.taskId,
+      taskTitle: task.title,
+      preview,
+    })),
+  );
+}
+
+/**
+ * Session-level Live Preview: the task workspace's PreviewSidePanel fed with
+ * entries collated across every linked task. When more than one task exposes
+ * previews, entry labels carry the task title so the service picker
+ * disambiguates them.
+ */
+function SessionPreviewsPanel({
+  tasks,
+  onClose,
+}: {
+  tasks: SessionPreviewTask[];
+  onClose: () => void;
+}) {
+  const previews = getSessionPreviews(tasks);
+  const tasksWithPreviews = new Set(previews.map((entry) => entry.taskId)).size;
+  const entries: PreviewEntry[] = previews.map((entry) => ({
+    name: `${entry.taskId}:${entry.preview.serviceName}`,
+    label:
+      tasksWithPreviews > 1
+        ? `${humanizePortName(entry.preview.serviceName)} - ${entry.taskTitle}`
+        : humanizePortName(entry.preview.serviceName),
+    url: entry.preview.url,
+    isPrimary: entry.preview.isPrimary,
+    runId: entry.preview.runId,
+  }));
+
+  return (
+    <FramedSurface
+      frameClassName="p-0"
+      surfaceClassName="relative flex flex-col overflow-hidden"
+    >
+      <PreviewPaneProvider>
+        <PreviewSidePanel entries={entries} onClose={onClose} />
+      </PreviewPaneProvider>
+    </FramedSurface>
+  );
+}
+
 function SessionTasksPanel({
   tasks,
   onOpenTask,
@@ -624,6 +702,7 @@ type BaseWorkspacePanel =
   | { kind: 'info' }
   | { kind: 'tasks'; autoOpened?: boolean }
   | { kind: 'artifacts' }
+  | { kind: 'previews' }
   | { kind: 'nested'; taskId: string };
 
 type WorkspacePanel =
@@ -679,6 +758,7 @@ export function SessionWorkspace({
   const taskCards = isFastTaskSource ? fastTasks : sessionTasks;
   const artifactTasks = isFastTaskSource ? fastTasks : sessionTasks;
   const sessionPullRequests = getSessionPullRequests(sessionTasks);
+  const sessionPreviewCount = getSessionPreviews(taskCards).length;
   const runningTasks = taskCards.filter((task) =>
     isTaskExecutingTurn(task.latestRun?.status, task.latestRun?.taskPhase),
   );
@@ -753,7 +833,7 @@ export function SessionWorkspace({
     setPanel(null);
     selectTask(null);
   };
-  const togglePanel = (kind: 'info' | 'tasks' | 'artifacts') => {
+  const togglePanel = (kind: 'info' | 'tasks' | 'artifacts' | 'previews') => {
     setPanel((previous) => (previous?.kind === kind ? null : { kind }));
     selectTask(null);
   };
@@ -811,6 +891,8 @@ export function SessionWorkspace({
       />
     ) : panel?.kind === 'artifacts' ? (
       <SessionArtifactsPanel tasks={artifactTasks} onClose={closePanel} />
+    ) : panel?.kind === 'previews' ? (
+      <SessionPreviewsPanel tasks={taskCards} onClose={closePanel} />
     ) : (
       <SessionInfoPanel session={session} onClose={closePanel} />
     );
@@ -840,6 +922,15 @@ export function SessionWorkspace({
                 active={panel?.kind === 'artifacts' && !selectedTask}
                 icon={LayoutGrid}
                 onClick={() => togglePanel('artifacts')}
+              />
+              <SideNavItem
+                side="right"
+                label="Live Preview"
+                tooltip="Live Preview"
+                active={panel?.kind === 'previews' && !selectedTask}
+                disabled={sessionPreviewCount === 0}
+                icon={AppWindow}
+                onClick={() => togglePanel('previews')}
               />
               <SideNavItem
                 side="right"

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/SandboxProvider.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/SandboxProvider.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from 'react';
 import { useStore } from 'zustand';
+import { createStore } from 'zustand/vanilla';
 import { useShallow } from 'zustand/react/shallow';
 
 import {
@@ -258,6 +259,20 @@ export function useSandboxHistoryReady(): boolean {
 export function useSandboxClient(): SandboxClient | null {
   const store = useSandboxStore();
   return useStore(store, (s) => s.client);
+}
+
+// A stable empty store so useOptionalSandboxClient can be called outside a
+// sandbox provider (e.g. the Session workspace's collated Live Preview panel).
+const nullSandboxClientStore = createStore<{ client: SandboxClient | null }>(
+  () => ({ client: null }),
+);
+
+export function useOptionalSandboxClient(): SandboxClient | null {
+  const store = useOptionalSandboxStore();
+  return useStore(
+    (store ?? nullSandboxClientStore) as typeof nullSandboxClientStore,
+    (s) => s.client,
+  );
 }
 
 export function useSandboxAppendAcpEvent() {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/preview-port-utils.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/preview-port-utils.ts
@@ -12,3 +12,11 @@ export function hasPreviewServiceListEntries(
 ): boolean {
   return portNames.some(shouldIncludeInPreviewServiceList);
 }
+
+/** Turns a configured port name like `WEB_APP` into a display label. */
+export function humanizePortName(portName: string): string {
+  return portName
+    .toLowerCase()
+    .replaceAll('_', ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/PreviewSidePanel.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/PreviewSidePanel.client.test.tsx
@@ -94,7 +94,7 @@ vi.mock('@/components/system', () => ({
 }));
 
 vi.mock('../hooks/SandboxProvider', () => ({
-  useSandboxClient: useSandboxClientMock,
+  useOptionalSandboxClient: useSandboxClientMock,
 }));
 
 vi.mock('../hooks/use-preview-pane', () => ({

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/PreviewSidePanel.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/PreviewSidePanel.tsx
@@ -37,21 +37,25 @@ import {
 } from '@/components/system';
 
 import { buildPreviewIframeUrl } from '../preview-iframe-url';
-import { useSandboxClient } from '../hooks/SandboxProvider';
+import { useOptionalSandboxClient } from '../hooks/SandboxProvider';
 import { usePreviewPane } from '../hooks/use-preview-pane';
 import { usePreviewUrls } from '../hooks/use-preview-urls';
 import { useTaskSidePanel } from '../hooks/use-task-side-panel';
-import { shouldIncludeInPreviewServiceList } from '../preview-port-utils';
+import {
+  humanizePortName,
+  shouldIncludeInPreviewServiceList,
+} from '../preview-port-utils';
 
 import { PreviewHelpDialog } from './PreviewHelpDialog';
 import { PreviewSetupState } from './PreviewSetupState';
 import { SidePanelHeader } from './SidePanelHeader';
 
-interface PreviewEntry {
+export interface PreviewEntry {
   name: string;
   label: string;
   url: string;
   isPrimary: boolean;
+  runId: number;
 }
 
 const KEEPALIVE_TOUCH_THROTTLE_MS = 5_000;
@@ -60,13 +64,6 @@ const INITIAL_RETRY_DELAY_MS = 2_000;
 const MAX_RETRY_DELAY_MS = 10_000;
 const MOBILE_WIDTH = 375;
 const MOBILE_HEIGHT = 667;
-
-function humanizePortName(portName: string): string {
-  return portName
-    .toLowerCase()
-    .replaceAll('_', ' ')
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-}
 
 function getDisplayPath(previewUrl: string | null): string {
   if (!previewUrl) {
@@ -121,9 +118,16 @@ function formatElementContext(context: {
 
 export function PreviewSidePanel({
   taskRun,
+  entries,
   onClose,
 }: {
   taskRun?: TaskRun;
+  /**
+   * Pre-collated preview entries (e.g. the Session workspace's cross-task
+   * list). When provided they replace the entries derived from `taskRun`,
+   * and each entry's own runId scopes its preview-iframe auth.
+   */
+  entries?: PreviewEntry[];
   onClose: () => void;
 }) {
   const {
@@ -142,7 +146,7 @@ export function PreviewSidePanel({
   const { previewUrls, initialPaths, primaryPortName } = usePreviewUrls(
     taskRun ?? {},
   );
-  const client = useSandboxClient();
+  const client = useOptionalSandboxClient();
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const urlInputRef = useRef<HTMLInputElement>(null);
   const navigatingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -197,8 +201,13 @@ export function PreviewSidePanel({
     [taskRun?.machineDomain, taskRun?.machineDomains, primaryPortName],
   );
 
+  const taskRunId = taskRun?.id;
   const serviceEntries = useMemo<PreviewEntry[]>(() => {
-    if (!previewUrls) {
+    if (entries) {
+      return entries;
+    }
+
+    if (!previewUrls || taskRunId == null) {
       return [];
     }
 
@@ -215,15 +224,18 @@ export function PreviewSidePanel({
           label: humanizePortName(name),
           url: appendInitialPath(url, pathForPort),
           isPrimary: name === resolvedPrimaryPortName,
+          runId: taskRunId,
         };
       })
       .sort((left, right) => Number(right.isPrimary) - Number(left.isPrimary));
   }, [
+    entries,
     initialPaths,
     previewPath,
     previewServiceName,
     previewUrls,
     resolvedPrimaryPortName,
+    taskRunId,
   ]);
 
   const activeEntry = useMemo(() => {
@@ -266,19 +278,20 @@ export function PreviewSidePanel({
   ]);
 
   const effectivePreviewUrl = previewPaneUrl ?? activeEntry?.url ?? null;
-  const effectiveRunId = previewPaneRunId ?? taskRun?.id ?? null;
+  const effectiveRunId =
+    previewPaneRunId ?? activeEntry?.runId ?? taskRun?.id ?? null;
   const iframeSrc =
     effectivePreviewUrl && effectiveRunId
       ? buildPreviewIframeUrl(effectivePreviewUrl, effectiveRunId)
       : null;
 
   useEffect(() => {
-    if (!taskRun || !activeEntry) {
+    if (!activeEntry) {
       return;
     }
 
     const hasMatchingPreviewSelection =
-      previewPaneRunId === taskRun.id &&
+      previewPaneRunId === activeEntry.runId &&
       (previewPaneServiceName
         ? previewPaneServiceName === activeEntry.name
         : previewPaneUrl === activeEntry.url);
@@ -305,10 +318,9 @@ export function PreviewSidePanel({
       return;
     }
 
-    openPreviewPane(activeEntry.url, taskRun.id, activeEntry.name);
+    openPreviewPane(activeEntry.url, activeEntry.runId, activeEntry.name);
   }, [
     activeEntry,
-    taskRun,
     currentUrl,
     openPreviewPane,
     previewPaneRunId,
@@ -463,12 +475,8 @@ export function PreviewSidePanel({
   };
 
   const handleSelectEntry = (entry: PreviewEntry) => {
-    if (!taskRun) {
-      return;
-    }
-
-    openPreviewPane(entry.url, taskRun.id, entry.name);
-    openPreviewView(entry.url, taskRun.id, entry.name);
+    openPreviewPane(entry.url, entry.runId, entry.name);
+    openPreviewView(entry.url, entry.runId, entry.name);
   };
 
   const postPreviewNavigation = useCallback(

--- a/apps/web/src/lib/server/fast-sessions.test.ts
+++ b/apps/web/src/lib/server/fast-sessions.test.ts
@@ -275,6 +275,7 @@ describe('Fast session queries', () => {
               version: 2,
             }),
           ],
+          previews: [],
           latestRun: {
             status: RunStatus.Running,
             taskPhase: 'running',
@@ -285,6 +286,7 @@ describe('Fast session queries', () => {
           title: 'Zero cost task',
           inferenceCostMicroUsd: 0,
           artifacts: [],
+          previews: [],
           latestRun: {
             status: RunStatus.Completed,
             taskPhase: null,
@@ -292,6 +294,75 @@ describe('Fast session queries', () => {
         },
       ]),
     );
+  });
+
+  it('collates live preview URLs from awake delegated task runs', async () => {
+    const owner = await userFactory.create();
+    const session = await createFastSession({
+      userId: owner.id,
+      conversationId: 'preview-session',
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const awakeTask = await taskFactory.create({
+      title: 'Awake task',
+      state: 'active',
+    });
+    const awakeRun = await runFactory.create({
+      taskId: awakeTask.id,
+      status: RunStatus.Running,
+      taskPhase: 'running',
+      machineDomains: {
+        WEB_APP: 'web.internal',
+        API: 'api.internal',
+        SANDBOX_SERVER: 'sandbox.internal',
+      },
+      initialPaths: { WEB_APP: '/dashboard' },
+      primaryPortName: 'WEB_APP',
+      payload: {
+        repo: 'acme/widgets',
+        description: 'Awake Fast task',
+        fastAgentSessionId: session.id,
+      },
+    });
+    const sleepingTask = await taskFactory.create({
+      title: 'Sleeping task',
+      state: 'active',
+    });
+    await runFactory.create({
+      taskId: sleepingTask.id,
+      status: RunStatus.Idle,
+      machineDomains: { WEB_APP: 'sleeping.internal' },
+      snapshotId: 'snapshot-1',
+      payload: {
+        repo: 'acme/widgets',
+        description: 'Sleeping Fast task',
+        fastAgentSessionId: session.id,
+      },
+    });
+
+    const result = await getFastSessionTasks(
+      { userId: owner.id, isAdmin: false },
+      session.id,
+    );
+
+    const awake = result?.find((task) => task.taskId === awakeTask.id);
+    expect(awake?.previews).toEqual([
+      {
+        serviceName: 'WEB_APP',
+        url: expect.stringContaining(`${awakeTask.id}-web-app`),
+        isPrimary: true,
+        runId: awakeRun.id,
+      },
+      {
+        serviceName: 'API',
+        url: expect.stringContaining(`${awakeTask.id}-api`),
+        isPrimary: false,
+        runId: awakeRun.id,
+      },
+    ]);
+    expect(awake?.previews[0]?.url).toContain('/dashboard');
+    const sleeping = result?.find((task) => task.taskId === sleepingTask.id);
+    expect(sleeping?.previews).toEqual([]);
   });
 
   it('keeps task-linked usage out of the legacy Fast direct cost', async () => {

--- a/apps/web/src/lib/server/fast-sessions.ts
+++ b/apps/web/src/lib/server/fast-sessions.ts
@@ -29,6 +29,11 @@ import type { FastAgentMessage } from '@roomote/db';
 
 import type { UserAuthSuccess } from '@/types';
 import { COMPOSER_SUGGESTION_HISTORY_LIMIT } from './composer-suggestion-history';
+import {
+  buildSessionTaskPreviews,
+  getSessionPreviewProxyConfig,
+  type SessionTaskPreview,
+} from './session-task-previews';
 
 type FastSessionAuth = Pick<UserAuthSuccess, 'userId' | 'isAdmin'>;
 
@@ -45,6 +50,7 @@ type FastSessionTaskSummary = {
     size: number;
     createdAt: Date;
   }>;
+  previews: SessionTaskPreview[];
   latestRun: {
     status: (typeof taskRuns.$inferSelect)['status'];
     taskPhase: (typeof taskRuns.$inferSelect)['taskPhase'];
@@ -264,6 +270,15 @@ export async function getFastSessionTasks(
         latestRunId: taskRuns.id,
         status: taskRuns.status,
         taskPhase: taskRuns.taskPhase,
+        machineDomain: taskRuns.machineDomain,
+        machineDomains: taskRuns.machineDomains,
+        initialPaths: taskRuns.initialPaths,
+        primaryPortName: taskRuns.primaryPortName,
+        sleepRequestedAt: taskRuns.sleepRequestedAt,
+        snapshotRequestedAt: taskRuns.snapshotRequestedAt,
+        snapshotCreatedAt: taskRuns.snapshotCreatedAt,
+        snapshotFailedAt: taskRuns.snapshotFailedAt,
+        snapshotId: taskRuns.snapshotId,
       })
       .from(taskRuns)
       .innerJoin(tasks, eq(tasks.id, taskRuns.taskId))
@@ -281,8 +296,18 @@ export async function getFastSessionTasks(
     .select({
       taskId: latestRunPerTask.taskId,
       title: latestRunPerTask.title,
+      latestRunId: latestRunPerTask.latestRunId,
       status: latestRunPerTask.status,
       taskPhase: latestRunPerTask.taskPhase,
+      machineDomain: latestRunPerTask.machineDomain,
+      machineDomains: latestRunPerTask.machineDomains,
+      initialPaths: latestRunPerTask.initialPaths,
+      primaryPortName: latestRunPerTask.primaryPortName,
+      sleepRequestedAt: latestRunPerTask.sleepRequestedAt,
+      snapshotRequestedAt: latestRunPerTask.snapshotRequestedAt,
+      snapshotCreatedAt: latestRunPerTask.snapshotCreatedAt,
+      snapshotFailedAt: latestRunPerTask.snapshotFailedAt,
+      snapshotId: latestRunPerTask.snapshotId,
       inferenceCostMicroUsd: sql<number>`coalesce(sum(${llmUsageEvents.costMicroUsd}), 0)::bigint`,
     })
     .from(latestRunPerTask)
@@ -296,10 +321,22 @@ export async function getFastSessionTasks(
       latestRunPerTask.latestRunId,
       latestRunPerTask.status,
       latestRunPerTask.taskPhase,
+      latestRunPerTask.machineDomain,
+      latestRunPerTask.machineDomains,
+      latestRunPerTask.initialPaths,
+      latestRunPerTask.primaryPortName,
+      latestRunPerTask.sleepRequestedAt,
+      latestRunPerTask.snapshotRequestedAt,
+      latestRunPerTask.snapshotCreatedAt,
+      latestRunPerTask.snapshotFailedAt,
+      latestRunPerTask.snapshotId,
     )
     .orderBy(desc(latestRunPerTask.latestRunId));
 
   const taskIds = rows.map((row) => row.taskId);
+  const previewConfig = taskIds.length
+    ? await getSessionPreviewProxyConfig()
+    : null;
   const artifactRows = taskIds.length
     ? await db
         .select({
@@ -329,6 +366,13 @@ export async function getFastSessionTasks(
     artifacts: artifactRows
       .filter((artifact) => artifact.taskId === row.taskId)
       .map(({ taskId: _taskId, ...artifact }) => artifact),
+    previews: previewConfig
+      ? buildSessionTaskPreviews(
+          row.taskId,
+          { ...row, id: row.latestRunId },
+          previewConfig,
+        )
+      : [],
     latestRun: {
       status: row.status,
       taskPhase: row.taskPhase,

--- a/apps/web/src/lib/server/session-task-previews.ts
+++ b/apps/web/src/lib/server/session-task-previews.ts
@@ -1,0 +1,109 @@
+import { resolveEffectivePreviewRuntimeConfig } from '@roomote/db/server';
+import {
+  appendInitialPath,
+  getPrimaryPortName,
+  isExitedRunStatus,
+  SYSTEM_PORT_NAMES,
+  type RunStatus,
+} from '@roomote/types';
+
+import { buildTaskPreviewUrls } from '@/lib/preview-urls';
+
+import { Env } from './env';
+
+/**
+ * A live preview URL exposed by a session-linked task, ready for the session
+ * workspace to embed via the preview-iframe auth route.
+ */
+export type SessionTaskPreview = {
+  serviceName: string;
+  url: string;
+  isPrimary: boolean;
+  runId: number;
+};
+
+type SessionPreviewProxyConfig = {
+  previewProxyBaseUrl: string | null;
+  previewProxySubdomainSuffix: string | null;
+};
+
+/**
+ * Resolve the effective preview-proxy config once per session read so every
+ * linked task's preview URLs are built against the same deployment settings.
+ */
+export async function getSessionPreviewProxyConfig(): Promise<SessionPreviewProxyConfig> {
+  const resolvedConfig = await resolveEffectivePreviewRuntimeConfig({
+    runtimeEnv: process.env,
+    defaultPreviewProxyBaseUrl: Env.PREVIEW_PROXY_BASE_URL,
+    defaultPreviewDomains: Env.PREVIEW_DOMAINS,
+  });
+
+  return {
+    previewProxyBaseUrl: resolvedConfig.effective.previewProxyBaseUrl ?? null,
+    previewProxySubdomainSuffix:
+      resolvedConfig.effective.previewProxySubdomainSuffix ?? null,
+  };
+}
+
+type SessionPreviewRunFields = {
+  id: number;
+  status: RunStatus;
+  machineDomain: string | null;
+  machineDomains: Record<string, string> | null;
+  initialPaths: Record<string, string> | null;
+  primaryPortName: string | null;
+  sleepRequestedAt: Date | null;
+  snapshotRequestedAt: Date | null;
+  snapshotCreatedAt: Date | null;
+  snapshotFailedAt: Date | null;
+  snapshotId: string | null;
+};
+
+// Mirrors the task workspace's isTaskRunAsleep: once the sandbox is going to
+// sleep or already snapshotted, its preview domains no longer serve anything.
+function isRunAsleep(run: SessionPreviewRunFields): boolean {
+  const isGoingToSleep =
+    (!!run.sleepRequestedAt || !!run.snapshotRequestedAt) &&
+    !run.snapshotCreatedAt &&
+    !run.snapshotFailedAt;
+
+  return isGoingToSleep || !!run.snapshotId;
+}
+
+/**
+ * Live preview entries for one session-linked task, primary service first.
+ * Exited or sleeping runs return no entries: their sandbox (and therefore the
+ * preview origin) is gone, and the task page owns the wake-up flow.
+ */
+export function buildSessionTaskPreviews(
+  taskId: string,
+  run: SessionPreviewRunFields | null | undefined,
+  config: SessionPreviewProxyConfig,
+): SessionTaskPreview[] {
+  if (!run?.machineDomains) return [];
+  if (isExitedRunStatus(run.status) || isRunAsleep(run)) return [];
+
+  const previewUrls = buildTaskPreviewUrls(
+    taskId,
+    run.machineDomains,
+    config.previewProxyBaseUrl,
+    config.previewProxySubdomainSuffix,
+  );
+  if (!previewUrls) return [];
+
+  const primaryPortName = getPrimaryPortName(
+    run.machineDomain,
+    run.machineDomains,
+    run.primaryPortName,
+  );
+
+  return Object.entries(previewUrls)
+    .filter(([portName]) => !SYSTEM_PORT_NAMES.has(portName.toUpperCase()))
+    .map(([portName, url]) => ({
+      serviceName: portName,
+      url: appendInitialPath(url, run.initialPaths?.[portName] ?? null),
+      isPrimary: portName === primaryPortName,
+      runId: run.id,
+    }))
+    .sort((left, right) => Number(right.isPrimary) - Number(left.isPrimary));
+}

--- a/apps/web/src/lib/server/sessions.test.ts
+++ b/apps/web/src/lib/server/sessions.test.ts
@@ -19,6 +19,7 @@ import {
 import {
   ACP_ENVELOPE_EVENT_TYPES,
   ROOMOTE_RUNTIME_TASK_MESSAGE_PROTOCOL,
+  RunStatus,
 } from '@roomote/types';
 
 const syncFastSlackTitle = vi.hoisted(() => vi.fn());
@@ -994,6 +995,73 @@ describe('unified Session queries', () => {
         }),
       ]),
     );
+  });
+
+  it('collates live preview URLs from awake linked task runs', async () => {
+    const owner = await userFactory.create();
+    const session = await sessionFactory.create({
+      ownerKind: 'user',
+      ownerUserId: owner.id,
+      title: 'Preview session',
+    });
+    const awakeTask = await taskFactory.create({
+      initiatorUserId: owner.id,
+      title: 'Awake task',
+    });
+    const sleepingTask = await taskFactory.create({
+      initiatorUserId: owner.id,
+      title: 'Sleeping task',
+    });
+    await db.insert(sessionTasks).values([
+      {
+        sessionId: session.id,
+        taskId: awakeTask.id,
+        origin: 'fast_delegation',
+        attachedAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+      {
+        sessionId: session.id,
+        taskId: sleepingTask.id,
+        origin: 'fast_delegation',
+        attachedAt: new Date('2026-01-01T00:00:01.000Z'),
+      },
+    ]);
+    const awakeRun = await runFactory.create({
+      taskId: awakeTask.id,
+      status: RunStatus.Running,
+      machineDomains: {
+        WEB_APP: 'web.internal',
+        SANDBOX_SERVER: 'sandbox.internal',
+      },
+      initialPaths: { WEB_APP: '/dashboard' },
+      primaryPortName: 'WEB_APP',
+    });
+    await runFactory.create({
+      taskId: sleepingTask.id,
+      status: RunStatus.Idle,
+      machineDomains: { WEB_APP: 'sleeping.internal' },
+      snapshotId: 'snapshot-1',
+    });
+
+    const detail = await getSessionById(
+      { userId: owner.id, isAdmin: false },
+      session.id,
+    );
+
+    const awake = detail?.tasks.find((task) => task.taskId === awakeTask.id);
+    expect(awake?.previews).toEqual([
+      {
+        serviceName: 'WEB_APP',
+        url: expect.stringContaining(`${awakeTask.id}-web-app`),
+        isPrimary: true,
+        runId: awakeRun.id,
+      },
+    ]);
+    expect(awake?.previews[0]?.url).toContain('/dashboard');
+    const sleeping = detail?.tasks.find(
+      (task) => task.taskId === sleepingTask.id,
+    );
+    expect(sleeping?.previews).toEqual([]);
   });
 
   it('resolves the latest external event from visible messages only', async () => {

--- a/apps/web/src/lib/server/sessions.ts
+++ b/apps/web/src/lib/server/sessions.ts
@@ -44,6 +44,10 @@ import { parseCreatorFilterValue } from '@/lib/task-creator-filter';
 import { getSessionPullRequests } from '@/lib/session-pull-requests';
 
 import { getFastSessionById } from './fast-sessions';
+import {
+  buildSessionTaskPreviews,
+  getSessionPreviewProxyConfig,
+} from './session-task-previews';
 
 type SessionAuth = Pick<UserAuthSuccess, 'userId' | 'isAdmin'>;
 export type SessionScope = 'all' | 'tasks' | 'reviews' | 'automations';
@@ -825,7 +829,7 @@ async function getSessionTasks(sessionId: string) {
   // Four batched lookups regardless of task count; the per-task N+1 version
   // multiplied badly under the session workspace's polling.
   const taskIds = linked.map((task) => task.taskId);
-  const [latestRuns, artifactRows, pullRequestRows, usageRows] =
+  const [latestRuns, artifactRows, pullRequestRows, usageRows, previewConfig] =
     await Promise.all([
       db
         .selectDistinctOn([taskRuns.taskId], {
@@ -835,6 +839,15 @@ async function getSessionTasks(sessionId: string) {
           taskPhase: taskRuns.taskPhase,
           error: taskRuns.error,
           result: taskRuns.result,
+          machineDomain: taskRuns.machineDomain,
+          machineDomains: taskRuns.machineDomains,
+          initialPaths: taskRuns.initialPaths,
+          primaryPortName: taskRuns.primaryPortName,
+          sleepRequestedAt: taskRuns.sleepRequestedAt,
+          snapshotRequestedAt: taskRuns.snapshotRequestedAt,
+          snapshotCreatedAt: taskRuns.snapshotCreatedAt,
+          snapshotFailedAt: taskRuns.snapshotFailedAt,
+          snapshotId: taskRuns.snapshotId,
         })
         .from(taskRuns)
         .where(inArray(taskRuns.taskId, taskIds))
@@ -878,6 +891,7 @@ async function getSessionTasks(sessionId: string) {
         .from(llmUsageEvents)
         .where(inArray(llmUsageEvents.taskId, taskIds))
         .groupBy(llmUsageEvents.taskId),
+      getSessionPreviewProxyConfig(),
     ]);
 
   const latestRunByTask = new Map(latestRuns.map((run) => [run.taskId, run]));
@@ -912,6 +926,11 @@ async function getSessionTasks(sessionId: string) {
       latestRun,
       latestOutput,
       inferenceCostMicroUsd: usageByTask.get(task.taskId) ?? 0,
+      previews: buildSessionTaskPreviews(
+        task.taskId,
+        latestRunRow,
+        previewConfig,
+      ),
       artifacts: artifactRows
         .filter((artifact) => artifact.taskId === task.taskId)
         .map(({ taskId: _taskId, ...artifact }) => artifact),


### PR DESCRIPTION
## Summary

Sessions now surface a **Live Preview** panel that collects live preview URLs from every linked task, imitating the task-level preview experience (service dropdown, nav bar, path input, mobile toggle, embedded iframe) rather than the artifact gallery.

### Server

- New `session-task-previews.ts` resolves the deployment's effective preview-proxy config once per session read and builds per-task preview entries (service name, full URL with initial path, primary flag, run id) from each task's latest run.
- Both unified sessions (`getSessionTasks`) and legacy Fast conversations (`getFastSessionTasks`) attach a `previews` array to every task summary.
- Entries only exist for awake runs: exited, sleeping, or snapshotted sandboxes return none (their preview origin is gone; the task page owns the wake-up flow). System ports (SANDBOX_SERVER, EDITOR, GUI) are filtered out.

### Web

- `PreviewSidePanel` accepts an optional pre-collated `entries` list where each entry carries its own `runId`, so one panel can span runs from different tasks. The task page's behavior is unchanged (it derives entries from its run as before).
- The Session workspace adds a **Live Preview** side-nav item, disabled until a linked task has a live preview, that opens the same panel fed with the cross-task list. When multiple tasks expose previews, service-picker labels fold in the task title ("Web App - Task title").
- New `useOptionalSandboxClient` hook lets the panel render without a sandbox connection; keepalive touches no-op outside the task workspace.

### Tests

- DB-backed coverage for preview collation in both session task queries (awake vs. sleeping runs, system-port filtering, initial paths).
- Session workspace client tests for the disabled state and the collated panel (default primary entry, iframe auth URL, cross-task labels).