### PR TITLE
[Fix] Fast turns interrupted after starting a task no longer ask the user to resend

### DIFF
--- a/.changeset/fast-delegated-interruption.md
+++ b/.changeset/fast-delegated-interruption.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fixed Fast Sessions asking the user to resend a request after a restart interrupted a turn that had already started a task. Resending would have started a second task. The closeout now says the started task is still running and will report back in the thread, and the next message no longer treats that request as unfinished.

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
@@ -1212,6 +1212,17 @@ describe('Fast conversation repository', () => {
       findFastAgentUnresolvedRequest(session.id),
     ).resolves.toBeNull();
 
+    // A turn interrupted after it had already started a task is not owed
+    // either: the task keeps running and its result settles the request.
+    await prompt('turn-3b', 350, 'Investigate the queue bypass');
+    await closeout('turn-3b', 360, {
+      interruptionReason: 'api_shutdown',
+      delegatedTaskIds: ['task-1'],
+    });
+    await expect(
+      findFastAgentUnresolvedRequest(session.id),
+    ).resolves.toBeNull();
+
     // An interrupted platform-event turn is not a request the user is owed.
     await prompt('turn-4', 400, '<platform_event>{}</platform_event>', {
       visibleInTranscript: false,

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -103,6 +103,8 @@ vi.mock('../fast-agent-conversation-repository', () => ({
     'The inference retry was interrupted before it completed. Please send the request again.',
   RESTARTED_ACTIVE_TURN_MESSAGE:
     'Roomote restarted while working on this request. Please send it again.',
+  DELEGATED_TURN_RESTART_MESSAGE:
+    'Roomote restarted while working on this request, but the task it started is still running and will report back here.',
   reconcileFastAgentInferenceRetryNotices: mocks.reconcileRetryNotices,
   markFastAgentInferenceRetryNoticeInterruption:
     mocks.markRetryNoticeInterruption,
@@ -3869,7 +3871,7 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       );
     });
 
-    it('posts the restart closeout when the interrupted turn already acted', async () => {
+    it('tells the user the started task continues instead of asking for a resend', async () => {
       const controller = new AbortController();
       const shutdown = new FastAgentProcessShutdownError('SIGTERM');
       const requestDurableResume = vi.fn().mockResolvedValue(undefined);
@@ -3890,7 +3892,68 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       await expect(
         answerFastAgentQuestion({
           ...baseParams,
-          adapter: callbacks({ postReply, requestDurableResume }),
+          adapter: callbacks({
+            postReply,
+            requestDurableResume,
+            launchTask: vi.fn<LaunchFastAgentTask>(async () => ({
+              success: true,
+              taskId: 'task-1',
+            })),
+          }),
+          signal: controller.signal,
+          durableAdmission,
+        }),
+      ).rejects.toBe(shutdown);
+
+      // The turn already started a task, so "send it again" would start a
+      // second one. The closeout says the task continues, and its marker names
+      // the task so the next message does not treat the request as owed.
+      expect(postReply).toHaveBeenCalledWith({
+        purpose: 'closeout',
+        message:
+          'Roomote restarted while working on this request, but the task it started is still running and will report back here.',
+      });
+      const closeoutWrite = mocks.upsertMessage.mock.calls
+        .map(([input]) => input.message)
+        .find((message) => message.metadata?.purpose === 'closeout');
+      expect(closeoutWrite?.metadata).toMatchObject({
+        interruptionReason: 'api_shutdown',
+        delegatedTaskIds: ['task-1'],
+      });
+      expect(mocks.releaseDurableClaim).not.toHaveBeenCalled();
+      expect(requestDurableResume).not.toHaveBeenCalled();
+    });
+
+    it('still asks for a resend when the interrupted turn acted but no task exists', async () => {
+      const controller = new AbortController();
+      const shutdown = new FastAgentProcessShutdownError('SIGTERM');
+      const postReply = vi.fn().mockResolvedValue({ messageId: 'reply-1' });
+      mocks.generateText.mockImplementationOnce(
+        async (_params, _session, options) => {
+          await options.onSessionReady('opencode-session-1');
+          // Replay is withdrawn before the launch is attempted, so the turn
+          // has acted, but the launch failed and nothing is running for the
+          // user: a resend is the right instruction here.
+          await invokeTool(nativeToolNames.launchTask, {
+            prompt: 'Fix the bug',
+            environmentId: 'env-1',
+            kickoffMessage: 'Starting.',
+          });
+          controller.abort(shutdown);
+          throw shutdown;
+        },
+      );
+
+      await expect(
+        answerFastAgentQuestion({
+          ...baseParams,
+          adapter: callbacks({
+            postReply,
+            launchTask: vi.fn<LaunchFastAgentTask>(async () => ({
+              success: false,
+              error: 'Launch failed.',
+            })),
+          }),
           signal: controller.signal,
           durableAdmission,
         }),
@@ -3901,8 +3964,10 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
         message:
           'Roomote restarted while working on this request. Please send it again.',
       });
-      expect(mocks.releaseDurableClaim).not.toHaveBeenCalled();
-      expect(requestDurableResume).not.toHaveBeenCalled();
+      const closeoutWrite = mocks.upsertMessage.mock.calls
+        .map(([input]) => input.message)
+        .find((message) => message.metadata?.purpose === 'closeout');
+      expect(closeoutWrite?.metadata).not.toHaveProperty('delegatedTaskIds');
     });
 
     it('does not resume a deliberately cancelled turn', async () => {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
@@ -69,6 +69,14 @@ export const RESTARTED_ACTIVE_TURN_MESSAGE =
   'Roomote restarted while working on this request. Please send it again.';
 
 /**
+ * Closeout for a turn interrupted after it had already handed its work to a
+ * task. Telling the user to resend would launch a second task; the one that
+ * exists keeps running and its result reaches the thread through the queue.
+ */
+export const DELEGATED_TURN_RESTART_MESSAGE =
+  'Roomote restarted while working on this request, but the task it started is still running and will report back here.';
+
+/**
  * Why an accepted Fast turn ended without a real answer. Stamped into the
  * terminal message's metadata by every writer so occurrence counts can be
  * attributed per cause instead of investigated per incident.
@@ -289,6 +297,9 @@ export async function findFastAgentUnresolvedRequest(
         eq(fastAgentMessages.turnId, latestPrompt.turnId),
         eq(fastAgentMessages.role, 'assistant'),
         sql`${fastAgentMessages.metadata}->>'interruptionReason' IS NOT NULL`,
+        // A turn that already delegated its work to a task is not owed a
+        // redo: the task's own result settles it.
+        sql`${fastAgentMessages.metadata}->>'delegatedTaskIds' IS NULL`,
       ),
     )
     .limit(1);

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -121,6 +121,7 @@ import {
   scheduleFastAgentDurableTurnRetry,
   reconcileFastAgentInferenceRetryNotices,
   renewFastSessionRespondingLease,
+  DELEGATED_TURN_RESTART_MESSAGE,
   RESTARTED_ACTIVE_TURN_MESSAGE,
   type FastAgentInterruptionReason,
   type FastAgentUnresolvedRequest,
@@ -1375,6 +1376,10 @@ export async function answerFastAgentQuestion({
     instructionVersion = currentInstructionVersion,
   ) => closedInstructionVersions.has(instructionVersion);
   let inferenceRetryReply: FastAgentReplyHandle | undefined;
+  // Tasks this turn itself started, as opposed to ones already active in the
+  // session. An interruption after a launch is not a lost request: the task
+  // keeps running and reports back through the queue.
+  const tasksLaunchedThisTurn = new Set<string>();
   let inferenceRetryMessageIndex: number | undefined;
   let inferenceRetryCanonicalEvent:
     | { eventId: string; turnSeq: number }
@@ -1950,6 +1955,7 @@ export async function answerFastAgentQuestion({
     inferenceRetryNotice = false,
     visibleInTranscript = true,
     interruptionReason,
+    delegatedTaskIds,
     ts,
   }: {
     reply: FastAgentReply;
@@ -1959,6 +1965,8 @@ export async function answerFastAgentQuestion({
     inferenceRetryNotice?: boolean;
     visibleInTranscript?: boolean;
     interruptionReason?: FastAgentInterruptionReason;
+    /** Tasks the turn started before it was interrupted; see the closeout. */
+    delegatedTaskIds?: string[];
     /** Explicit event time; retry notices pin it to the episode start. */
     ts?: number;
   }) =>
@@ -1983,6 +1991,7 @@ export async function answerFastAgentQuestion({
               }
             : {}),
           ...(interruptionReason ? { interruptionReason } : {}),
+          ...(delegatedTaskIds?.length ? { delegatedTaskIds } : {}),
           ...(platformMessageId ? { platformMessageId } : {}),
         },
         payload: {
@@ -2177,6 +2186,7 @@ export async function answerFastAgentQuestion({
     bestEffort = false,
     onDelivered?: () => void,
     interruptionReason?: FastAgentInterruptionReason,
+    delegatedTaskIds?: string[],
   ): Promise<boolean> => {
     if (!inferenceRetryCanonicalEvent) {
       return false;
@@ -2203,6 +2213,7 @@ export async function answerFastAgentQuestion({
         inferenceRetryNotice: true,
         visibleInTranscript: false,
         interruptionReason,
+        delegatedTaskIds,
         ts: noticeTs,
       });
       return false;
@@ -2238,6 +2249,7 @@ export async function answerFastAgentQuestion({
         inferenceRetryNotice: true,
         visibleInTranscript: false,
         interruptionReason,
+        delegatedTaskIds,
         ts: noticeTs,
       });
       return false;
@@ -2254,6 +2266,7 @@ export async function answerFastAgentQuestion({
         platformMessageId: inferenceRetryReply.messageId,
         inferenceRetryNotice: true,
         interruptionReason,
+        delegatedTaskIds,
         ts: noticeTs,
       });
     }
@@ -3381,6 +3394,7 @@ export async function answerFastAgentQuestion({
             }
             if (result.success) {
               currentTasks.set(result.taskId, { taskId: result.taskId });
+              tasksLaunchedThisTurn.add(result.taskId);
               if (result.kickoffDelivered) {
                 visibleUpdatePosted = true;
                 substantiveWorkAcknowledged = true;
@@ -4303,27 +4317,37 @@ export async function answerFastAgentQuestion({
             : await revokeDurableTurnReplay(
                 `Turn interrupted without replay (${interruptionReason}).`,
               );
+        // A turn that already started a task must not ask the user to
+        // resend: that would start a second one. The task keeps running and
+        // reports back through the queue, and the closeout records which
+        // task(s) so the next message does not treat this as owed.
+        const delegatedTaskIds = [...tasksLaunchedThisTurn];
+        const delegated = delegatedTaskIds.length > 0;
+        const closeoutMessage = delegated
+          ? DELEGATED_TURN_RESTART_MESSAGE
+          : shutdownInterrupted
+            ? // A shutdown is a restart the user can see through honestly;
+              // other aborts keep the generic retry-interruption wording.
+              RESTARTED_ACTIVE_TURN_MESSAGE
+            : INTERRUPTED_INFERENCE_RETRY_MESSAGE;
         if (!terminalCloseoutAllowed) {
           // Resumable turns and unrevoked rows fall through to the rethrow
           // below without a user-facing closeout.
         } else if (!lockOwnershipLost && inferenceRetryReply) {
           await replaceInferenceRetryReply(
-            {
-              purpose: 'closeout',
-              // A shutdown is a restart the user can see through honestly;
-              // other aborts keep the generic retry-interruption wording.
-              message: shutdownInterrupted
-                ? RESTARTED_ACTIVE_TURN_MESSAGE
-                : INTERRUPTED_INFERENCE_RETRY_MESSAGE,
-            },
+            { purpose: 'closeout', message: closeoutMessage },
             true,
             undefined,
             interruptionReason,
+            delegated ? delegatedTaskIds : undefined,
           );
-        } else if (shutdownInterrupted && !isInstructionClosed()) {
+        } else if (
+          (shutdownInterrupted || delegated) &&
+          !isInstructionClosed()
+        ) {
           const reply = {
             purpose: 'closeout' as const,
-            message: RESTARTED_ACTIVE_TURN_MESSAGE,
+            message: closeoutMessage,
           };
           try {
             const posted =
@@ -4339,6 +4363,7 @@ export async function answerFastAgentQuestion({
               platformMessageId: posted?.messageId,
               inferenceRetryNotice: Boolean(retryEvent),
               interruptionReason,
+              delegatedTaskIds: delegated ? delegatedTaskIds : undefined,
             });
           } catch (postError) {
             console.error(


### PR DESCRIPTION
## What changed

- A Fast turn interrupted after it had already started a task no longer closes out with "Please send it again." It says the task it started is still running and will report back in the thread.
- The closeout's marker records which task(s) the turn started (`delegatedTaskIds`), and the unresolved-request carry-over skips such turns, so the next message is treated as a new request rather than a redo of the delegated one.
- Applies to every interruption closeout variant (restart, retry-notice replacement) and is decided by launches made in the interrupted turn itself, not by tasks that were already active in the session.

## Why

Observed on staging: a turn started a task, a deploy killed the turn twenty seconds later, and the closeout told the user to send the request again. Following that instruction would have started a second task. The one that existed kept running and its result was always going to arrive in the thread through the parent-event queue; the parent turn's only remaining job was to say so.

The next message did resume the request through the carry-over and, fortunately, the model found the running task instead of relaunching. This change removes the dependency on that judgment: the closeout is accurate on its own and the carry-over no longer offers the request back.

## What it does not change

- Turns that acted without starting a task (a failed launch, a memory write, a task message) still get the honest "send it again" closeout, since nothing is running on the user's behalf.
- Turns that had not acted are still handed back to the queue and resumed silently, as before.
- No schema change. The marker is a metadata field on the existing closeout row.

## Verification

- `fast-agent-service` tests: a shutdown after a successful launch posts the delegated wording and records the task id on the closeout; a shutdown after a failed launch keeps the resend wording and records no task.
- `fast-agent-conversation-repository` real-DB test: a delegated closeout is not surfaced as an unresolved request.
- Full fast-agent suite, type check, lint, and knip pass.
