### PR TITLE
feat: deep-link Session artifacts from create_artifact results and copy-link

### DIFF
--- a/apps/docs/fast-sessions.mdx
+++ b/apps/docs/fast-sessions.mdx
@@ -46,7 +46,9 @@ timeline shows the live task count. Select that activity to open the **Tasks**
 panel. The **Artifacts** panel combines the latest uploaded outputs from every
 task with documents created directly during the conversation, labels each item
 by its Session or task source, and opens previews without leaving the Session.
-Individual task details continue to show their own artifacts.
+Links to a Session-created artifact, including the link the Session shares when
+it creates one, open that artifact directly in the Artifacts panel. Individual
+task details continue to show their own artifacts.
 
 **Session info** shows the total inference cost for the conversation and its
 attached tasks. Open the cost breakdown to separate direct Session orchestration

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.client.test.tsx
@@ -829,6 +829,95 @@ describe('SessionWorkspace', () => {
     );
   });
 
+  it('opens a deep-linked Session artifact without a click and clears the link on back', async () => {
+    artifactQueryState.dataByPath['session-1:notes/decision.md'] = {
+      id: 'session-artifact',
+      taskId: null,
+      sessionId: 'session-1',
+      path: 'notes/decision.md',
+      version: 1,
+      artifactType: 'general',
+      contentType: 'text/markdown',
+      size: 100,
+      createdAt: new Date('2026-01-05T00:00:00.000Z'),
+      downloadUrl: '/api/artifacts/session-artifact/download',
+    };
+    renderWorkspace({
+      isMobile: false,
+      searchParams: 'artifact=notes%2Fdecision.md&v=1',
+      sessionOverride: {
+        artifacts: [
+          {
+            id: 'session-artifact',
+            path: 'notes/decision.md',
+            version: 2,
+            artifactType: 'general',
+            contentType: 'text/markdown',
+            size: 100,
+            createdAt: new Date('2026-01-05T00:00:00.000Z'),
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByRole('heading', { name: 'Decision' })).toBeVisible();
+    expect(
+      screen.queryByRole('button', { name: 'Open Decision from Session' }),
+    ).toBeNull();
+    await waitFor(() =>
+      expect(artifactQueryInputs).toContainEqual({
+        sessionId: 'session-1',
+        path: 'notes/decision.md',
+        version: 1,
+      }),
+    );
+    expect(routerReplaceMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to artifacts' }));
+
+    expect(routerReplaceMock).toHaveBeenCalledWith('/sessions/session-1');
+    expect(
+      screen.getByRole('button', { name: 'Open Decision from Session' }),
+    ).toBeVisible();
+  });
+
+  it('shows the artifact gallery when a deep link matches no Session artifact', () => {
+    renderWorkspace({
+      isMobile: false,
+      searchParams: 'artifact=notes%2Fmissing.md&v=1',
+    });
+
+    expect(screen.getByRole('heading', { name: 'Artifacts' })).toBeVisible();
+    expect(screen.getByText('No artifacts in this session yet.')).toBeVisible();
+    expect(artifactQueryInputs).toEqual([]);
+    expect(routerReplaceMock).not.toHaveBeenCalled();
+  });
+
+  it('leaves the side panel to the URL-selected task when a deep link also names an artifact', () => {
+    renderWorkspace({
+      isMobile: false,
+      queriedTasks: [singleTask],
+      searchParams: 'task=task-1&artifact=notes%2Fdecision.md&v=1',
+      sessionOverride: {
+        tasks: [singleTask],
+        artifacts: [
+          {
+            id: 'session-artifact',
+            path: 'notes/decision.md',
+            version: 1,
+            artifactType: 'general',
+            contentType: 'text/markdown',
+            size: 100,
+            createdAt: new Date('2026-01-05T00:00:00.000Z'),
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByLabelText('Full task task-1')).toBeVisible();
+    expect(screen.queryByRole('heading', { name: 'Decision' })).toBeNull();
+  });
+
   it('aggregates latest artifacts per task and preserves duplicate paths across tasks', async () => {
     const sharedPath = 'reports/result.md';
     const firstTask = {

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.tsx
@@ -26,6 +26,10 @@ import {
   getUserDisplayName,
   humanizeFilename,
 } from '@/lib';
+import {
+  parseSessionArtifactSearchParams,
+  type SessionArtifactSelection,
+} from '@/lib/artifact-view-urls';
 import { getSessionPullRequests } from '@/lib/session-pull-requests';
 import { SessionInferenceCostBreakdown } from '@/components/sessions/SessionInferenceCostBreakdown';
 import { PullRequestBadge } from '@/components/sandbox';
@@ -419,24 +423,52 @@ function SessionArtifactViewer({
   );
 }
 
+type SessionArtifactViewerSelection = {
+  owner: { taskId: string } | { sessionId: string };
+  path: string;
+  version?: number;
+};
+
 function SessionArtifactsPanel({
   tasks,
   sessionId,
   sessionArtifacts,
+  initialSelection,
+  onDeselect,
   onClose,
 }: {
   tasks: SessionArtifactTask[];
   sessionId: string;
   sessionArtifacts: SessionArtifact[];
+  /**
+   * Session-owned artifact requested by the page URL. Preselects the matching
+   * gallery entry on mount; an unmatched request falls back to the gallery.
+   */
+  initialSelection?: SessionArtifactSelection | null;
+  /** Called when the viewer returns to the gallery. */
+  onDeselect?: () => void;
   onClose: () => void;
 }) {
-  const [selectedArtifact, setSelectedArtifact] =
-    useState<SessionArtifactEntry | null>(null);
   const artifacts = getLatestSessionArtifacts(
     tasks,
     sessionId,
     sessionArtifacts,
   );
+  const [selectedArtifact, setSelectedArtifact] =
+    useState<SessionArtifactViewerSelection | null>(() => {
+      if (!initialSelection) return null;
+      const entry = artifacts.find(
+        ({ owner, artifact }) =>
+          'sessionId' in owner && artifact.path === initialSelection.path,
+      );
+      return entry
+        ? {
+            owner: entry.owner,
+            path: entry.artifact.path,
+            version: initialSelection.version ?? entry.artifact.version,
+          }
+        : null;
+    });
   const artifactSections = [
     {
       label: 'Screenshots',
@@ -467,14 +499,13 @@ function SessionArtifactsPanel({
     >
       {selectedArtifact ? (
         <SessionArtifactViewer
-          selection={{
-            owner: selectedArtifact.owner,
-            path: selectedArtifact.artifact.path,
-            version: selectedArtifact.artifact.version,
-          }}
+          selection={selectedArtifact}
           backLabel="Back to artifacts"
           closeLabel="Close artifacts"
-          onBack={() => setSelectedArtifact(null)}
+          onBack={() => {
+            setSelectedArtifact(null);
+            onDeselect?.();
+          }}
           onClose={onClose}
         />
       ) : (
@@ -504,7 +535,13 @@ function SessionArtifactsPanel({
                               key={`${'taskId' in entry.owner ? `task:${entry.owner.taskId}` : `session:${entry.owner.sessionId}`}:${entry.artifact.path}`}
                               artifact={entry.artifact}
                               taskTitle={entry.taskTitle}
-                              onOpen={() => setSelectedArtifact(entry)}
+                              onOpen={() =>
+                                setSelectedArtifact({
+                                  owner: entry.owner,
+                                  path: entry.artifact.path,
+                                  version: entry.artifact.version,
+                                })
+                              }
                             />
                           ))}
                         </div>
@@ -750,12 +787,21 @@ export function SessionWorkspace({
   session: SessionInfo;
   children: ReactNode;
 }) {
-  // Exactly one local side panel can be active. A URL-selected task normally
-  // takes precedence, except while its artifact detail temporarily overlays it.
-  const [panel, setPanel] = useState<WorkspacePanel | null>(null);
   const trpc = useTRPC();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const selectedTaskId = searchParams.get('task');
+  // A `?artifact=<path>&v=<version>` link (the create_artifact result and the
+  // viewer's copy-link URL) opens the Session-owned artifact in the Artifacts
+  // panel unless a URL-selected task already owns the side panel.
+  const requestedArtifact = selectedTaskId
+    ? null
+    : parseSessionArtifactSearchParams(searchParams);
+  // Exactly one local side panel can be active. A URL-selected task normally
+  // takes precedence, except while its artifact detail temporarily overlays it.
+  const [panel, setPanel] = useState<WorkspacePanel | null>(() =>
+    requestedArtifact ? { kind: 'artifacts' } : null,
+  );
   const isFastTaskSource = session.taskSource === 'fast';
   const { data: currentSession } = useQuery(
     trpc.sessions.byId.queryOptions(
@@ -797,7 +843,6 @@ export function SessionWorkspace({
   );
   const singleRunningTaskId =
     runningTaskCount === 1 ? runningTasks[0]?.taskId : null;
-  const selectedTaskId = searchParams.get('task');
   const selectedTask = taskCards.find((task) => task.taskId === selectedTaskId);
   const panelOpen = panel !== null || Boolean(selectedTask);
   const isMdOrLarger = useMediaQuery('(min-width: 768px)', {
@@ -827,17 +872,36 @@ export function SessionWorkspace({
     };
   }, [isMdOrLarger, panel, runningTaskCount, selectedTask, taskCards.length]);
 
-  const selectTask = useCallback(
-    (taskId: string | null) => {
-      if (taskId === selectedTaskId) return;
-
+  const replaceSearchParams = useCallback(
+    (update: (params: URLSearchParams) => void) => {
       const params = new URLSearchParams(searchParams);
-      if (taskId) params.set('task', taskId);
-      else params.delete('task');
+      update(params);
       const query = params.toString();
+      if (query === searchParams.toString()) return;
       router.replace(`/sessions/${session.id}${query ? `?${query}` : ''}`);
     },
-    [router, searchParams, selectedTaskId, session.id],
+    [router, searchParams, session.id],
+  );
+  // Leaving the deep-linked artifact drops it from the URL so a refresh does
+  // not reopen it.
+  const clearRequestedArtifact = useCallback(
+    () =>
+      replaceSearchParams((params) => {
+        params.delete('artifact');
+        params.delete('v');
+      }),
+    [replaceSearchParams],
+  );
+  const selectTask = useCallback(
+    (taskId: string | null) =>
+      replaceSearchParams((params) => {
+        if (taskId) params.set('task', taskId);
+        else params.delete('task');
+        // Any side-panel change moves away from the deep-linked artifact.
+        params.delete('artifact');
+        params.delete('v');
+      }),
+    [replaceSearchParams],
   );
 
   const openTaskPanel = useCallback(
@@ -926,6 +990,8 @@ export function SessionWorkspace({
         tasks={artifactTasks}
         sessionId={session.id}
         sessionArtifacts={session.artifacts ?? []}
+        initialSelection={requestedArtifact}
+        onDeselect={clearRequestedArtifact}
         onClose={closePanel}
       />
     ) : panel?.kind === 'previews' ? (

--- a/apps/web/src/components/tasks/ArtifactViewerContent.tsx
+++ b/apps/web/src/components/tasks/ArtifactViewerContent.tsx
@@ -12,6 +12,10 @@ import type { ArtifactWithContent } from '@/types';
 
 import { useTRPC, useTRPCClient } from '@/trpc/client';
 
+import {
+  getArtifactViewUrl,
+  getSessionArtifactViewUrl,
+} from '@/lib/artifact-view-urls';
 import { cn } from '@/lib/utils';
 
 import {
@@ -114,16 +118,6 @@ function isHtmlArtifact(contentType: string, path: string): boolean {
     extension === 'htm' ||
     extension === 'xhtml'
   );
-}
-
-function getArtifactViewUrl(
-  origin: string,
-  taskId: string,
-  path: string,
-  version: number,
-): string {
-  const search = new URLSearchParams({ path, v: String(version) });
-  return `${origin}/task/${encodeURIComponent(taskId)}/artifacts?${search}`;
 }
 
 interface ArtifactViewerContentProps {
@@ -269,14 +263,20 @@ export function ArtifactViewerContent({
   };
 
   const handleCopyUrl = async () => {
-    const url = taskId
-      ? getArtifactViewUrl(
-          window.location.origin,
-          taskId,
-          artifact.path,
-          artifact.version,
-        )
-      : `${window.location.origin}/sessions/${'sessionId' in artifactOwner ? artifactOwner.sessionId : ''}`;
+    const url =
+      'taskId' in artifactOwner
+        ? getArtifactViewUrl(
+            window.location.origin,
+            artifactOwner.taskId,
+            artifact.path,
+            artifact.version,
+          )
+        : getSessionArtifactViewUrl(
+            window.location.origin,
+            artifactOwner.sessionId,
+            artifact.path,
+            artifact.version,
+          );
     await navigator.clipboard.writeText(url);
     setIsUrlCopied(true);
     toast.success('URL copied to clipboard');

--- a/apps/web/src/lib/artifact-view-urls.test.ts
+++ b/apps/web/src/lib/artifact-view-urls.test.ts
@@ -1,0 +1,65 @@
+import {
+  getArtifactViewUrl,
+  getSessionArtifactViewUrl,
+  parseSessionArtifactSearchParams,
+} from './artifact-view-urls';
+
+describe('getArtifactViewUrl', () => {
+  it('links to the task artifacts view with the path and version', () => {
+    expect(
+      getArtifactViewUrl('https://roomote.example', 'task-1', 'notes/a.md', 2),
+    ).toBe(
+      'https://roomote.example/task/task-1/artifacts?path=notes%2Fa.md&v=2',
+    );
+  });
+});
+
+describe('getSessionArtifactViewUrl', () => {
+  it('links to the Session with the artifact path and version', () => {
+    expect(
+      getSessionArtifactViewUrl(
+        'https://roomote.example',
+        'session-1',
+        'notes/decision.md',
+        1,
+      ),
+    ).toBe(
+      'https://roomote.example/sessions/session-1?artifact=notes%2Fdecision.md&v=1',
+    );
+  });
+
+  it('round-trips through the search param parser', () => {
+    const url = new URL(
+      getSessionArtifactViewUrl('https://roomote.example', 's', 'a b/c.md', 3),
+    );
+
+    expect(parseSessionArtifactSearchParams(url.searchParams)).toEqual({
+      path: 'a b/c.md',
+      version: 3,
+    });
+  });
+});
+
+describe('parseSessionArtifactSearchParams', () => {
+  it('returns null without an artifact param', () => {
+    expect(parseSessionArtifactSearchParams(new URLSearchParams('v=1'))).toBe(
+      null,
+    );
+    expect(
+      parseSessionArtifactSearchParams(new URLSearchParams('artifact=')),
+    ).toBe(null);
+  });
+
+  it('drops versions that are not positive integers', () => {
+    for (const v of ['', '0', '-1', '1.5', 'latest']) {
+      expect(
+        parseSessionArtifactSearchParams(
+          new URLSearchParams({ artifact: 'notes/a.md', v }),
+        ),
+      ).toEqual({ path: 'notes/a.md' });
+    }
+    expect(
+      parseSessionArtifactSearchParams(new URLSearchParams('artifact=a.md')),
+    ).toEqual({ path: 'a.md' });
+  });
+});

--- a/apps/web/src/lib/artifact-view-urls.ts
+++ b/apps/web/src/lib/artifact-view-urls.ts
@@ -1,0 +1,54 @@
+/**
+ * Deep link to a task artifact in the task workspace:
+ * `/task/<taskId>/artifacts?path=<path>&v=<version>`.
+ */
+export function getArtifactViewUrl(
+  origin: string,
+  taskId: string,
+  path: string,
+  version: number,
+): string {
+  const search = new URLSearchParams({ path, v: String(version) });
+  return `${origin}/task/${encodeURIComponent(taskId)}/artifacts?${search}`;
+}
+
+/**
+ * Deep link to a Session-owned artifact in the Session Artifacts panel:
+ * `/sessions/<sessionId>?artifact=<path>&v=<version>`.
+ *
+ * The sdk builds the same shape as a plain template in
+ * `packages/sdk/src/server/lib/artifacts/create-session-artifact.ts` for
+ * `create_artifact` tool results; keep the two in sync.
+ */
+export function getSessionArtifactViewUrl(
+  origin: string,
+  sessionId: string,
+  path: string,
+  version: number,
+): string {
+  const search = new URLSearchParams({ artifact: path, v: String(version) });
+  return `${origin}/sessions/${encodeURIComponent(sessionId)}?${search}`;
+}
+
+export type SessionArtifactSelection = {
+  path: string;
+  /** Requested version; omitted when the link points at the latest version. */
+  version?: number;
+};
+
+/**
+ * Reads the Session artifact deep link (`artifact` and `v`) from the Session
+ * page search params. Returns null when no artifact is requested.
+ */
+export function parseSessionArtifactSearchParams(
+  searchParams: URLSearchParams,
+): SessionArtifactSelection | null {
+  const path = searchParams.get('artifact');
+  if (!path) return null;
+
+  const rawVersion = searchParams.get('v');
+  const version = rawVersion === null ? Number.NaN : Number(rawVersion);
+  return Number.isInteger(version) && version > 0
+    ? { path, version }
+    : { path };
+}

--- a/packages/sdk/src/server/lib/artifacts/__tests__/create-session-artifact.test.ts
+++ b/packages/sdk/src/server/lib/artifacts/__tests__/create-session-artifact.test.ts
@@ -93,7 +93,9 @@ describe('createSessionArtifact', () => {
     const session = await getSessionForFastConversation(db, conversation!.id);
 
     expect(session).not.toBeNull();
-    expect(artifact.viewUrl).toContain(`/sessions/${session!.id}`);
+    const viewUrl = new URL(artifact.viewUrl);
+    expect(viewUrl.pathname).toBe(`/sessions/${session!.id}`);
+    expect(viewUrl.search).toBe('?artifact=notes%2Fresult.md&v=1');
     const [row] = await db
       .select()
       .from(taskArtifacts)

--- a/packages/sdk/src/server/lib/artifacts/create-session-artifact.ts
+++ b/packages/sdk/src/server/lib/artifacts/create-session-artifact.ts
@@ -92,7 +92,9 @@ export async function createFastAgentSessionArtifact(
     artifactType: artifact.artifactType as 'general' | 'plan',
     contentType: artifact.contentType,
     size: artifact.size,
-    viewUrl: `${baseUrl}/sessions/${input.sessionId}`,
+    // Deep link into the Session Artifacts panel; mirrors
+    // getSessionArtifactViewUrl in apps/web/src/lib/artifact-view-urls.ts.
+    viewUrl: `${baseUrl}/sessions/${input.sessionId}?artifact=${encodeURIComponent(artifact.path)}&v=${artifact.version}`,
   };
 }
 


### PR DESCRIPTION
## What changed

- Session-owned artifacts now have a deep link: `/sessions/<sessionId>?artifact=<path>&v=<version>`. The `create_artifact` tool result (`viewUrl`) and the viewer's copy-link button for Session artifacts both use it.
- The Session workspace reads `artifact` and `v` from the URL. When present (and no `?task=` is selected), it opens the Artifacts panel with that Session-owned artifact preselected at the requested version. An unmatched path shows the normal gallery. Leaving the artifact (back, close, or switching panels) strips the params so a refresh does not reopen it.
- `getArtifactViewUrl` moves from `ArtifactViewerContent.tsx` into `apps/web/src/lib/artifact-view-urls.ts` alongside the new `getSessionArtifactViewUrl` and `parseSessionArtifactSearchParams`.
- Docs: the Sessions page notes that links to Session-created artifacts open them directly.

## Why

#2143 listed as a remaining limitation that the returned artifact link only opened the owning Session, leaving the reader to find the artifact in the panel.

## Validation

- New unit tests for the URL builders and parser, the sdk `viewUrl` shape, and three Session workspace cases (deep link opens the viewer with no click and Back clears the URL; unmatched path shows the gallery; `?task=` takes precedence).
- `check-types` for web and sdk, `oxlint`, residual `eslint`, and `oxfmt` pass.