### PR TITLE
feat: quote the answered comment like GitHub's quote reply

### DIFF
--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -71,6 +71,7 @@ import {
 import {
   buildSourceControlFastAdapter,
   buildSourceControlFastDelivery,
+  buildSourceControlReplyQuote,
 } from './source-control-fast-delivery';
 import { buildCustomAutomationSlackMessage } from './manager-slack';
 import {
@@ -1619,6 +1620,12 @@ async function createSourceControlFastAgentParentTurn(params: {
       delivery,
       userId: actorUserId,
       sessionId: session.id,
+      // Mentions reach this turn through the durable queue, so the quote of
+      // the answered comment has to come from the queued event itself.
+      quote:
+        params.event.type === 'human_follow_up'
+          ? buildSourceControlReplyQuote({ text: params.event.question })
+          : null,
       onReplyPosted: params.onReplyPosted,
     }),
   };

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
@@ -61,6 +61,7 @@ import {
 import {
   buildSourceControlFastAdapter,
   buildSourceControlFastDelivery,
+  buildSourceControlReplyQuote,
 } from './source-control-fast-delivery';
 
 const SLACK_QUOTE_MAX_LENGTH = 100;
@@ -527,6 +528,12 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
         delivery,
         userId: params.userId,
         sessionId: session.id,
+        quote: params.externalInput
+          ? null
+          : buildSourceControlReplyQuote({
+              senderDisplayName: params.senderDisplayName,
+              text: params.question,
+            }),
       }),
     };
   }

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
@@ -530,10 +530,7 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
         sessionId: session.id,
         quote: params.externalInput
           ? null
-          : buildSourceControlReplyQuote({
-              senderDisplayName: params.senderDisplayName,
-              text: params.question,
-            }),
+          : buildSourceControlReplyQuote({ text: params.question }),
       }),
     };
   }

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -393,6 +393,7 @@ describe('GitHub Fast delivery', () => {
       delivery: delivery!,
       userId: 'user-1',
       sessionId: 'fast-1',
+      quote: '> **alice:** @roomote please rebase this',
     });
 
     await adapter.postReply({ message: 'On it.' });
@@ -406,6 +407,15 @@ describe('GitHub Fast delivery', () => {
         comment_id: 6001,
         body: expect.stringContaining('On it.\n\nRebased; running checks.'),
       }),
+    );
+    // The turn opened with the quote and appends keep it at the top.
+    const firstBody = createComment.mock.calls[0]?.[0].body as string;
+    const editedBody = updateComment.mock.calls[0]?.[0].body as string;
+    expect(firstBody.startsWith('> **alice:** @roomote please rebase')).toBe(
+      true,
+    );
+    expect(editedBody.startsWith('> **alice:** @roomote please rebase')).toBe(
+      true,
     );
     // Footer appears once, at the bottom of the edited body.
     const body = updateComment.mock.calls[0]?.[0].body as string;

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -80,6 +80,7 @@ import {
   buildSourceControlFastAdapter,
   buildSourceControlFastConversation,
   buildSourceControlFastDelivery,
+  buildSourceControlReplyQuote,
   createFastAgentSourceControlTaskLauncher,
   parseSourceControlFastConversation,
 } from './source-control-fast-delivery';
@@ -393,7 +394,7 @@ describe('GitHub Fast delivery', () => {
       delivery: delivery!,
       userId: 'user-1',
       sessionId: 'fast-1',
-      quote: '> **alice:** @roomote please rebase this',
+      quote: '> @roomote please rebase this',
     });
 
     await adapter.postReply({ message: 'On it.' });
@@ -411,12 +412,8 @@ describe('GitHub Fast delivery', () => {
     // The turn opened with the quote and appends keep it at the top.
     const firstBody = createComment.mock.calls[0]?.[0].body as string;
     const editedBody = updateComment.mock.calls[0]?.[0].body as string;
-    expect(firstBody.startsWith('> **alice:** @roomote please rebase')).toBe(
-      true,
-    );
-    expect(editedBody.startsWith('> **alice:** @roomote please rebase')).toBe(
-      true,
-    );
+    expect(firstBody.startsWith('> @roomote please rebase this')).toBe(true);
+    expect(editedBody.startsWith('> @roomote please rebase this')).toBe(true);
     // Footer appears once, at the bottom of the edited body.
     const body = updateComment.mock.calls[0]?.[0].body as string;
     expect(body.match(/footer:github/g)).toHaveLength(1);
@@ -665,5 +662,16 @@ describe('other provider Fast deliveries', () => {
         }),
       ),
     ).resolves.toBeNull();
+  });
+});
+
+describe('buildSourceControlReplyQuote', () => {
+  it('quotes every line the way GitHub quote-reply does, with no username', () => {
+    expect(
+      buildSourceControlReplyQuote({
+        text: '@roomote please rebase\n\nand rerun the checks',
+      }),
+    ).toBe('> @roomote please rebase\n>\n> and rerun the checks');
+    expect(buildSourceControlReplyQuote({ text: '   ' })).toBeNull();
   });
 });

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -672,6 +672,10 @@ describe('buildSourceControlReplyQuote', () => {
         text: '@roomote please rebase\n\nand rerun the checks',
       }),
     ).toBe('> @roomote please rebase\n>\n> and rerun the checks');
