### PR TITLE
docs: describe on-demand pull request reviews from Sessions and mentions

### DIFF
--- a/apps/docs/fast-sessions.mdx
+++ b/apps/docs/fast-sessions.mdx
@@ -12,6 +12,10 @@ orchestrator inside a Session: it answers directly when it can and delegates
 execution work when needed across Slack, Discord, Microsoft Teams, Telegram,
 automations, and the web dashboard.
 
+A Session can also run Roomote's structured code review on demand. Ask it to
+review a pull request and the Review Code pipeline runs as a task inside the
+Session; in a pull request discussion, it reviews that pull request.
+
 ## Start a Session from the dashboard
 
 On the home page, leave the workspace selector on **Fast** to start a

--- a/apps/docs/how-roomote-works.mdx
+++ b/apps/docs/how-roomote-works.mdx
@@ -38,6 +38,10 @@ with merge-conflict resolution when the relevant automation is enabled. Admins
 manage these in the web app under **Automations** — see
 [Automations](/automations).
 
+The same review is available on demand. Mention Roomote on a pull request and
+ask for a review, or ask in any Session, and the Review Code pipeline runs as a
+task inside that Session and reports back when it finishes.
+
 ## Where work starts
 
 | Surface       | How work starts                                            | Where updates appear                    |

--- a/apps/docs/providers/source-control/azure-devops.mdx
+++ b/apps/docs/providers/source-control/azure-devops.mdx
@@ -133,7 +133,10 @@ reads the discussion, answers as a comment when no workspace is needed, and
 otherwise starts a task on the pull request's source branch (or the project's
 mapped repository for a work item) and reports back in the same discussion.
 Pull request replies stay in the comment thread the mention came from. The
-commenter must have a linked Azure DevOps account.
+commenter must have a linked Azure DevOps account. Ask for a review in the
+mention (for example `@roomote review this`) and Roomote runs the Review Code
+automation's structured review on the current head, posts the findings on the
+pull request, and reports back in the same discussion.
 
 ## Current limits
 

--- a/apps/docs/providers/source-control/bitbucket.mdx
+++ b/apps/docs/providers/source-control/bitbucket.mdx
@@ -55,7 +55,10 @@ pull request. Each pull request is a Roomote Session: Roomote reads the
 discussion, answers as a comment when no workspace is needed, and otherwise
 starts a task on the pull request's source branch and reports back in the same
 discussion. Mention it again to redirect it, ask a follow-up, or steer a
-running task. The commenter must have a linked Bitbucket account.
+running task. The commenter must have a linked Bitbucket account. Ask for a
+review in the mention (for example `@roomote review this`) and Roomote runs the
+Review Code automation's structured review on the current head, posts the
+findings on the pull request, and reports back in the same discussion.
 
 ## Personal account linking
 

--- a/apps/docs/providers/source-control/gitea.mdx
+++ b/apps/docs/providers/source-control/gitea.mdx
@@ -108,7 +108,10 @@ discussion, answers as a comment when no workspace is needed, and otherwise
 starts a task on the pull request's head branch (or the issue's repository)
 and reports back in the same discussion. Mention it again to redirect it, ask a
 follow-up, or steer a running task. The commenter must have a linked Gitea
-account.
+account. Ask for a review in the mention (for example `@roomote review this`)
+and Roomote runs the Review Code automation's structured review on the current
+head, posts the findings on the pull request, and reports back in the same
+discussion.
 
 ## Current limits
 

--- a/apps/docs/providers/source-control/github.mdx
+++ b/apps/docs/providers/source-control/github.mdx
@@ -228,6 +228,10 @@ answers as a comment when no workspace is needed, and otherwise starts a task
 on the pull request's branch (or the issue's repository) and reports back in
 the same discussion. Mention it again to redirect it, ask a follow-up, or
 steer a running task. Replies to a review comment stay in that review thread.
+Ask for a review in the mention (for example `@roomote review this`) and
+Roomote runs the Review Code automation's structured review on the current
+head, posts the findings on the pull request, and reports back in the same
+discussion.
 
 When a Roomote task opens a pull request, actionable review feedback returns to
 the owning Session and appears in both Fast and standard web task transcripts.

--- a/apps/docs/providers/source-control/gitlab.mdx
+++ b/apps/docs/providers/source-control/gitlab.mdx
@@ -82,6 +82,10 @@ Roomote Session: Roomote reads the discussion, answers as a note when no
 workspace is needed, and otherwise starts a task on the merge request's source
 branch (or the issue's repository) and reports back in the same discussion.
 Mention it again to redirect it, ask a follow-up, or steer a running task.
+Ask for a review in the mention (for example `@roomote review this`) and
+Roomote runs the Review Code automation's structured review on the current
+head, posts the findings on the merge request, and reports back in the same
+discussion.
 
 ## Enable review automation
 


### PR DESCRIPTION
## What changed

- Source-control provider pages (GitHub, GitLab, Bitbucket, Azure DevOps, Gitea): the mention sections now say that asking for a review in a mention runs the Review Code automation's structured review on the current head, posts the findings on the pull request, and reports back in the discussion.
- Sessions page and How Roomote works: note that the same review is available on demand from any Session and runs as a task inside it.

## Why

#2151 added the `review_pull_request` Fast tool, so a Session or a pull request mention can trigger the structured review pipeline again. The public docs still only described automatic reviews.

## Validation

Prose-only change under `apps/docs`; no code paths touched.