### PR TITLE
feat: include the session live preview link in source-control comment footers

### DIFF
--- a/packages/communication/src/__tests__/fast-session-footer-context.test.ts
+++ b/packages/communication/src/__tests__/fast-session-footer-context.test.ts
@@ -16,17 +16,21 @@ vi.mock('@roomote/db/server', () => ({
   db: {
     select: vi.fn(() => ({
       from: vi.fn(() => ({
-        innerJoin: vi.fn(() => ({ where: selectWhereMock })),
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({ orderBy: selectWhereMock })),
+        })),
       })),
     })),
   },
   and: vi.fn((...args: unknown[]) => ({ and: args })),
+  asc: vi.fn((value: unknown) => ({ asc: value })),
   eq: vi.fn((...args: unknown[]) => ({ eq: args })),
   getSessionForFastConversation: getSessionForFastConversationMock,
   isNull: vi.fn((value: unknown) => ({ isNull: value })),
   sessionTasks: {
     sessionId: 'sessionId',
     taskId: 'taskId',
+    attachedAt: 'attachedAt',
   },
   tasks: {
     id: 'id',

--- a/packages/communication/src/__tests__/fast-session-footer-context.test.ts
+++ b/packages/communication/src/__tests__/fast-session-footer-context.test.ts
@@ -4,10 +4,12 @@ const {
   getSessionForFastConversationMock,
   selectWhereMock,
   resolveThreadReplyFooterContextMock,
+  resolveThreadReplyLivePreviewUrlMock,
 } = vi.hoisted(() => ({
   getSessionForFastConversationMock: vi.fn(),
   selectWhereMock: vi.fn(),
   resolveThreadReplyFooterContextMock: vi.fn(),
+  resolveThreadReplyLivePreviewUrlMock: vi.fn(),
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -34,13 +36,17 @@ vi.mock('@roomote/db/server', () => ({
 
 vi.mock('../thread-reply-footer-context', () => ({
   resolveThreadReplyFooterContext: resolveThreadReplyFooterContextMock,
+  resolveThreadReplyLivePreviewUrl: resolveThreadReplyLivePreviewUrlMock,
 }));
 
 vi.mock('@roomote/env', () => ({
   Env: { R_APP_URL: 'https://roomote.example' },
 }));
 
-import { resolveFastSessionReplyFooterContext } from '../fast-session-footer';
+import {
+  resolveFastSessionLivePreviewUrl,
+  resolveFastSessionReplyFooterContext,
+} from '../fast-session-footer';
 
 describe('resolveFastSessionReplyFooterContext', () => {
   beforeEach(() => {
@@ -97,5 +103,44 @@ describe('resolveFastSessionReplyFooterContext', () => {
       'fast-session-1',
     );
     expect(resolveThreadReplyFooterContextMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('resolveFastSessionLivePreviewUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionForFastConversationMock.mockResolvedValue({ id: 'session-1' });
+    selectWhereMock.mockResolvedValue([
+      { taskId: 'task-1' },
+      { taskId: 'task-2' },
+    ]);
+  });
+
+  it('returns the first linked task preview URL', async () => {
+    resolveThreadReplyLivePreviewUrlMock.mockImplementation(
+      async (taskId: string) =>
+        taskId === 'task-2' ? 'https://preview.example/app' : null,
+    );
+
+    await expect(
+      resolveFastSessionLivePreviewUrl('fast-session-1'),
+    ).resolves.toBe('https://preview.example/app');
+  });
+
+  it('returns null when no linked task exposes a preview', async () => {
+    resolveThreadReplyLivePreviewUrlMock.mockResolvedValue(null);
+
+    await expect(
+      resolveFastSessionLivePreviewUrl('fast-session-1'),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when the session is unknown', async () => {
+    getSessionForFastConversationMock.mockResolvedValue(null);
+
+    await expect(
+      resolveFastSessionLivePreviewUrl('fast-session-1'),
+    ).resolves.toBeNull();
+    expect(resolveThreadReplyLivePreviewUrlMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/communication/src/fast-session-footer.ts
+++ b/packages/communication/src/fast-session-footer.ts
@@ -15,7 +15,10 @@ import {
   type ThreadReplyLinkedPr,
 } from './chat-messages';
 import { chunkDiscordMessage } from './discord-provider';
-import { resolveThreadReplyFooterContext } from './thread-reply-footer-context';
+import {
+  resolveThreadReplyFooterContext,
+  resolveThreadReplyLivePreviewUrl,
+} from './thread-reply-footer-context';
 
 export type FastSessionFooterProvider =
   | 'slack'
@@ -64,12 +67,10 @@ function collectFastSessionLinkedPrs(params: {
   return [...uniquePrs.values()];
 }
 
-export async function resolveFastSessionReplyFooterContext(params: {
-  sessionId: string;
-  pullRequest?: FastSessionPullRequestReference | null;
-  pullRequests?: readonly FastSessionPullRequestReference[];
-}): Promise<FastSessionReplyFooterContext> {
-  const session = await getSessionForFastConversation(db, params.sessionId);
+async function getFastSessionLinkedTaskIds(
+  sessionId: string,
+): Promise<string[]> {
+  const session = await getSessionForFastConversation(db, sessionId);
   const linkedTasks = session
     ? await db
         .select({ taskId: sessionTasks.taskId })
@@ -79,8 +80,31 @@ export async function resolveFastSessionReplyFooterContext(params: {
           and(eq(sessionTasks.sessionId, session.id), isNull(tasks.deletedAt)),
         )
     : [];
+  return linkedTasks.map(({ taskId }) => taskId);
+}
+
+/**
+ * The live preview URL of the first session-linked task that exposes one, for
+ * footers that skip the full linked-PR context (source-control comments).
+ */
+export async function resolveFastSessionLivePreviewUrl(
+  sessionId: string,
+): Promise<string | null> {
+  const taskIds = await getFastSessionLinkedTaskIds(sessionId);
+  const urls = await Promise.all(
+    taskIds.map((taskId) => resolveThreadReplyLivePreviewUrl(taskId)),
+  );
+  return urls.find((url) => url) ?? null;
+}
+
+export async function resolveFastSessionReplyFooterContext(params: {
+  sessionId: string;
+  pullRequest?: FastSessionPullRequestReference | null;
+  pullRequests?: readonly FastSessionPullRequestReference[];
+}): Promise<FastSessionReplyFooterContext> {
+  const linkedTaskIds = await getFastSessionLinkedTaskIds(params.sessionId);
   const contexts = await Promise.all(
-    linkedTasks.map(({ taskId }) =>
+    linkedTaskIds.map((taskId) =>
       resolveThreadReplyFooterContext({
         taskId,
         prRepo: null,

--- a/packages/communication/src/fast-session-footer.ts
+++ b/packages/communication/src/fast-session-footer.ts
@@ -1,6 +1,7 @@
 import { Env } from '@roomote/env';
 import {
   and,
+  asc,
   db,
   eq,
   getSessionForFastConversation,
@@ -79,6 +80,9 @@ async function getFastSessionLinkedTaskIds(
         .where(
           and(eq(sessionTasks.sessionId, session.id), isNull(tasks.deletedAt)),
         )
+        // Deterministic ordering so "the first task with a preview" is stable
+        // across footer rebuilds.
+        .orderBy(asc(sessionTasks.attachedAt), asc(sessionTasks.taskId))
     : [];
   return linkedTasks.map(({ taskId }) => taskId);
 }

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -1,5 +1,8 @@
 const mocks = vi.hoisted(() => ({
   createFastAgentTaskLauncher: vi.fn(),
+  resolveFastSessionLivePreviewUrl: vi.fn(
+    async (): Promise<string | null> => null,
+  ),
   repositoriesFindMany: vi.fn(),
   getInstallationOctokit: vi.fn(),
   gitlabCreateIssueNote: vi.fn(),
@@ -33,8 +36,17 @@ vi.mock('@roomote/db/server', () => ({
 }));
 
 vi.mock('@roomote/communication', () => ({
-  buildFastSessionReplyFooterText: ({ provider }: { provider: string }) =>
-    `[footer:${provider}]`,
+  buildFastSessionReplyFooterText: ({
+    provider,
+    livePreviewUrl,
+  }: {
+    provider: string;
+    livePreviewUrl?: string | null;
+  }) =>
+    livePreviewUrl
+      ? `[footer:${provider}:${livePreviewUrl}]`
+      : `[footer:${provider}]`,
+  resolveFastSessionLivePreviewUrl: mocks.resolveFastSessionLivePreviewUrl,
 }));
 
 vi.mock('@roomote/github', () => ({
@@ -364,6 +376,64 @@ describe('GitHub Fast delivery', () => {
         sha: 'abc123',
       },
     });
+  });
+
+  it('includes the session live preview link in the comment footer when one exists', async () => {
+    mocks.resolveFastSessionLivePreviewUrl.mockResolvedValueOnce(
+      'https://preview.example/app',
+    );
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    const adapter = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+    });
+
+    await adapter.postReply({ message: 'On it.' });
+
+    expect(mocks.resolveFastSessionLivePreviewUrl).toHaveBeenCalledWith(
+      'fast-1',
+    );
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: 'On it.\n\n[footer:github:https://preview.example/app]',
+      }),
+    );
+  });
+
+  it('still posts the comment when the live preview lookup fails', async () => {
+    mocks.resolveFastSessionLivePreviewUrl.mockRejectedValueOnce(
+      new Error('db down'),
+    );
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    const adapter = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+    });
+
+    await expect(adapter.postReply({ message: 'On it.' })).resolves.toEqual({
+      messageId: '5001',
+    });
+    expect(createComment).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'On it.\n\n[footer:github]' }),
+    );
   });
 
   it('edits the turn comment in place for later replies instead of posting again', async () => {

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -5,7 +5,10 @@ import {
   type LaunchFastAgentTask,
 } from '@roomote/cloud-agents/server';
 import { and, db, eq, repositories } from '@roomote/db/server';
-import { buildFastSessionReplyFooterText } from '@roomote/communication';
+import {
+  buildFastSessionReplyFooterText,
+  resolveFastSessionLivePreviewUrl,
+} from '@roomote/communication';
 import {
   ALL_REPOSITORIES,
   buildFastAgentChildTaskMetadata,
@@ -842,6 +845,10 @@ export function buildSourceControlFastAdapter(params: {
       const footer = buildFastSessionReplyFooterText({
         provider: discussion.provider,
         sessionId: params.sessionId,
+        // The preview link is a nicety; its lookup never blocks the comment.
+        livePreviewUrl: await resolveFastSessionLivePreviewUrl(
+          params.sessionId,
+        ).catch(() => null),
       });
       // One comment per turn: the first reply opens it, later replies append
       // by editing it in place, so a turn never stacks comments on the
@@ -870,6 +877,9 @@ export function buildSourceControlFastAdapter(params: {
             const footer = buildFastSessionReplyFooterText({
               provider: discussion.provider,
               sessionId: params.sessionId,
+              livePreviewUrl: await resolveFastSessionLivePreviewUrl(
+                params.sessionId,
+              ).catch(() => null),
             });
             await params.delivery.updateCommentById!({
               discussion,


### PR DESCRIPTION
Source-control comment footers from Fast sessions now include the "live preview" link when a session-linked task exposes one, matching the chat-surface footers.

- `resolveFastSessionLivePreviewUrl` in `@roomote/communication` resolves the first session-linked task preview URL (shared linked-task lookup extracted from `resolveFastSessionReplyFooterContext`).
- The source-control Fast adapter resolves it per footer build (so a preview that appears mid-turn is picked up by the in-place comment edits) and treats lookup failures as no-preview instead of failing the comment.
- Linked-PR links stay out of source-control footers as before.