+    // Indentation and outer blank lines are preserved verbatim.
+    expect(
+      buildSourceControlReplyQuote({ text: '    indented code\nplain\n' }),
+    ).toBe('>     indented code\n> plain\n>');
     expect(buildSourceControlReplyQuote({ text: '   ' })).toBeNull();
   });
 });

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -209,13 +209,15 @@ export function createFastAgentSourceControlTaskLauncher(params: {
 export function buildSourceControlReplyQuote(params: {
   text: string;
 }): string | null {
-  const trimmed = params.text.trim();
-  if (!trimmed) {
+  if (!params.text.trim()) {
     return null;
   }
-  return trimmed
+  // Quote the text verbatim: indentation and blank lines are meaningful
+  // Markdown (code blocks, paragraph breaks) and GitHub preserves them.
+  return params.text
+    .replace(/\r\n/g, '\n')
     .split('\n')
-    .map((line) => (line.trim() ? `> ${line}` : '>'))
+    .map((line) => (line.length > 0 ? `> ${line}` : '>'))
     .join('\n');
 }
 

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -201,27 +201,22 @@ export function createFastAgentSourceControlTaskLauncher(params: {
   };
 }
 
-const SOURCE_CONTROL_QUOTE_MAX_LENGTH = 200;
-
 /**
- * A markdown blockquote of the comment a turn answers, prepended to the
- * turn's comment the way Slack replies quote their message. Kept to one
- * normalized line so the quote stays a header, not a second comment.
+ * The comment a turn answers, quoted exactly the way GitHub's own
+ * "Quote reply" does: every line of the original prefixed with "> ",
+ * nothing added.
  */
 export function buildSourceControlReplyQuote(params: {
-  senderDisplayName: string | null;
   text: string;
 }): string | null {
-  const username = params.senderDisplayName?.replace(/\s+/g, ' ').trim();
-  const normalized = params.text.replace(/\s+/g, ' ').trim();
-  if (!normalized) {
+  const trimmed = params.text.trim();
+  if (!trimmed) {
     return null;
   }
-  const text =
-    normalized.length > SOURCE_CONTROL_QUOTE_MAX_LENGTH
-      ? `${normalized.slice(0, SOURCE_CONTROL_QUOTE_MAX_LENGTH)}…`
-      : normalized;
-  return `> ${username ? `**${username}:** ` : ''}${text}`;
+  return trimmed
+    .split('\n')
+    .map((line) => (line.trim() ? `> ${line}` : '>'))
+    .join('\n');
 }
 
 export type SourceControlPostedComment = {

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -201,6 +201,29 @@ export function createFastAgentSourceControlTaskLauncher(params: {
   };
 }
 
+const SOURCE_CONTROL_QUOTE_MAX_LENGTH = 200;
+
+/**
+ * A markdown blockquote of the comment a turn answers, prepended to the
+ * turn's comment the way Slack replies quote their message. Kept to one
+ * normalized line so the quote stays a header, not a second comment.
+ */
+export function buildSourceControlReplyQuote(params: {
+  senderDisplayName: string | null;
+  text: string;
+}): string | null {
+  const username = params.senderDisplayName?.replace(/\s+/g, ' ').trim();
+  const normalized = params.text.replace(/\s+/g, ' ').trim();
+  if (!normalized) {
+    return null;
+  }
+  const text =
+    normalized.length > SOURCE_CONTROL_QUOTE_MAX_LENGTH
+      ? `${normalized.slice(0, SOURCE_CONTROL_QUOTE_MAX_LENGTH)}…`
+      : normalized;
+  return `> ${username ? `**${username}:** ` : ''}${text}`;
+}
+
 export type SourceControlPostedComment = {
   messageId: string;
   /**
@@ -815,6 +838,8 @@ export function buildSourceControlFastAdapter(params: {
   delivery: SourceControlFastDelivery;
   userId: string;
   sessionId: string;
+  /** Blockquote of the message this turn answers; opens the turn's comment. */
+  quote?: string | null;
   onReplyPosted?: () => void;
 }): {
   launchTask: LaunchFastAgentTask;
@@ -852,10 +877,10 @@ export function buildSourceControlFastAdapter(params: {
         params.onReplyPosted?.();
         return { messageId: turnComment.messageId };
       }
-      turnBody = message;
+      turnBody = params.quote ? `${params.quote}\n\n${message}` : message;
       const posted = await params.delivery.postComment({
         discussion,
-        body: `${message}\n\n${footer}`,
+        body: `${turnBody}\n\n${footer}`,
       });
       turnComment = posted;
       params.onReplyPosted?.();


### PR DESCRIPTION
## What changed

Source-control Fast turns open their comment with a quote of the message they answer, formatted exactly like GitHub's native "Quote reply": every line of the original prefixed with `> `, multiline preserved, no username, no truncation. The quote stays at the top as the turn edits its comment in place. Reaction-driven turns and resumed turns (no triggering message) skip it. Applies to all five providers via the shared adapter.

Follow-up to #2136, which merged before these two commits landed on its branch.

## Validation

Quote-builder test pins the GitHub quote shape (multiline, blank-line handling, null for empty); the in-place edit test asserts the quote opens the comment and survives appends. sdk suites, lint, types, knip pass.