### PR TITLE
feat: source-control Fast turns edit one comment in place

### DIFF
--- a/packages/ado/src/api.ts
+++ b/packages/ado/src/api.ts
@@ -233,7 +233,7 @@ async function requestAdoJson<T>({
 }: {
   organizationApiBaseUrl: string;
   fetchImpl?: typeof fetch;
-  method?: 'GET' | 'POST' | 'PUT';
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH';
   path: string;
   params: Record<string, string | number | boolean>;
   token: string;
@@ -1701,4 +1701,123 @@ export async function createTaskRunAdoCredentials(
     ),
     expiresAt: resolvedToken?.expiresAt ?? null,
   };
+}
+
+/** Replaces the content of an existing pull request thread comment. */
+export async function updateAdoPullRequestComment({
+  repositoryFullName,
+  repositoryId,
+  pullRequestNumber,
+  threadId,
+  commentId,
+  body,
+  token,
+  organization,
+  baseUrl,
+  organizationApiBaseUrl,
+  fetchImpl,
+}: {
+  repositoryFullName: string;
+  repositoryId: string;
+  pullRequestNumber: number;
+  threadId: string;
+  commentId: string | number;
+  body: string;
+  token?: string;
+  organization?: string;
+  baseUrl?: string;
+  organizationApiBaseUrl?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  const adoToken = token ?? (await resolveAdoToken());
+
+  if (!adoToken?.trim()) {
+    throw new Error(
+      'ADO_TOKEN is required to update Azure DevOps pull request comments.',
+    );
+  }
+
+  const parsedRepository = parseAdoRepositoryFullName(repositoryFullName);
+  const resolvedOrganizationApiBaseUrl = await resolveAdoOrganizationApiBaseUrl(
+    {
+      organization: organization ?? parsedRepository.organization,
+      baseUrl,
+      organizationApiBaseUrl,
+    },
+  );
+
+  if (!resolvedOrganizationApiBaseUrl) {
+    throw new Error(
+      'ADO_ORGANIZATION is required to update Azure DevOps pull request comments.',
+    );
+  }
+
+  await requestAdoJson({
+    organizationApiBaseUrl: resolvedOrganizationApiBaseUrl,
+    fetchImpl,
+    method: 'PATCH',
+    path: `/${encodeURIComponent(
+      parsedRepository.project,
+    )}/_apis/git/repositories/${encodeURIComponent(
+      repositoryId,
+    )}/pullRequests/${pullRequestNumber}/threads/${encodeURIComponent(
+      String(threadId),
+    )}/comments/${encodeURIComponent(String(commentId))}`,
+    params: { 'api-version': ADO_API_VERSION },
+    token: adoToken,
+    body: { content: body },
+    schema: z.object({}).passthrough(),
+  });
+}
+
+/** Replaces the text of an existing work item comment. */
+export async function updateAdoWorkItemComment({
+  project,
+  workItemId,
+  commentId,
+  body,
+  token,
+  organization,
+  baseUrl,
+  organizationApiBaseUrl,
+  fetchImpl,
+}: {
+  project: string;
+  workItemId: number;
+  commentId: string | number;
+  body: string;
+  token?: string;
+  organization?: string;
+  baseUrl?: string;
+  organizationApiBaseUrl?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  const adoToken = token ?? (await resolveAdoToken());
+
+  if (!adoToken?.trim()) {
+    throw new Error(
+      'ADO_TOKEN is required to update Azure DevOps work item comments.',
+    );
+  }
+
+  const resolvedOrganizationApiBaseUrl = await resolveAdoOrganizationApiBaseUrl(
+    { organization, baseUrl, organizationApiBaseUrl },
+  );
+
+  if (!resolvedOrganizationApiBaseUrl) {
+    throw new Error(
+      'ADO_ORGANIZATION is required to update Azure DevOps work item comments.',
+    );
+  }
+
+  await requestAdoJson({
+    organizationApiBaseUrl: resolvedOrganizationApiBaseUrl,
+    fetchImpl,
+    method: 'PATCH',
+    path: `/${encodeURIComponent(project)}/_apis/wit/workItems/${workItemId}/comments/${encodeURIComponent(String(commentId))}`,
+    params: { 'api-version': '7.1-preview.4' },
+    token: adoToken,
+    body: { text: body },
+    schema: z.object({}).passthrough(),
+  });
 }

--- a/packages/bitbucket/src/api.ts
+++ b/packages/bitbucket/src/api.ts
@@ -1410,3 +1410,49 @@ export async function getBitbucketPullRequest({
 
   return data;
 }
+
+/** Replaces the body of an existing pull request comment. */
+export async function updateBitbucketPullRequestComment({
+  repositoryFullName,
+  pullRequestNumber,
+  commentId,
+  body,
+  token,
+  username,
+  baseUrl,
+  apiBaseUrl,
+  fetchImpl,
+}: {
+  repositoryFullName: string;
+  pullRequestNumber: number;
+  commentId: number;
+  body: string;
+  token?: string;
+  username?: string;
+  baseUrl?: string;
+  apiBaseUrl?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  const auth = await resolveAuthIdentity({
+    token,
+    username,
+    baseUrl,
+    apiBaseUrl,
+    fetchImpl,
+  });
+  const { workspace, repo } =
+    splitBitbucketRepositoryFullName(repositoryFullName);
+  await requestBitbucketJson({
+    apiBaseUrl: auth.apiBaseUrl,
+    fetchImpl,
+    method: 'PUT',
+    path: `/repositories/${encodeURIComponent(workspace)}/${encodeURIComponent(
+      repo,
+    )}/pullrequests/${pullRequestNumber}/comments/${commentId}`,
+    username: auth.username,
+    token: auth.token,
+    authScheme: auth.authScheme,
+    body: { content: { raw: body } },
+    schema: bitbucketCommentSchema,
+  });
+}

--- a/packages/communication/src/fast-session-footer.ts
+++ b/packages/communication/src/fast-session-footer.ts
@@ -137,11 +137,20 @@ export function buildFastSessionReplyFooterText(params: {
 }): string {
   const sessionUrl = buildFastSessionUrl(params.provider, params.sessionId);
 
+  // Chat surfaces route any thread reply to the Session; source-control
+  // discussions only hear @-mentions, so the footer must say so.
+  const explicitMentionRequired =
+    params.provider === 'github' ||
+    params.provider === 'gitlab' ||
+    params.provider === 'bitbucket' ||
+    params.provider === 'ado' ||
+    params.provider === 'gitea';
+
   return buildThreadReplyFooterText({
     taskUrl: sessionUrl,
     linkedPrs: collectFastSessionLinkedPrs(params),
     livePreviewUrl: params.livePreviewUrl,
-    explicitMentionRequired: false,
+    explicitMentionRequired,
     ...(params.provider === 'slack'
       ? { formatLink: (label: string, url: string) => `<${url}|${label}>` }
       : params.provider === 'discord'

--- a/packages/gitea/src/api.ts
+++ b/packages/gitea/src/api.ts
@@ -1268,3 +1268,46 @@ export async function getGiteaPullRequest({
 
   return data;
 }
+
+/** Replaces the body of an existing issue or pull request comment. */
+export async function updateGiteaComment({
+  repositoryFullName,
+  commentId,
+  body,
+  token,
+  baseUrl,
+  apiBaseUrl,
+  fetchImpl,
+}: {
+  repositoryFullName: string;
+  commentId: number;
+  body: string;
+  token?: string;
+  baseUrl?: string;
+  apiBaseUrl?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  const giteaToken = token ?? (await resolveGiteaToken());
+
+  if (!giteaToken?.trim()) {
+    throw new Error('A Gitea token is required to update comments.');
+  }
+
+  const resolvedBaseUrl = baseUrl ?? (await resolveGiteaBaseUrl());
+
+  if (!resolvedBaseUrl?.trim() && !apiBaseUrl?.trim()) {
+    throw new Error('A Gitea base URL is required to update comments.');
+  }
+
+  const { owner, repo } = splitGiteaRepositoryFullName(repositoryFullName);
+  await requestGiteaJson({
+    apiBaseUrl: apiBaseUrl ?? buildGiteaApiBaseUrl(resolvedBaseUrl!),
+    fetchImpl,
+    method: 'PATCH',
+    path: `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/comments/${commentId}`,
+    params: {},
+    token: giteaToken,
+    body: { body },
+    schema: z.object({ id: z.number() }).passthrough(),
+  });
+}

--- a/packages/gitlab/src/api.ts
+++ b/packages/gitlab/src/api.ts
@@ -1425,3 +1425,41 @@ export async function getGitLabMergeRequest({
 
   return data;
 }
+
+/** Replaces the body of an existing merge request or issue note. */
+export async function updateGitLabNote({
+  projectId,
+  noteableType,
+  noteableIid,
+  noteId,
+  body,
+  token,
+  apiBaseUrl,
+  fetchImpl,
+}: {
+  projectId: string | number;
+  noteableType: 'merge_requests' | 'issues';
+  noteableIid: number;
+  noteId: number;
+  body: string;
+  token?: string;
+  apiBaseUrl?: string;
+  fetchImpl?: typeof fetch;
+}): Promise<void> {
+  const gitLabToken = token ?? (await resolveGitLabToken());
+
+  if (!gitLabToken?.trim()) {
+    throw new Error('A GitLab token is required to update notes.');
+  }
+
+  await requestGitLabJson({
+    apiBaseUrl,
+    fetchImpl,
+    method: 'PUT',
+    path: `/projects/${encodeURIComponent(String(projectId))}/${noteableType}/${noteableIid}/notes/${noteId}`,
+    params: {},
+    token: gitLabToken,
+    body: { body },
+    schema: z.object({ id: z.number() }).passthrough(),
+  });
+}

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -413,6 +413,57 @@ describe('GitHub Fast delivery', () => {
     expect(second).toEqual({ messageId: '6001' });
   });
 
+  it('replaces a resumed turn comment by id and keeps appending into it', async () => {
+    const updateComment = vi.fn().mockResolvedValue({});
+    mocks.getInstallationOctokit.mockResolvedValue({
+      rest: {
+        issues: { createComment, updateComment },
+        pulls: { get: pullsGet },
+      },
+      request,
+    });
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    // A fresh adapter, as a resumed process would build: no in-memory state.
+    const adapter = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+    });
+
+    const replaced = await adapter.replaceReply!(
+      { messageId: '7001' },
+      { message: 'Recovered; here is the result.' },
+    );
+    await adapter.postReply({ message: 'And one more detail.' });
+
+    expect(replaced).toEqual({ messageId: '7001' });
+    expect(createComment).not.toHaveBeenCalled();
+    expect(updateComment).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        comment_id: 7001,
+        body: expect.stringContaining('Recovered; here is the result.'),
+      }),
+    );
+    expect(updateComment).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        comment_id: 7001,
+        body: expect.stringContaining(
+          'Recovered; here is the result.\n\nAnd one more detail.',
+        ),
+      }),
+    );
+  });
+
   it('threads replies under the review comment the mention came from', async () => {
     const conversation = buildSourceControlFastConversation({
       provider: 'github',
@@ -567,7 +618,8 @@ describe('other provider Fast deliveries', () => {
       userId: 'user-1',
       sessionId: 'fast-1',
     });
-    await adapter.postReply({ message: 'On it.' });
+    const adoPosted = await adapter.postReply({ message: 'On it.' });
+    expect(adoPosted).toEqual({ messageId: 'thread:5:901' });
     await delivery!.resolveTarget();
 
     expect(mocks.adoListRepositories).toHaveBeenCalledTimes(1);

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -14,6 +14,11 @@ const mocks = vi.hoisted(() => ({
   adoCreateWorkItemComment: vi.fn(),
   adoGetPullRequest: vi.fn(),
   adoListRepositories: vi.fn(),
+  gitlabUpdateNote: vi.fn(),
+  giteaUpdateComment: vi.fn(),
+  bitbucketUpdateComment: vi.fn(),
+  adoUpdatePullRequestComment: vi.fn(),
+  adoUpdateWorkItemComment: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
@@ -40,17 +45,20 @@ vi.mock('@roomote/gitlab', () => ({
   createGitLabIssueNote: mocks.gitlabCreateIssueNote,
   createGitLabMergeRequestNote: mocks.gitlabCreateMergeRequestNote,
   getGitLabMergeRequest: mocks.gitlabGetMergeRequest,
+  updateGitLabNote: mocks.gitlabUpdateNote,
 }));
 
 vi.mock('@roomote/gitea', () => ({
   createGiteaIssueComment: mocks.giteaCreateIssueComment,
   createGiteaPullRequestComment: mocks.giteaCreatePullRequestComment,
   getGiteaPullRequest: mocks.giteaGetPullRequest,
+  updateGiteaComment: mocks.giteaUpdateComment,
 }));
 
 vi.mock('@roomote/bitbucket', () => ({
   createBitbucketPullRequestComment: mocks.bitbucketCreateComment,
   getBitbucketPullRequest: mocks.bitbucketGetPullRequest,
+  updateBitbucketPullRequestComment: mocks.bitbucketUpdateComment,
 }));
 
 vi.mock('@roomote/ado', () => ({
@@ -58,6 +66,8 @@ vi.mock('@roomote/ado', () => ({
   createAdoWorkItemComment: mocks.adoCreateWorkItemComment,
   getAdoPullRequest: mocks.adoGetPullRequest,
   listAdoRepositories: mocks.adoListRepositories,
+  updateAdoPullRequestComment: mocks.adoUpdatePullRequestComment,
+  updateAdoWorkItemComment: mocks.adoUpdateWorkItemComment,
   parseAdoRepositoryFullName: (fullName: string) => {
     const [organization, project, repository] = fullName.split('/');
     return { organization, project, repository };
@@ -354,6 +364,53 @@ describe('GitHub Fast delivery', () => {
         sha: 'abc123',
       },
     });
+  });
+
+  it('edits the turn comment in place for later replies instead of posting again', async () => {
+    const updateComment = vi.fn().mockResolvedValue({});
+    mocks.getInstallationOctokit.mockResolvedValue({
+      rest: {
+        issues: {
+          createComment: createComment.mockResolvedValue({
+            data: { id: 6001 },
+          }),
+          updateComment,
+        },
+        pulls: { get: pullsGet },
+      },
+      request,
+    });
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    const adapter = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+    });
+
+    await adapter.postReply({ message: 'On it.' });
+    const second = await adapter.postReply({
+      message: 'Rebased; running checks.',
+    });
+
+    expect(createComment).toHaveBeenCalledTimes(1);
+    expect(updateComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        comment_id: 6001,
+        body: expect.stringContaining('On it.\n\nRebased; running checks.'),
+      }),
+    );
+    // Footer appears once, at the bottom of the edited body.
+    const body = updateComment.mock.calls[0]?.[0].body as string;
+    expect(body.match(/footer:github/g)).toHaveLength(1);
+    expect(second).toEqual({ messageId: '6001' });
   });
 
   it('threads replies under the review comment the mention came from', async () => {

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -222,6 +222,15 @@ export type SourceControlFastReplyPoster = (input: {
  */
 export type SourceControlFastDelivery = {
   postComment: SourceControlFastReplyPoster;
+  /**
+   * Rebuilds an in-place editor from a previously posted comment's message
+   * id, for turns that resume in a fresh process and only carry the id.
+   */
+  updateCommentById?: (input: {
+    discussion: SourceControlFastDiscussion;
+    messageId: string;
+    body: string;
+  }) => Promise<void>;
   resolveTarget: () => Promise<SourceControlFastLaunchTarget>;
 };
 
@@ -299,6 +308,27 @@ async function buildGitHubFastDelivery(
           });
         },
       };
+    },
+    updateCommentById: async ({ discussion: target, messageId, body }) => {
+      const commentId = Number(messageId);
+      if (!Number.isInteger(commentId)) {
+        throw new Error(`Not an editable GitHub comment id: ${messageId}`);
+      }
+      if (target.kind === 'pull' && target.reviewCommentId) {
+        await octokit.rest.pulls.updateReviewComment({
+          owner,
+          repo,
+          comment_id: commentId,
+          body,
+        });
+        return;
+      }
+      await octokit.rest.issues.updateComment({
+        owner,
+        repo,
+        comment_id: commentId,
+        body,
+      });
     },
     resolveTarget: async () => {
       if (discussion.kind === 'issues') {
@@ -432,6 +462,15 @@ async function buildGitLabFastDelivery(
         },
       };
     },
+    updateCommentById: async ({ discussion: target, messageId, body }) => {
+      await updateGitLabNote({
+        projectId: target.repositoryFullName,
+        noteableType: target.kind === 'pull' ? 'merge_requests' : 'issues',
+        noteableIid: target.number,
+        noteId: Number(messageId),
+        body,
+      });
+    },
     resolveTarget: async () => {
       if (discussion.kind === 'issues') {
         return {
@@ -492,6 +531,14 @@ async function buildBitbucketFastDelivery(
         },
       };
     },
+    updateCommentById: async ({ discussion: target, messageId, body }) => {
+      await updateBitbucketPullRequestComment({
+        repositoryFullName: target.repositoryFullName,
+        pullRequestNumber: target.number,
+        commentId: Number(messageId),
+        body,
+      });
+    },
     resolveTarget: async () => {
       const pullRequest = await getBitbucketPullRequest({
         repositoryFullName: discussion.repositoryFullName,
@@ -549,6 +596,13 @@ async function buildGiteaFastDelivery(
           });
         },
       };
+    },
+    updateCommentById: async ({ discussion: target, messageId, body }) => {
+      await updateGiteaComment({
+        repositoryFullName: target.repositoryFullName,
+        commentId: Number(messageId),
+        body,
+      });
     },
     resolveTarget: async () => {
       if (discussion.kind === 'issues') {
@@ -622,8 +676,9 @@ async function buildAdoFastDelivery(
           organization: parsed.organization,
         });
         return {
-          messageId:
-            comment.commentId ?? `ado-work-item-comment:${randomUUID()}`,
+          messageId: comment.commentId
+            ? `wit:${comment.commentId}`
+            : `ado-work-item-comment:${randomUUID()}`,
           ...(comment.commentId
             ? {
                 update: async (nextBody: string) => {
@@ -657,7 +712,9 @@ async function buildAdoFastDelivery(
         organization: parsed.organization,
       });
       return {
-        messageId: comment.commentId ?? `ado-thread:${comment.threadId}`,
+        messageId: comment.commentId
+          ? `thread:${comment.threadId}:${comment.commentId}`
+          : `ado-thread:${comment.threadId}`,
         ...(comment.commentId
           ? {
               update: async (nextBody: string) => {
@@ -674,6 +731,40 @@ async function buildAdoFastDelivery(
             }
           : {}),
       };
+    },
+    updateCommentById: async ({ discussion: target, messageId, body }) => {
+      const witMatch = /^wit:(.+)$/.exec(messageId);
+      if (witMatch) {
+        await updateAdoWorkItemComment({
+          project: parsed.project,
+          workItemId: target.number,
+          commentId: witMatch[1]!,
+          body,
+          organization: parsed.organization,
+        });
+        return;
+      }
+      const threadMatch = /^thread:([^:]+):(.+)$/.exec(messageId);
+      if (!threadMatch) {
+        throw new Error(
+          `Not an editable Azure DevOps comment id: ${messageId}`,
+        );
+      }
+      const adoRepositoryId = await resolveAdoRepositoryId();
+      if (!adoRepositoryId) {
+        throw new Error(
+          `Azure DevOps repository ${target.repositoryFullName} could not be resolved.`,
+        );
+      }
+      await updateAdoPullRequestComment({
+        repositoryFullName: target.repositoryFullName,
+        repositoryId: adoRepositoryId,
+        pullRequestNumber: target.number,
+        threadId: threadMatch[1]!,
+        commentId: threadMatch[2]!,
+        body,
+        organization: parsed.organization,
+      });
     },
     resolveTarget: async () => {
       if (discussion.kind === 'issues') {
@@ -728,6 +819,10 @@ export function buildSourceControlFastAdapter(params: {
 }): {
   launchTask: LaunchFastAgentTask;
   postReply: (reply: { message: string }) => Promise<{ messageId: string }>;
+  replaceReply?: (
+    handle: { messageId: string },
+    reply: { message: string },
+  ) => Promise<{ messageId: string }>;
 } {
   const discussion = parseSourceControlFastConversation(params.conversation);
   let turnComment: SourceControlPostedComment | null = null;
@@ -766,5 +861,35 @@ export function buildSourceControlFastAdapter(params: {
       params.onReplyPosted?.();
       return { messageId: posted.messageId };
     },
+    ...(params.delivery.updateCommentById && discussion
+      ? {
+          // A resumed turn only carries the prior comment's id: rebuild the
+          // editor from it, replace the comment's body, and adopt it as the
+          // turn's comment so later replies keep appending in place.
+          replaceReply: async ({ messageId }, { message }) => {
+            const footer = buildFastSessionReplyFooterText({
+              provider: discussion.provider,
+              sessionId: params.sessionId,
+            });
+            await params.delivery.updateCommentById!({
+              discussion,
+              messageId,
+              body: `${message}\n\n${footer}`,
+            });
+            turnBody = message;
+            turnComment = {
+              messageId,
+              update: (nextBody: string) =>
+                params.delivery.updateCommentById!({
+                  discussion,
+                  messageId,
+                  body: nextBody,
+                }),
+            };
+            params.onReplyPosted?.();
+            return { messageId };
+          },
+        }
+      : {}),
   };
 }

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -201,10 +201,20 @@ export function createFastAgentSourceControlTaskLauncher(params: {
   };
 }
 
+export type SourceControlPostedComment = {
+  messageId: string;
+  /**
+   * Replaces the comment's whole body in place. A turn's later replies edit
+   * the comment it opened with instead of stacking new comments on the
+   * discussion.
+   */
+  update?: (body: string) => Promise<void>;
+};
+
 export type SourceControlFastReplyPoster = (input: {
   discussion: SourceControlFastDiscussion;
   body: string;
-}) => Promise<{ messageId: string }>;
+}) => Promise<SourceControlPostedComment>;
 
 /**
  * Delivery for one discussion: how replies post and how delegated tasks
@@ -258,7 +268,18 @@ async function buildGitHubFastDelivery(
             body,
           },
         );
-        return { messageId: String(response.data.id) };
+        const commentId = response.data.id;
+        return {
+          messageId: String(commentId),
+          update: async (nextBody) => {
+            await octokit.rest.pulls.updateReviewComment({
+              owner,
+              repo,
+              comment_id: commentId,
+              body: nextBody,
+            });
+          },
+        };
       }
       const response = await octokit.rest.issues.createComment({
         owner,
@@ -266,7 +287,18 @@ async function buildGitHubFastDelivery(
         issue_number: target.number,
         body,
       });
-      return { messageId: String(response.data.id) };
+      const commentId = response.data.id;
+      return {
+        messageId: String(commentId),
+        update: async (nextBody) => {
+          await octokit.rest.issues.updateComment({
+            owner,
+            repo,
+            comment_id: commentId,
+            body: nextBody,
+          });
+        },
+      };
     },
     resolveTarget: async () => {
       if (discussion.kind === 'issues') {
@@ -367,9 +399,14 @@ async function buildGitLabFastDelivery(
     createGitLabIssueNote,
     createGitLabMergeRequestNote,
     getGitLabMergeRequest,
+    updateGitLabNote,
   } = await import('@roomote/gitlab');
   return {
     postComment: async ({ discussion: target, body }) => {
+      const noteableType =
+        target.kind === 'pull'
+          ? ('merge_requests' as const)
+          : ('issues' as const);
       const note =
         target.kind === 'pull'
           ? await createGitLabMergeRequestNote({
@@ -382,7 +419,18 @@ async function buildGitLabFastDelivery(
               issueIid: target.number,
               body,
             });
-      return { messageId: String(note.id) };
+      return {
+        messageId: String(note.id),
+        update: async (nextBody) => {
+          await updateGitLabNote({
+            projectId: target.repositoryFullName,
+            noteableType,
+            noteableIid: target.number,
+            noteId: note.id,
+            body: nextBody,
+          });
+        },
+      };
     },
     resolveTarget: async () => {
       if (discussion.kind === 'issues') {
@@ -420,8 +468,11 @@ async function buildBitbucketFastDelivery(
   if (!repository || discussion.kind !== 'pull') {
     return null;
   }
-  const { createBitbucketPullRequestComment, getBitbucketPullRequest } =
-    await import('@roomote/bitbucket');
+  const {
+    createBitbucketPullRequestComment,
+    getBitbucketPullRequest,
+    updateBitbucketPullRequestComment,
+  } = await import('@roomote/bitbucket');
   return {
     postComment: async ({ discussion: target, body }) => {
       const comment = await createBitbucketPullRequestComment({
@@ -429,7 +480,17 @@ async function buildBitbucketFastDelivery(
         pullRequestNumber: target.number,
         body,
       });
-      return { messageId: String(comment.id) };
+      return {
+        messageId: String(comment.id),
+        update: async (nextBody) => {
+          await updateBitbucketPullRequestComment({
+            repositoryFullName: target.repositoryFullName,
+            pullRequestNumber: target.number,
+            commentId: comment.id,
+            body: nextBody,
+          });
+        },
+      };
     },
     resolveTarget: async () => {
       const pullRequest = await getBitbucketPullRequest({
@@ -462,6 +523,7 @@ async function buildGiteaFastDelivery(
     createGiteaIssueComment,
     createGiteaPullRequestComment,
     getGiteaPullRequest,
+    updateGiteaComment,
   } = await import('@roomote/gitea');
   return {
     postComment: async ({ discussion: target, body }) => {
@@ -477,7 +539,16 @@ async function buildGiteaFastDelivery(
               issueNumber: target.number,
               body,
             });
-      return { messageId: String(comment.id) };
+      return {
+        messageId: String(comment.id),
+        update: async (nextBody) => {
+          await updateGiteaComment({
+            repositoryFullName: target.repositoryFullName,
+            commentId: comment.id,
+            body: nextBody,
+          });
+        },
+      };
     },
     resolveTarget: async () => {
       if (discussion.kind === 'issues') {
@@ -519,6 +590,8 @@ async function buildAdoFastDelivery(
     getAdoPullRequest,
     listAdoRepositories,
     parseAdoRepositoryFullName,
+    updateAdoPullRequestComment,
+    updateAdoWorkItemComment,
   } = await import('@roomote/ado');
   const parsed = parseAdoRepositoryFullName(discussion.repositoryFullName);
   // Azure DevOps addresses pull requests by repository GUID, which the
@@ -551,6 +624,19 @@ async function buildAdoFastDelivery(
         return {
           messageId:
             comment.commentId ?? `ado-work-item-comment:${randomUUID()}`,
+          ...(comment.commentId
+            ? {
+                update: async (nextBody: string) => {
+                  await updateAdoWorkItemComment({
+                    project: parsed.project,
+                    workItemId: target.number,
+                    commentId: comment.commentId!,
+                    body: nextBody,
+                    organization: parsed.organization,
+                  });
+                },
+              }
+            : {}),
         };
       }
       const adoRepositoryId = await resolveAdoRepositoryId();
@@ -572,6 +658,21 @@ async function buildAdoFastDelivery(
       });
       return {
         messageId: comment.commentId ?? `ado-thread:${comment.threadId}`,
+        ...(comment.commentId
+          ? {
+              update: async (nextBody: string) => {
+                await updateAdoPullRequestComment({
+                  repositoryFullName: target.repositoryFullName,
+                  repositoryId: adoRepositoryId,
+                  pullRequestNumber: target.number,
+                  threadId: comment.threadId,
+                  commentId: comment.commentId!,
+                  body: nextBody,
+                  organization: parsed.organization,
+                });
+              },
+            }
+          : {}),
       };
     },
     resolveTarget: async () => {
@@ -629,6 +730,8 @@ export function buildSourceControlFastAdapter(params: {
   postReply: (reply: { message: string }) => Promise<{ messageId: string }>;
 } {
   const discussion = parseSourceControlFastConversation(params.conversation);
+  let turnComment: SourceControlPostedComment | null = null;
+  let turnBody = '';
   return {
     launchTask: createFastAgentSourceControlTaskLauncher({
       userId: params.userId,
@@ -645,12 +748,23 @@ export function buildSourceControlFastAdapter(params: {
         provider: discussion.provider,
         sessionId: params.sessionId,
       });
+      // One comment per turn: the first reply opens it, later replies append
+      // by editing it in place, so a turn never stacks comments on the
+      // discussion.
+      if (turnComment?.update) {
+        turnBody = `${turnBody}\n\n${message}`;
+        await turnComment.update(`${turnBody}\n\n${footer}`);
+        params.onReplyPosted?.();
+        return { messageId: turnComment.messageId };
+      }
+      turnBody = message;
       const posted = await params.delivery.postComment({
         discussion,
         body: `${message}\n\n${footer}`,
       });
+      turnComment = posted;
       params.onReplyPosted?.();
-      return posted;
+      return { messageId: posted.messageId };
     },
   };
 }


### PR DESCRIPTION
## What changed

- **One comment per turn.** The source-control Fast adapter keeps the comment its turn opened and appends later replies into it by editing in place, with the footer once at the bottom. Delegated-child outcome turns and new mention turns still get their own comment; the stacking within a turn is gone.
- **Per-provider editors.** `postComment` now returns an `update` handle: GitHub (`issues.updateComment` / `pulls.updateReviewComment`), GitLab (`updateGitLabNote`), Bitbucket (`updateBitbucketPullRequestComment`), Gitea (`updateGiteaComment`), Azure DevOps (`updateAdoPullRequestComment`, `updateAdoWorkItemComment`, both new). A provider without an editor for a shape (legacy ADO responses without a comment id) falls back to posting.
- **Footer copy.** On source-control surfaces the footer reads "Reply with @-mention or use the web app," since plain comments do not route to the Session there.

## Why

Dogfood on a real PR: one turn produced two stacked comments ("I'm bringing the PR up to date…" then "I'll report back…"), each with a footer, and "Reply" was misleading because only mentions route on GitHub.

## Validation

Delivery test covers the in-place edit (single create, appended body, one footer); provider update functions are exercised through the delivery mocks; sdk, communication, api, and provider package suites pass; lint, types, knip clean.