### PR TITLE
feat: attach automatic PR reviews to the Fast session that opened the PR

### DIFF
--- a/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/ado/__tests__/handlePullRequest.test.ts
@@ -22,6 +22,7 @@ const {
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
+  getPrOriginFastAgentParent: vi.fn(async () => null),
 }));
 
 vi.mock('@roomote/sdk/server', () => ({

--- a/apps/api/src/handlers/ado/handlePullRequest.ts
+++ b/apps/api/src/handlers/ado/handlePullRequest.ts
@@ -1,6 +1,7 @@
 import pMap from 'p-map';
 
 import {
+  buildFastAgentSessionAttachment,
   type TaskPayload,
   DEFAULT_PR_REVIEW_SETTINGS,
   type PrReviewSettings,
@@ -19,7 +20,10 @@ import {
   isNull,
   sql,
 } from '@roomote/db/server';
-import { enqueueTask } from '@roomote/cloud-agents/server';
+import {
+  enqueueTask,
+  getPrOriginFastAgentParent,
+} from '@roomote/cloud-agents/server';
 import {
   recordPrStatusChangeInTaskHistory,
   updateTaskPrStatus,
@@ -418,8 +422,21 @@ export async function handleAdoPullRequest(
   const prAuthorName = getAdoIdentityName(pullRequest.createdBy);
   const prAuthorId = pullRequest.createdBy?.id?.trim() || prAuthorName;
 
-  const enqueued = await pMap(targets, async (target) =>
-    enqueueTask(
+  const enqueued = await pMap(targets, async (target) => {
+    // A PR opened by a session-delegated task pulls its review into that
+    // same session, so the review shows up as a task there instead of
+    // spawning an unrelated one.
+    const reviewBranch = branchName;
+    const originParent = reviewBranch
+      ? await getPrOriginFastAgentParent({
+          repository: repoFullName,
+          prNumber: pullRequest.pullRequestId,
+          branchName: reviewBranch,
+          sourceControlProvider: 'ado',
+          host: target.repo.host,
+        }).catch(() => null)
+      : null;
+    return enqueueTask(
       {
         task: {
           type: taskType,
@@ -431,6 +448,9 @@ export async function handleAdoPullRequest(
             // Legacy rows without a recorded host omit the field.
             ...(target.repo.host
               ? { sourceControlHost: target.repo.host }
+              : {}),
+            ...(originParent
+              ? buildFastAgentSessionAttachment(originParent)
               : {}),
             prNumber: pullRequest.pullRequestId,
             prTitle: pullRequest.title,
@@ -472,8 +492,8 @@ export async function handleAdoPullRequest(
       {
         launchClass: 'automation',
       },
-    ),
-  );
+    );
+  });
 
   return {
     status: 'ok',

--- a/apps/api/src/handlers/ado/handlePullRequest.ts
+++ b/apps/api/src/handlers/ado/handlePullRequest.ts
@@ -433,6 +433,7 @@ export async function handleAdoPullRequest(
           prNumber: pullRequest.pullRequestId,
           branchName: reviewBranch,
           sourceControlProvider: 'ado',
+          repositoryId: target.repo.id,
           // Legacy repository rows may lack a host; fall back to the
           // webhook's own host so a same-named repository on another
           // instance can never supply this review's session.

--- a/apps/api/src/handlers/ado/handlePullRequest.ts
+++ b/apps/api/src/handlers/ado/handlePullRequest.ts
@@ -433,7 +433,10 @@ export async function handleAdoPullRequest(
           prNumber: pullRequest.pullRequestId,
           branchName: reviewBranch,
           sourceControlProvider: 'ado',
-          host: target.repo.host,
+          // Legacy repository rows may lack a host; fall back to the
+          // webhook's own host so a same-named repository on another
+          // instance can never supply this review's session.
+          host: target.repo.host ?? toHostFromUrl(prUrl),
         }).catch(() => null)
       : null;
     return enqueueTask(

--- a/apps/api/src/handlers/bitbucket/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/bitbucket/__tests__/handlePullRequest.test.ts
@@ -20,6 +20,7 @@ const {
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
+  getPrOriginFastAgentParent: vi.fn(async () => null),
 }));
 
 vi.mock('@roomote/sdk/server', () => ({

--- a/apps/api/src/handlers/bitbucket/handlePullRequest.ts
+++ b/apps/api/src/handlers/bitbucket/handlePullRequest.ts
@@ -251,6 +251,7 @@ export async function handleBitbucketPullRequest(
           prNumber: prNumber,
           branchName: reviewBranch,
           sourceControlProvider: 'bitbucket',
+          repositoryId: target.repo.id,
           // Legacy repository rows may lack a host; fall back to the
           // webhook's own host so a same-named repository on another
           // instance can never supply this review's session.

--- a/apps/api/src/handlers/bitbucket/handlePullRequest.ts
+++ b/apps/api/src/handlers/bitbucket/handlePullRequest.ts
@@ -1,6 +1,7 @@
 import pMap from 'p-map';
 
 import {
+  buildFastAgentSessionAttachment,
   type TaskPayload,
   DEFAULT_PR_REVIEW_SETTINGS,
   type PrReviewSettings,
@@ -13,7 +14,10 @@ import {
   eq,
   findActiveGitHubPrReviewTask,
 } from '@roomote/db/server';
-import { enqueueTask } from '@roomote/cloud-agents/server';
+import {
+  enqueueTask,
+  getPrOriginFastAgentParent,
+} from '@roomote/cloud-agents/server';
 import {
   recordPrStatusChangeInTaskHistory,
   updateTaskPrStatus,
@@ -236,8 +240,21 @@ export async function handleBitbucketPullRequest(
   const prAuthorId =
     getBitbucketUserAccountKey(pullRequest.author) ?? prAuthorName;
 
-  const enqueued = await pMap(targets, async (target) =>
-    enqueueTask(
+  const enqueued = await pMap(targets, async (target) => {
+    // A PR opened by a session-delegated task pulls its review into that
+    // same session, so the review shows up as a task there instead of
+    // spawning an unrelated one.
+    const reviewBranch = headRef;
+    const originParent = reviewBranch
+      ? await getPrOriginFastAgentParent({
+          repository: repoFullName,
+          prNumber: prNumber,
+          branchName: reviewBranch,
+          sourceControlProvider: 'bitbucket',
+          host: target.repo.host,
+        }).catch(() => null)
+      : null;
+    return enqueueTask(
       {
         task: {
           type: taskType,
@@ -249,6 +266,9 @@ export async function handleBitbucketPullRequest(
             // Legacy rows without a recorded host omit the field.
             ...(target.repo.host
               ? { sourceControlHost: target.repo.host }
+              : {}),
+            ...(originParent
+              ? buildFastAgentSessionAttachment(originParent)
               : {}),
             prNumber,
             prTitle: pullRequest.title,
@@ -291,8 +311,8 @@ export async function handleBitbucketPullRequest(
       {
         launchClass: 'automation',
       },
-    ),
-  );
+    );
+  });
 
   return {
     status: 'ok',

--- a/apps/api/src/handlers/bitbucket/handlePullRequest.ts
+++ b/apps/api/src/handlers/bitbucket/handlePullRequest.ts
@@ -251,7 +251,10 @@ export async function handleBitbucketPullRequest(
           prNumber: prNumber,
           branchName: reviewBranch,
           sourceControlProvider: 'bitbucket',
-          host: target.repo.host,
+          // Legacy repository rows may lack a host; fall back to the
+          // webhook's own host so a same-named repository on another
+          // instance can never supply this review's session.
+          host: target.repo.host ?? toHostFromUrl(prUrl),
         }).catch(() => null)
       : null;
     return enqueueTask(

--- a/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
+++ b/apps/api/src/handlers/gitea/__tests__/handlePullRequest.test.ts
@@ -20,6 +20,7 @@ const {
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
+  getPrOriginFastAgentParent: vi.fn(async () => null),
 }));
 
 vi.mock('@roomote/sdk/server', () => ({

--- a/apps/api/src/handlers/gitea/handlePullRequest.ts
+++ b/apps/api/src/handlers/gitea/handlePullRequest.ts
@@ -240,7 +240,10 @@ export async function handleGiteaPullRequest(
           prNumber: payload.number,
           branchName: reviewBranch,
           sourceControlProvider: 'gitea',
-          host: target.repo.host,
+          // Legacy repository rows may lack a host; fall back to the
+          // webhook's own host so a same-named repository on another
+          // instance can never supply this review's session.
+          host: target.repo.host ?? toHostFromUrl(prUrl),
         }).catch(() => null)
       : null;
     return enqueueTask(

--- a/apps/api/src/handlers/gitea/handlePullRequest.ts
+++ b/apps/api/src/handlers/gitea/handlePullRequest.ts
@@ -240,6 +240,7 @@ export async function handleGiteaPullRequest(
           prNumber: payload.number,
           branchName: reviewBranch,
           sourceControlProvider: 'gitea',
+          repositoryId: target.repo.id,
           // Legacy repository rows may lack a host; fall back to the
           // webhook's own host so a same-named repository on another
           // instance can never supply this review's session.

--- a/apps/api/src/handlers/gitea/handlePullRequest.ts
+++ b/apps/api/src/handlers/gitea/handlePullRequest.ts
@@ -1,6 +1,7 @@
 import pMap from 'p-map';
 
 import {
+  buildFastAgentSessionAttachment,
   type TaskPayload,
   DEFAULT_PR_REVIEW_SETTINGS,
   type PrReviewSettings,
@@ -13,7 +14,10 @@ import {
   eq,
   findActiveGitHubPrReviewTask,
 } from '@roomote/db/server';
-import { enqueueTask } from '@roomote/cloud-agents/server';
+import {
+  enqueueTask,
+  getPrOriginFastAgentParent,
+} from '@roomote/cloud-agents/server';
 import {
   recordPrStatusChangeInTaskHistory,
   updateTaskPrStatus,
@@ -225,8 +229,21 @@ export async function handleGiteaPullRequest(
   const prAuthorId =
     pullRequest.user?.id != null ? String(pullRequest.user.id) : prAuthorName;
 
-  const enqueued = await pMap(targets, async (target) =>
-    enqueueTask(
+  const enqueued = await pMap(targets, async (target) => {
+    // A PR opened by a session-delegated task pulls its review into that
+    // same session, so the review shows up as a task there instead of
+    // spawning an unrelated one.
+    const reviewBranch = pullRequest.head?.ref;
+    const originParent = reviewBranch
+      ? await getPrOriginFastAgentParent({
+          repository: repoFullName,
+          prNumber: payload.number,
+          branchName: reviewBranch,
+          sourceControlProvider: 'gitea',
+          host: target.repo.host,
+        }).catch(() => null)
+      : null;
+    return enqueueTask(
       {
         task: {
           type: taskType,
@@ -238,6 +255,9 @@ export async function handleGiteaPullRequest(
             // Legacy rows without a recorded host omit the field.
             ...(target.repo.host
               ? { sourceControlHost: target.repo.host }
+              : {}),
+            ...(originParent
+              ? buildFastAgentSessionAttachment(originParent)
               : {}),
             prNumber: payload.number,
             prTitle: pullRequest.title,
@@ -280,8 +300,8 @@ export async function handleGiteaPullRequest(
       {
         launchClass: 'automation',
       },
-    ),
-  );
+    );
+  });
 
   return {
     status: 'ok',

--- a/apps/api/src/handlers/github/__tests__/reviewTaskRelayPayload.test.ts
+++ b/apps/api/src/handlers/github/__tests__/reviewTaskRelayPayload.test.ts
@@ -42,6 +42,38 @@ describe('getReviewTaskRelayPayload', () => {
     });
   });
 
+  it('attaches the PR-origin session when the opening task has a Fast parent', async () => {
+    const fastParent = {
+      sessionId: 'a3a5e5f5-9c9e-4a37-9a06-000000000001',
+      conversation: {
+        surface: 'slack',
+        workspaceId: 'T123',
+        conversationId: '100.001',
+        replyTarget: { channelId: 'C123', threadId: '100.001' },
+      },
+    };
+    mocks.getRelayState.mockResolvedValue({
+      linkedTaskId: 'implementation-task',
+      relayEnabled: true,
+      handoffTarget: 'fast_parent',
+      fastAgentParent: fastParent,
+    });
+
+    await expect(
+      getReviewTaskRelayPayload({
+        repository: 'acme/app',
+        prNumber: 42,
+        branchName: 'feature/test',
+      }),
+    ).resolves.toEqual({
+      relayReviewResultsToTask: true,
+      linkedTaskId: 'implementation-task',
+      linkedReviewHandoffTarget: 'fast_parent',
+      fastAgentSessionId: fastParent.sessionId,
+      fastAgentParent: fastParent,
+    });
+  });
+
   it('keeps the late owner lookup eligible when ordinary relay is disabled', async () => {
     mocks.getRelayState.mockResolvedValue({
       linkedTaskId: null,

--- a/apps/api/src/handlers/github/__tests__/reviewTaskRelayPayload.test.ts
+++ b/apps/api/src/handlers/github/__tests__/reviewTaskRelayPayload.test.ts
@@ -1,10 +1,12 @@
 const mocks = vi.hoisted(() => ({
   getRelayState: vi.fn(),
   getSettings: vi.fn(),
+  getPrOriginFastAgentParent: vi.fn(async (): Promise<unknown> => null),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   getLinkedTaskRelayState: mocks.getRelayState,
+  getPrOriginFastAgentParent: mocks.getPrOriginFastAgentParent,
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -42,7 +44,7 @@ describe('getReviewTaskRelayPayload', () => {
     });
   });
 
-  it('attaches the PR-origin session when the opening task has a Fast parent', async () => {
+  it('attaches the PR-origin session pinned to the reviewing repository row', async () => {
     const fastParent = {
       sessionId: 'a3a5e5f5-9c9e-4a37-9a06-000000000001',
       conversation: {
@@ -56,14 +58,16 @@ describe('getReviewTaskRelayPayload', () => {
       linkedTaskId: 'implementation-task',
       relayEnabled: true,
       handoffTarget: 'fast_parent',
-      fastAgentParent: fastParent,
     });
+    mocks.getPrOriginFastAgentParent.mockResolvedValueOnce(fastParent);
 
     await expect(
       getReviewTaskRelayPayload({
         repository: 'acme/app',
         prNumber: 42,
         branchName: 'feature/test',
+        repositoryId: 'repo-1',
+        host: 'github.com',
       }),
     ).resolves.toEqual({
       relayReviewResultsToTask: true,
@@ -72,6 +76,29 @@ describe('getReviewTaskRelayPayload', () => {
       fastAgentSessionId: fastParent.sessionId,
       fastAgentParent: fastParent,
     });
+    expect(mocks.getPrOriginFastAgentParent).toHaveBeenCalledWith({
+      repository: 'acme/app',
+      prNumber: 42,
+      branchName: 'feature/test',
+      repositoryId: 'repo-1',
+      host: 'github.com',
+    });
+  });
+
+  it('skips the session attachment when no repository row id is supplied', async () => {
+    mocks.getRelayState.mockResolvedValue({
+      linkedTaskId: null,
+      relayEnabled: false,
+    });
+
+    await expect(
+      getReviewTaskRelayPayload({
+        repository: 'acme/app',
+        prNumber: 42,
+        branchName: 'feature/test',
+      }),
+    ).resolves.toEqual({ relayReviewResultsToTask: false });
+    expect(mocks.getPrOriginFastAgentParent).not.toHaveBeenCalled();
   });
 
   it('keeps the late owner lookup eligible when ordinary relay is disabled', async () => {

--- a/apps/api/src/handlers/github/handlePrOpen.ts
+++ b/apps/api/src/handlers/github/handlePrOpen.ts
@@ -101,6 +101,8 @@ export async function handlePrOpen(
       branchName: pr.head.ref,
       prBody: pr.body ?? null,
       reviewerSettings: target.settings,
+      repositoryId: target.repo.id,
+      host: target.repo.host ?? toHostFromUrl(pr.html_url),
     });
 
     const releaseLifecycleLock = await acquireGithubPrReviewLifecycleLock(

--- a/apps/api/src/handlers/github/handlePrSynchronize.ts
+++ b/apps/api/src/handlers/github/handlePrSynchronize.ts
@@ -290,6 +290,8 @@ export async function handlePrSynchronize({
             branchName: pr.head.ref,
             prBody: pr.body ?? null,
             reviewerSettings: currentTarget.settings,
+            repositoryId: currentTarget.repo.id,
+            host: currentTarget.repo.host ?? toHostFromUrl(pr.html_url),
           });
 
           await enqueueActivePrReviewFollowUp({
@@ -398,6 +400,8 @@ export async function handlePrSynchronize({
         branchName: pr.head.ref,
         prBody: pr.body ?? null,
         reviewerSettings: currentTarget.settings,
+        repositoryId: currentTarget.repo.id,
+        host: currentTarget.repo.host ?? toHostFromUrl(pr.html_url),
       });
 
       const launch = await enqueueTask({

--- a/apps/api/src/handlers/github/reviewTaskRelayPayload.ts
+++ b/apps/api/src/handlers/github/reviewTaskRelayPayload.ts
@@ -4,6 +4,7 @@ import {
   type PrReviewSettings,
 } from '@roomote/types';
 import { getReviewCodeAutomationSettings } from '@roomote/db/server';
+import { getPrOriginFastAgentParent } from '@roomote/cloud-agents/server';
 
 import { getLinkedTaskRelayState } from './linkedTaskRelay';
 
@@ -27,12 +28,22 @@ export async function getReviewTaskRelayPayload({
   branchName,
   prBody,
   reviewerSettings,
+  repositoryId,
+  host,
 }: {
   repository: string;
   prNumber: number;
   branchName: string;
   prBody?: string | null;
   reviewerSettings?: PrReviewSettings | null;
+  /**
+   * The reviewing repository's row id; when present, the review is attached
+   * to the Fast session of the task that opened the PR, pinned to this exact
+   * connected repository so another instance's same-named repository can
+   * never supply the session.
+   */
+  repositoryId?: string | null;
+  host?: string | null;
 }): Promise<{
   relayReviewResultsToTask?: boolean;
   linkedTaskId?: string;
@@ -61,9 +72,18 @@ export async function getReviewTaskRelayPayload({
 
   // A PR opened by a session-delegated task pulls its review into that same
   // session, so the review shows up as a task there instead of spawning an
-  // unrelated one.
-  const sessionAttachment = relayState.fastAgentParent
-    ? buildFastAgentSessionAttachment(relayState.fastAgentParent)
+  // unrelated one. The lookup is pinned to the reviewing repository row.
+  const originParent: FastAgentParent | null = repositoryId
+    ? await getPrOriginFastAgentParent({
+        repository,
+        prNumber,
+        branchName,
+        repositoryId,
+        ...(host ? { host } : {}),
+      }).catch(() => null)
+    : null;
+  const sessionAttachment = originParent
+    ? buildFastAgentSessionAttachment(originParent)
     : {};
 
   if (relayState.relayEnabled && relayState.linkedTaskId) {

--- a/apps/api/src/handlers/github/reviewTaskRelayPayload.ts
+++ b/apps/api/src/handlers/github/reviewTaskRelayPayload.ts
@@ -1,4 +1,8 @@
-import { type PrReviewSettings } from '@roomote/types';
+import {
+  buildFastAgentSessionAttachment,
+  type FastAgentParent,
+  type PrReviewSettings,
+} from '@roomote/types';
 import { getReviewCodeAutomationSettings } from '@roomote/db/server';
 
 import { getLinkedTaskRelayState } from './linkedTaskRelay';
@@ -34,6 +38,8 @@ export async function getReviewTaskRelayPayload({
   linkedTaskId?: string;
   linkedTaskRelayLookupPending?: boolean;
   linkedReviewHandoffTarget?: 'fast_parent' | 'implementation_task';
+  fastAgentSessionId?: string;
+  fastAgentParent?: FastAgentParent;
 }> {
   const settings =
     reviewerSettings ?? (await getReviewCodeAutomationSettings());
@@ -53,6 +59,13 @@ export async function getReviewTaskRelayPayload({
     };
   }
 
+  // A PR opened by a session-delegated task pulls its review into that same
+  // session, so the review shows up as a task there instead of spawning an
+  // unrelated one.
+  const sessionAttachment = relayState.fastAgentParent
+    ? buildFastAgentSessionAttachment(relayState.fastAgentParent)
+    : {};
+
   if (relayState.relayEnabled && relayState.linkedTaskId) {
     return {
       relayReviewResultsToTask: true,
@@ -60,8 +73,9 @@ export async function getReviewTaskRelayPayload({
       ...(relayState.handoffTarget
         ? { linkedReviewHandoffTarget: relayState.handoffTarget }
         : {}),
+      ...sessionAttachment,
     };
   }
 
-  return { relayReviewResultsToTask: false };
+  return { relayReviewResultsToTask: false, ...sessionAttachment };
 }

--- a/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
+++ b/apps/api/src/handlers/gitlab/__tests__/handleMergeRequest.test.ts
@@ -7,6 +7,7 @@ const {
   mockScheduleNotifyPullRequestTerminalStatus,
   mockScheduleSourceControlPullRequestFactSync,
   mockFindActiveGitHubPrReviewTask,
+  mockGetPrOriginFastAgentParent,
 } = vi.hoisted(() => ({
   mockEnqueueTask: vi.fn(),
   mockGetGitLabAutomationTargets: vi.fn(),
@@ -16,10 +17,12 @@ const {
   mockScheduleNotifyPullRequestTerminalStatus: vi.fn(),
   mockScheduleSourceControlPullRequestFactSync: vi.fn(),
   mockFindActiveGitHubPrReviewTask: vi.fn(),
+  mockGetPrOriginFastAgentParent: vi.fn(),
 }));
 
 vi.mock('@roomote/cloud-agents/server', () => ({
   enqueueTask: mockEnqueueTask,
+  getPrOriginFastAgentParent: mockGetPrOriginFastAgentParent,
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
@@ -104,6 +107,8 @@ describe('handleGitLabMergeRequest', () => {
     mockRepositoriesFindFirst.mockReset();
     mockScheduleNotifyPullRequestTerminalStatus.mockReset();
     mockFindActiveGitHubPrReviewTask.mockReset();
+    mockGetPrOriginFastAgentParent.mockReset();
+    mockGetPrOriginFastAgentParent.mockResolvedValue(null);
 
     mockRepositoriesFindFirst.mockResolvedValue({
       id: 'repo-row-1',
@@ -267,6 +272,41 @@ describe('handleGitLabMergeRequest', () => {
         }),
       }),
       expect.any(Object),
+    );
+  });
+
+  it('attaches the review to the Fast session whose task opened the MR', async () => {
+    const fastParent = {
+      sessionId: '22222222-2222-4222-8222-222222222222',
+      conversation: {
+        surface: 'slack',
+        workspaceId: 'T123',
+        conversationId: '100.001',
+        replyTarget: { channelId: 'C123', threadId: '100.001' },
+      },
+    };
+    mockGetPrOriginFastAgentParent.mockResolvedValue(fastParent);
+
+    await handleGitLabMergeRequest(makePayload('open'));
+
+    expect(mockGetPrOriginFastAgentParent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: 'acme/backend',
+        prNumber: 42,
+        branchName: 'feature/test',
+        sourceControlProvider: 'gitlab',
+      }),
+    );
+    expect(mockEnqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            fastAgentParent: fastParent,
+            fastAgentSessionId: fastParent.sessionId,
+          }),
+        }),
+      }),
+      expect.anything(),
     );
   });
 

--- a/apps/api/src/handlers/gitlab/handleMergeRequest.ts
+++ b/apps/api/src/handlers/gitlab/handleMergeRequest.ts
@@ -243,7 +243,10 @@ export async function handleGitLabMergeRequest(
           prNumber: mergeRequest.iid,
           branchName: reviewBranch,
           sourceControlProvider: 'gitlab',
-          host: target.repo.host,
+          // Legacy repository rows may lack a host; fall back to the
+          // webhook's own host so a same-named repository on another
+          // instance can never supply this review's session.
+          host: target.repo.host ?? toHostFromUrl(mergeRequest.url),
         }).catch(() => null)
       : null;
     return enqueueTask(

--- a/apps/api/src/handlers/gitlab/handleMergeRequest.ts
+++ b/apps/api/src/handlers/gitlab/handleMergeRequest.ts
@@ -243,6 +243,7 @@ export async function handleGitLabMergeRequest(
           prNumber: mergeRequest.iid,
           branchName: reviewBranch,
           sourceControlProvider: 'gitlab',
+          repositoryId: target.repo.id,
           // Legacy repository rows may lack a host; fall back to the
           // webhook's own host so a same-named repository on another
           // instance can never supply this review's session.

--- a/apps/api/src/handlers/gitlab/handleMergeRequest.ts
+++ b/apps/api/src/handlers/gitlab/handleMergeRequest.ts
@@ -1,6 +1,7 @@
 import pMap from 'p-map';
 
 import {
+  buildFastAgentSessionAttachment,
   type TaskPayload,
   DEFAULT_PR_REVIEW_SETTINGS,
   type PrReviewSettings,
@@ -13,7 +14,10 @@ import {
   eq,
   findActiveGitHubPrReviewTask,
 } from '@roomote/db/server';
-import { enqueueTask } from '@roomote/cloud-agents/server';
+import {
+  enqueueTask,
+  getPrOriginFastAgentParent,
+} from '@roomote/cloud-agents/server';
 import {
   recordPrStatusChangeInTaskHistory,
   updateTaskPrStatus,
@@ -228,8 +232,21 @@ export async function handleGitLabMergeRequest(
     payload.user?.id != null ? String(payload.user.id) : payload.user?.username;
   const mrAuthorName = payload.user?.name ?? payload.user?.username;
 
-  const enqueued = await pMap(targets, async (target) =>
-    enqueueTask(
+  const enqueued = await pMap(targets, async (target) => {
+    // A PR opened by a session-delegated task pulls its review into that
+    // same session, so the review shows up as a task there instead of
+    // spawning an unrelated one.
+    const reviewBranch = mergeRequest.source_branch;
+    const originParent = reviewBranch
+      ? await getPrOriginFastAgentParent({
+          repository: repoFullName,
+          prNumber: mergeRequest.iid,
+          branchName: reviewBranch,
+          sourceControlProvider: 'gitlab',
+          host: target.repo.host,
+        }).catch(() => null)
+      : null;
+    return enqueueTask(
       {
         task: {
           type: taskType,
@@ -241,6 +258,9 @@ export async function handleGitLabMergeRequest(
             // Legacy rows without a recorded host omit the field.
             ...(target.repo.host
               ? { sourceControlHost: target.repo.host }
+              : {}),
+            ...(originParent
+              ? buildFastAgentSessionAttachment(originParent)
               : {}),
             prNumber: mergeRequest.iid,
             prTitle: mergeRequest.title,
@@ -284,8 +304,8 @@ export async function handleGitLabMergeRequest(
       {
         launchClass: 'automation',
       },
-    ),
-  );
+    );
+  });
 
   return {
     status: 'ok',

--- a/apps/bullmq/src/jobs/pr-review-notification.ts
+++ b/apps/bullmq/src/jobs/pr-review-notification.ts
@@ -56,6 +56,7 @@ import {
   PR_REVIEW_ACTION_LABELS,
   isTaskExecutingTurn,
   getFastAgentParentFromPayload,
+  isPrReviewPayload,
   WORKER_HEARTBEAT_STALE_MS,
 } from '@roomote/types';
 
@@ -161,6 +162,11 @@ function isButtonRoute(
 function getFastParentButtonRoute(
   payload: unknown,
 ): ButtonPrReviewNotificationRoute | null {
+  // Review-pipeline runs carry a Fast parent for session visibility only;
+  // their PR notifications must not route buttons into the parent thread.
+  if (isPrReviewPayload(payload)) {
+    return null;
+  }
   const parent = getFastAgentParentFromPayload(payload);
   if (
     !parent ||

--- a/packages/cloud-agents/src/server/__tests__/linked-task-relay.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/linked-task-relay.test.ts
@@ -64,7 +64,6 @@ describe('getLinkedTaskRelayState', () => {
       linkedTaskId: 'implementation-task',
       relayEnabled: true,
       handoffTarget: 'fast_parent',
-      fastAgentParent: fastParent,
     });
   });
 
@@ -102,6 +101,7 @@ describe('getPrOriginFastAgentParent', () => {
         branchName: 'feature/test',
         sourceControlProvider: 'gitlab',
         host: 'git.example.com',
+        repositoryId: 'repo-1',
       }),
     ).resolves.toEqual(fastParent);
     expect(mocks.findOwner).toHaveBeenCalledWith({
@@ -110,6 +110,7 @@ describe('getPrOriginFastAgentParent', () => {
       branchName: 'feature/test',
       sourceControlProvider: 'gitlab',
       host: 'git.example.com',
+      repositoryId: 'repo-1',
     });
   });
 
@@ -121,6 +122,7 @@ describe('getPrOriginFastAgentParent', () => {
         repository: 'acme/app',
         prNumber: 42,
         branchName: 'feature/test',
+        repositoryId: 'repo-1',
       }),
     ).resolves.toBeNull();
   });
@@ -133,6 +135,7 @@ describe('getPrOriginFastAgentParent', () => {
         repository: 'acme/app',
         prNumber: 42,
         branchName: 'feature/test',
+        repositoryId: 'repo-1',
       }),
     ).resolves.toBeNull();
   });

--- a/packages/cloud-agents/src/server/__tests__/linked-task-relay.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/linked-task-relay.test.ts
@@ -20,7 +20,10 @@ vi.mock('@roomote/db/server', () => ({
   taskRuns: { taskId: 'taskRuns.taskId', createdAt: 'taskRuns.createdAt' },
 }));
 
-import { getLinkedTaskRelayState } from '../linked-task-relay';
+import {
+  getLinkedTaskRelayState,
+  getPrOriginFastAgentParent,
+} from '../linked-task-relay';
 
 const fastParent = {
   sessionId: '11111111-1111-4111-8111-111111111111',
@@ -61,6 +64,7 @@ describe('getLinkedTaskRelayState', () => {
       linkedTaskId: 'implementation-task',
       relayEnabled: true,
       handoffTarget: 'fast_parent',
+      fastAgentParent: fastParent,
     });
   });
 
@@ -77,5 +81,59 @@ describe('getLinkedTaskRelayState', () => {
       linkedTaskId: 'implementation-task',
       relayEnabled: false,
     });
+  });
+});
+
+describe('getPrOriginFastAgentParent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findOwner.mockResolvedValue({ taskId: 'implementation-task' });
+  });
+
+  it('returns the PR-opening task Fast parent for the requested provider', async () => {
+    mocks.findRun.mockResolvedValue({
+      payload: { fastAgentParent: fastParent },
+    });
+
+    await expect(
+      getPrOriginFastAgentParent({
+        repository: 'acme/app',
+        prNumber: 42,
+        branchName: 'feature/test',
+        sourceControlProvider: 'gitlab',
+        host: 'git.example.com',
+      }),
+    ).resolves.toEqual(fastParent);
+    expect(mocks.findOwner).toHaveBeenCalledWith({
+      repoFullName: 'acme/app',
+      prNumber: 42,
+      branchName: 'feature/test',
+      sourceControlProvider: 'gitlab',
+      host: 'git.example.com',
+    });
+  });
+
+  it('returns null when no session-delegated task opened the PR', async () => {
+    mocks.findOwner.mockResolvedValue(null);
+
+    await expect(
+      getPrOriginFastAgentParent({
+        repository: 'acme/app',
+        prNumber: 42,
+        branchName: 'feature/test',
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('returns null when the opening task run has no Fast parent', async () => {
+    mocks.findRun.mockResolvedValue({ payload: {} });
+
+    await expect(
+      getPrOriginFastAgentParent({
+        repository: 'acme/app',
+        prNumber: 42,
+        branchName: 'feature/test',
+      }),
+    ).resolves.toBeNull();
   });
 });

--- a/packages/cloud-agents/src/server/linked-task-relay.ts
+++ b/packages/cloud-agents/src/server/linked-task-relay.ts
@@ -19,8 +19,6 @@ export type LinkedTaskRelayState = {
   relayEnabled: boolean;
   handoffTarget?: 'fast_parent' | 'implementation_task';
   ownerLookupPending?: true;
-  /** The Fast parent of the task that opened the PR, when it has one. */
-  fastAgentParent?: FastAgentParent;
 };
 
 function getRelayEligibleCreatorIds(
@@ -87,16 +85,15 @@ export async function getLinkedTaskRelayState({
     orderBy: [desc(taskRuns.createdAt)],
     columns: { payload: true },
   });
-  const fastParent = getFastAgentParentFromPayload(latestRun?.payload);
-  const hasFastParent = Boolean(fastParent);
+  const hasFastParent = Boolean(
+    getFastAgentParentFromPayload(latestRun?.payload),
+  );
 
   if (!linkedTask.initiatorUserId) {
     return {
       linkedTaskId: linkedTask.id,
       relayEnabled: hasFastParent,
-      ...(fastParent
-        ? { handoffTarget: 'fast_parent' as const, fastAgentParent: fastParent }
-        : {}),
+      ...(hasFastParent ? { handoffTarget: 'fast_parent' as const } : {}),
     };
   }
 
@@ -107,8 +104,8 @@ export async function getLinkedTaskRelayState({
   return {
     linkedTaskId: linkedTask.id,
     relayEnabled: hasFastParent || creatorRelayEnabled,
-    ...(fastParent
-      ? { handoffTarget: 'fast_parent' as const, fastAgentParent: fastParent }
+    ...(hasFastParent
+      ? { handoffTarget: 'fast_parent' as const }
       : creatorRelayEnabled
         ? { handoffTarget: 'implementation_task' as const }
         : {}),
@@ -146,12 +143,19 @@ export async function getPrOriginFastAgentParent({
   branchName,
   sourceControlProvider = 'github',
   host,
+  repositoryId,
 }: {
   repository: string;
   prNumber: number;
   branchName: string;
   sourceControlProvider?: SourceControlProvider;
   host?: string | null;
+  /**
+   * The reviewing repository's own row id. Required so legacy null-host
+   * linkage rows on another instance can never supply the session; the
+   * origin task must be linked to this exact connected repository.
+   */
+  repositoryId: string;
 }): Promise<FastAgentParent | null> {
   const owner = await findReusableGitHubPrFollowUpOwner({
     repoFullName: repository,
@@ -159,6 +163,7 @@ export async function getPrOriginFastAgentParent({
     branchName,
     sourceControlProvider,
     ...(host ? { host } : {}),
+    repositoryId,
   });
   if (!owner?.taskId) {
     return null;

--- a/packages/cloud-agents/src/server/linked-task-relay.ts
+++ b/packages/cloud-agents/src/server/linked-task-relay.ts
@@ -9,7 +9,9 @@ import {
 } from '@roomote/db/server';
 import {
   getFastAgentParentFromPayload,
+  type FastAgentParent,
   type PrReviewSettings,
+  type SourceControlProvider,
 } from '@roomote/types';
 
 export type LinkedTaskRelayState = {
@@ -17,6 +19,8 @@ export type LinkedTaskRelayState = {
   relayEnabled: boolean;
   handoffTarget?: 'fast_parent' | 'implementation_task';
   ownerLookupPending?: true;
+  /** The Fast parent of the task that opened the PR, when it has one. */
+  fastAgentParent?: FastAgentParent;
 };
 
 function getRelayEligibleCreatorIds(
@@ -83,15 +87,16 @@ export async function getLinkedTaskRelayState({
     orderBy: [desc(taskRuns.createdAt)],
     columns: { payload: true },
   });
-  const hasFastParent = Boolean(
-    getFastAgentParentFromPayload(latestRun?.payload),
-  );
+  const fastParent = getFastAgentParentFromPayload(latestRun?.payload);
+  const hasFastParent = Boolean(fastParent);
 
   if (!linkedTask.initiatorUserId) {
     return {
       linkedTaskId: linkedTask.id,
       relayEnabled: hasFastParent,
-      ...(hasFastParent ? { handoffTarget: 'fast_parent' as const } : {}),
+      ...(fastParent
+        ? { handoffTarget: 'fast_parent' as const, fastAgentParent: fastParent }
+        : {}),
     };
   }
 
@@ -102,8 +107,8 @@ export async function getLinkedTaskRelayState({
   return {
     linkedTaskId: linkedTask.id,
     relayEnabled: hasFastParent || creatorRelayEnabled,
-    ...(hasFastParent
-      ? { handoffTarget: 'fast_parent' as const }
+    ...(fastParent
+      ? { handoffTarget: 'fast_parent' as const, fastAgentParent: fastParent }
       : creatorRelayEnabled
         ? { handoffTarget: 'implementation_task' as const }
         : {}),
@@ -129,4 +134,40 @@ export async function isLinkedTaskCreatorRelayEnabled({
       reviewerSettings,
     })
   ).relayEnabled;
+}
+
+/**
+ * The Fast parent of the session-delegated task that opened this PR, for
+ * attaching follow-on work (like the PR's review task) to the same session.
+ */
+export async function getPrOriginFastAgentParent({
+  repository,
+  prNumber,
+  branchName,
+  sourceControlProvider = 'github',
+  host,
+}: {
+  repository: string;
+  prNumber: number;
+  branchName: string;
+  sourceControlProvider?: SourceControlProvider;
+  host?: string | null;
+}): Promise<FastAgentParent | null> {
+  const owner = await findReusableGitHubPrFollowUpOwner({
+    repoFullName: repository,
+    prNumber,
+    branchName,
+    sourceControlProvider,
+    ...(host ? { host } : {}),
+  });
+  if (!owner?.taskId) {
+    return null;
+  }
+
+  const latestRun = await db.query.taskRuns.findFirst({
+    where: eq(taskRuns.taskId, owner.taskId),
+    orderBy: [desc(taskRuns.createdAt)],
+    columns: { payload: true },
+  });
+  return getFastAgentParentFromPayload(latestRun?.payload);
 }

--- a/packages/db/src/lib/__tests__/github-branch-activity.test.ts
+++ b/packages/db/src/lib/__tests__/github-branch-activity.test.ts
@@ -1,4 +1,6 @@
 import {
+  githubInstallationFactory,
+  repositoryFactory,
   runFactory,
   db,
   eq,
@@ -35,6 +37,7 @@ async function createPrLinkedTask({
   prSha,
   sourceControlProvider = 'github',
   host,
+  repositoryId,
 }: {
   repoFullName: string;
   prNumber: number;
@@ -42,6 +45,7 @@ async function createPrLinkedTask({
   prSha?: string;
   sourceControlProvider?: SourceControlProvider;
   host?: string | null;
+  repositoryId?: string | null;
 }) {
   const task = await taskFactory.create({
     initiatorUserId: userId,
@@ -56,6 +60,7 @@ async function createPrLinkedTask({
     prSha: prSha ?? null,
     sourceControlProvider,
     host: host ?? null,
+    repositoryId: repositoryId ?? null,
     status: 'open',
   });
 
@@ -733,6 +738,98 @@ describe('findActiveGitHubBranchWork', () => {
 });
 
 describe('findReusableGitHubPrFollowUpOwner', () => {
+  it('pins linkage matches to the exact repository row when repositoryId is given', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'owner/repo-reusable-owner-repo-pin';
+    const branchName = 'feature/repo-pin';
+    const installation = await githubInstallationFactory.create({
+      installedByUserId: user.id,
+    });
+    const reviewingRepo = await repositoryFactory.create({
+      installationId: installation.id,
+      linkedByUserId: user.id,
+      fullName: repoFullName,
+    });
+    const otherRepo = await repositoryFactory.create({
+      installationId: installation.id,
+      linkedByUserId: user.id,
+      fullName: repoFullName,
+      host: 'ghe-other.example.com',
+    });
+    const taskId = await createPrLinkedTask({
+      repoFullName,
+      prNumber: 905,
+      userId: user.id,
+      repositoryId: reviewingRepo.id,
+    });
+    await runFactory.create({
+      actingUserId: user.id,
+      taskId,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Pending,
+      payload: { repo: repoFullName, branch: branchName },
+    });
+
+    await expect(
+      findReusableGitHubPrFollowUpOwner({
+        repoFullName,
+        prNumber: 905,
+        branchName,
+        repositoryId: reviewingRepo.id,
+      }),
+    ).resolves.toMatchObject({ taskId });
+
+    await expect(
+      findReusableGitHubPrFollowUpOwner({
+        repoFullName,
+        prNumber: 905,
+        branchName,
+        repositoryId: otherRepo.id,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('skips the branch fallback entirely for repository-pinned lookups', async () => {
+    const { user } = await createActor();
+    const repoFullName = 'owner/repo-reusable-owner-repo-pin-fallback';
+    const branchName = 'feature/repo-pin-fallback';
+    const installation = await githubInstallationFactory.create({
+      installedByUserId: user.id,
+    });
+    const reviewingRepo = await repositoryFactory.create({
+      installationId: installation.id,
+      linkedByUserId: user.id,
+      fullName: repoFullName,
+    });
+    // No linkage row: only the payload-branch fallback could match this run,
+    // and a repository-pinned lookup must not take it.
+    const task = await taskFactory.create({ initiatorUserId: user.id });
+    await runFactory.create({
+      actingUserId: user.id,
+      taskId: task.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Pending,
+      payload: { repo: repoFullName, branch: branchName },
+    });
+
+    await expect(
+      findReusableGitHubPrFollowUpOwner({
+        repoFullName,
+        prNumber: 906,
+        branchName,
+      }),
+    ).resolves.toMatchObject({ taskId: task.id });
+
+    await expect(
+      findReusableGitHubPrFollowUpOwner({
+        repoFullName,
+        prNumber: 906,
+        branchName,
+        repositoryId: reviewingRepo.id,
+      }),
+    ).resolves.toBeNull();
+  });
+
   it('skips the branch fallback when no branch name is given', async () => {
     const { user } = await createActor();
     const repoFullName = 'owner/repo-reusable-owner-empty-branch';

--- a/packages/db/src/lib/github-branch-activity.ts
+++ b/packages/db/src/lib/github-branch-activity.ts
@@ -255,6 +255,7 @@ export async function findReusableGitHubPrFollowUpOwner({
   branchName,
   sourceControlProvider = 'github',
   host,
+  repositoryId,
   fastAgentConversation,
 }: {
   repoFullName: string;
@@ -262,6 +263,13 @@ export async function findReusableGitHubPrFollowUpOwner({
   branchName: string;
   sourceControlProvider?: SourceControlProvider;
   host?: string | null;
+  /**
+   * When set, the linkage-row match requires this exact repositories-row FK.
+   * Unlike the host predicate (which tolerates legacy null-host rows), this
+   * pins the lookup to one connected repository, so a same-named repository
+   * on another self-managed instance can never match.
+   */
+  repositoryId?: string | null;
   fastAgentConversation?: Pick<
     FastAgentConversation,
     'surface' | 'workspaceId' | 'conversationId'
@@ -291,6 +299,9 @@ export async function findReusableGitHubPrFollowUpOwner({
         eq(taskPullRequests.prNumber, prNumber),
         ...(host
           ? [or(eq(taskPullRequests.host, host), isNull(taskPullRequests.host))]
+          : []),
+        ...(repositoryId
+          ? [eq(taskPullRequests.repositoryId, repositoryId)]
           : []),
       ),
     )

--- a/packages/db/src/lib/github-branch-activity.ts
+++ b/packages/db/src/lib/github-branch-activity.ts
@@ -323,6 +323,13 @@ export async function findReusableGitHubPrFollowUpOwner({
     return null;
   }
 
+  // The payload-branch fallback cannot be pinned to a repositories row, so a
+  // caller that demands the exact-repository match gets no fallback: an
+  // unstamped legacy payload on another instance must never satisfy it.
+  if (repositoryId) {
+    return null;
+  }
+
   const branchRows = await db
     .select(REUSABLE_FOLLOW_UP_OWNER_COLUMNS)
     .from(taskRuns)

--- a/packages/sdk/src/server/lib/task-runs/__tests__/notify-fast-agent-parent-on-settle.test.ts
+++ b/packages/sdk/src/server/lib/task-runs/__tests__/notify-fast-agent-parent-on-settle.test.ts
@@ -1,5 +1,5 @@
 import type { TaskRun } from '@roomote/db/server';
-import { RunStatus, TaskRunErrorCode } from '@roomote/types';
+import { RunStatus, TaskPayloadKind, TaskRunErrorCode } from '@roomote/types';
 
 const mocks = vi.hoisted(() => ({
   claimReturning: vi.fn(),
@@ -81,6 +81,40 @@ describe('notifyFastAgentParentOnSettle', () => {
     mocks.listPullRequests.mockResolvedValue([]);
     mocks.recordLifecycle.mockResolvedValue(undefined);
     mocks.canRetryFailedStart.mockResolvedValue(false);
+  });
+
+  it('stays quiet for a successful review child settle', async () => {
+    await notifyFastAgentParentOnSettle(
+      makeRun({
+        type: TaskPayloadKind.GithubPrReview,
+        fastAgentParent: fastParent,
+      }),
+      RunStatus.Idle,
+      'Review acme/app#42',
+    );
+
+    expect(mocks.enqueueParentEvent).not.toHaveBeenCalled();
+    expect(mocks.updateSet).not.toHaveBeenCalled();
+  });
+
+  it('still announces a failed review child settle', async () => {
+    await notifyFastAgentParentOnSettle(
+      makeRun({
+        type: TaskPayloadKind.GithubPrReviewSync,
+        fastAgentParent: fastParent,
+      }),
+      RunStatus.Failed,
+      'Review acme/app#42',
+    );
+
+    expect(mocks.enqueueParentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          type: 'task_settled',
+          status: RunStatus.Failed,
+        }),
+      }),
+    );
   });
 
   it('queues child lifecycle state and settles the source claim immediately', async () => {

--- a/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pr-feedback.ts
+++ b/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pr-feedback.ts
@@ -11,6 +11,7 @@ import {
   getFastAgentParentFromPayload,
   type PullRequestStatus,
   type SourceControlProvider,
+  isPrReviewPayload,
 } from '@roomote/types';
 
 import {
@@ -110,6 +111,13 @@ export async function notifyFastAgentParentOnPrFeedback(params: {
 }): Promise<boolean> {
   const parent = getFastAgentParentFromPayload(params.run.payload);
   if (!parent) {
+    return false;
+  }
+
+  // Review-pipeline runs never forward PR events to their parent session:
+  // the PR's implementation task already delivers them, and a duplicate from
+  // the attached review task would double-announce in the same session.
+  if (isPrReviewPayload(params.run.payload)) {
     return false;
   }
 

--- a/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pull-request-conflict.ts
+++ b/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pull-request-conflict.ts
@@ -9,6 +9,7 @@ import {
 import {
   getFastAgentParentFromPayload,
   type SourceControlProvider,
+  isPrReviewPayload,
 } from '@roomote/types';
 
 import {
@@ -46,6 +47,13 @@ export async function notifyFastAgentParentOnPullRequestConflict(params: {
 }): Promise<boolean> {
   const parent = getFastAgentParentFromPayload(params.run.payload);
   if (!parent) return false;
+
+  // Review-pipeline runs never forward PR events to their parent session:
+  // the PR's implementation task already delivers them, and a duplicate from
+  // the attached review task would double-announce in the same session.
+  if (isPrReviewPayload(params.run.payload)) {
+    return false;
+  }
 
   const deliveryKey = buildNotifiedResultKey({
     prUrl: params.pullRequest.url,

--- a/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pull-request-status-changed.ts
+++ b/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pull-request-status-changed.ts
@@ -9,6 +9,7 @@ import {
 import {
   getFastAgentParentFromPayload,
   type SourceControlProvider,
+  isPrReviewPayload,
 } from '@roomote/types';
 
 import type { FastAgentPullRequestContext } from '../fast-agent-parent-event';
@@ -43,6 +44,13 @@ export async function notifyFastAgentParentOnPullRequestStatusChanged(params: {
 }): Promise<void> {
   const parent = getFastAgentParentFromPayload(params.run.payload);
   if (!parent) {
+    return;
+  }
+
+  // Review-pipeline runs never forward PR events to their parent session:
+  // the PR's implementation task already delivers them, and a duplicate from
+  // the attached review task would double-announce in the same session.
+  if (isPrReviewPayload(params.run.payload)) {
     return;
   }
 

--- a/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-settle.ts
+++ b/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-settle.ts
@@ -1,6 +1,10 @@
 import { redactSecrets } from '@roomote/communication/redact-secrets';
 import { canRetryFailedStart, getTaskUrl } from '@roomote/cloud-agents/server';
-import { RunStatus, getFastAgentParentFromPayload } from '@roomote/types';
+import {
+  RunStatus,
+  getFastAgentParentFromPayload,
+  isPrReviewPayload,
+} from '@roomote/types';
 import {
   type TaskRun,
   and,
@@ -50,6 +54,13 @@ export async function notifyFastAgentParentOnSettle(
 ): Promise<void> {
   const parent = getFastAgentParentFromPayload(run.payload);
   if (!parent) {
+    return;
+  }
+
+  // A review child is attached to the session for visibility only: its
+  // outcome reaches the session through the PR feedback relay and the PR
+  // summary comment, so only failures announce here.
+  if (isPrReviewPayload(run.payload) && status !== RunStatus.Failed) {
     return;
   }
 

--- a/packages/types/src/fast-agent.ts
+++ b/packages/types/src/fast-agent.ts
@@ -195,6 +195,23 @@ export function buildFastAgentChildTaskMetadata(parent: FastAgentParent): {
   };
 }
 
+/**
+ * Session linkage without orchestrator report ownership: the task shows up in
+ * the parent Fast session (session_tasks + the fast task list) and can emit
+ * parent events, but keeps its own workflow's report and communication
+ * behavior. Used for review-pipeline tasks attached to the session whose
+ * delegated work opened the reviewed PR.
+ */
+export function buildFastAgentSessionAttachment(parent: FastAgentParent): {
+  fastAgentSessionId: string;
+  fastAgentParent: FastAgentParent;
+} {
+  return {
+    fastAgentSessionId: parent.sessionId,
+    fastAgentParent: parent,
+  };
+}
+
 export function getFastAgentParentFromPayload(
   payload: unknown,
 ): FastAgentParent | null {

--- a/packages/types/src/task-runs.ts
+++ b/packages/types/src/task-runs.ts
@@ -537,6 +537,20 @@ export function shouldUseAppTokenOnly(type: TaskPayloadKind): boolean {
 }
 
 /**
+ * Review-pipeline payloads carry a Fast parent only for session visibility:
+ * review outcomes reach the session through the reviewed PR's feedback relay
+ * and the PR summary comment, so review runs stay quiet on the parent-event
+ * channel except for failures.
+ */
+export function isPrReviewPayload(payload: unknown): boolean {
+  const type = (payload as { type?: string } | null | undefined)?.type;
+  return (
+    type === TaskPayloadKind.GithubPrReview ||
+    type === TaskPayloadKind.GithubPrReviewSync
+  );
+}
+
+/**
  * CodingHarness
  */
 


### PR DESCRIPTION
When a webhook-triggered PR review targets a PR that was opened by a session-delegated task, the review task now attaches to that same Fast session instead of spawning an unrelated session of its own. The review shows up in the session's task list and workspace across all five source-control providers.

- `getPrOriginFastAgentParent` (cloud-agents) resolves the PR-opening task's Fast parent by provider/host; `getLinkedTaskRelayState` now surfaces the parent it already loads, and the GitHub review relay payload carries the session attachment so PR-open and PR-synchronize launches inherit it. GitLab/Bitbucket/Gitea/ADO handlers resolve it directly at enqueue.
- `buildFastAgentSessionAttachment` (types) stamps only `fastAgentParent` + `fastAgentSessionId` — session visibility without the orchestrator report ownership that full Fast delegation implies.
- Review runs stay quiet on the parent-event channel: successful settles, PR feedback, PR status changes, and conflict events are suppressed for review payloads (the implementation task already delivers those to the session, and the review's substance lives in the PR summary comment and the existing feedback relay). Failed review settles still announce. The PR-review notification job also refuses to route action buttons through a review run's parent.

Follow-up (separate PR): letting a session launch the structured review pipeline on demand.