### PR TITLE
feat(github): treat replies in Roomote's review threads as mentions on human-opened pull requests

### DIFF
--- a/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
@@ -14,7 +14,9 @@ vi.mock('@roomote/db/server', () => ({
 
 vi.mock('@roomote/github', () => ({
   Schemas: {
-    isRoomoteGitHubLogin: vi.fn(() => false),
+    isRoomoteGitHubLogin: vi.fn(
+      (login: string) => login === 'roomote' || login === 'roomote[bot]',
+    ),
   },
   getEffectiveGitHubAppSlug: vi.fn(() => 'roomote'),
   isGitHubRoomoteMentionEnabled: vi.fn(() => true),
@@ -321,5 +323,117 @@ describe('handlePrComment', () => {
 
     expect(result).toEqual({ status: 'ok', message: 'no_mention' });
     expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
+  });
+
+  describe('replies in a review thread Roomote opened', () => {
+    function makeRoomoteThreadReplyPayload(): WebhookPullRequestCommentCreated {
+      const payload = makeReviewCommentPayload();
+      payload.comment.body = 'Can you make this loop bounded instead?';
+      return payload;
+    }
+
+    beforeEach(() => {
+      request.mockImplementation(async (route: string) => {
+        if (route.startsWith('GET /repos/{owner}/{repo}/pulls/comments/')) {
+          return {
+            data: {
+              id: 800,
+              body: 'This loop never terminates.',
+              path: 'src/retry.ts',
+              diff_hunk: '@@ -1 +1 @@\n-old\n+new',
+              user: { login: 'roomote[bot]' },
+            },
+          };
+        }
+        return { data: {} };
+      });
+    });
+
+    it('enters the Session without an @mention when no task owns the pull request', async () => {
+      const result = await handlePrComment(makeRoomoteThreadReplyPayload());
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          status: 'ok',
+          message: 'fast_session_queued',
+        }),
+      );
+      expect(mocks.findReusableGitHubPrFollowUpOwner).toHaveBeenCalledWith({
+        repoFullName: 'acme/api',
+        prNumber: 42,
+        branchName: 'feature/ship',
+        host: 'github.com',
+      });
+      // The gate's fetch is reused for the context; the parent is not
+      // fetched a second time.
+      expect(
+        request.mock.calls.filter(([route]) =>
+          String(route).startsWith('GET /repos/{owner}/{repo}/pulls/comments/'),
+        ),
+      ).toHaveLength(1);
+      expect(createForPullRequestReviewComment).toHaveBeenCalledWith(
+        expect.objectContaining({ comment_id: 900, content: 'eyes' }),
+      );
+      expect(mocks.startSourceControlFastSessionTurn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          discussion: expect.objectContaining({
+            kind: 'pull',
+            number: 42,
+            reviewCommentId: '800',
+          }),
+          question: 'Can you make this loop bounded instead?',
+          agentContext: expect.stringContaining(
+            "alice replied to Roomote's review comment #800",
+          ),
+        }),
+      );
+    });
+
+    it('leaves replies on a Roomote-opened pull request to the review-feedback pipeline', async () => {
+      mocks.findReusableGitHubPrFollowUpOwner.mockResolvedValue({
+        taskId: 'task-owner',
+        runId: 5,
+        status: 'running',
+        taskPhase: null,
+        delivery: 'attach',
+      });
+
+      const result = await handlePrComment(makeRoomoteThreadReplyPayload());
+
+      expect(result).toEqual({ status: 'ok', message: 'no_mention' });
+      expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
+      expect(createForPullRequestReviewComment).not.toHaveBeenCalled();
+    });
+
+    it('ignores replies to review comments written by people', async () => {
+      request.mockImplementation(async (route: string) => {
+        if (route.startsWith('GET /repos/{owner}/{repo}/pulls/comments/')) {
+          return {
+            data: {
+              id: 800,
+              body: 'This loop never terminates.',
+              user: { login: 'carol' },
+            },
+          };
+        }
+        return { data: {} };
+      });
+
+      const result = await handlePrComment(makeRoomoteThreadReplyPayload());
+
+      expect(result).toEqual({ status: 'ok', message: 'no_mention' });
+      expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
+    });
+
+    it('ignores top-level review comments without a mention', async () => {
+      const payload = makeRoomoteThreadReplyPayload();
+      delete (payload.comment as { in_reply_to_id?: number }).in_reply_to_id;
+
+      const result = await handlePrComment(payload);
+
+      expect(result).toEqual({ status: 'ok', message: 'no_mention' });
+      expect(request).not.toHaveBeenCalled();
+      expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
@@ -2,6 +2,7 @@ const mocks = vi.hoisted(() => ({
   getGitHubAutomationTargets: vi.fn(),
   getInstallationOctokit: vi.fn(),
   findActiveGitHubPrReviewTask: vi.fn(),
+  findGitHubPullRequestLinkedTask: vi.fn(),
   findReusableGitHubPrFollowUpOwner: vi.fn(),
   startSourceControlFastSessionTurn: vi.fn(),
   fetchGitHubLinkedReferences: vi.fn(),
@@ -9,6 +10,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@roomote/db/server', () => ({
   findActiveGitHubPrReviewTask: mocks.findActiveGitHubPrReviewTask,
+  findGitHubPullRequestLinkedTask: mocks.findGitHubPullRequestLinkedTask,
   findReusableGitHubPrFollowUpOwner: mocks.findReusableGitHubPrFollowUpOwner,
 }));
 
@@ -164,6 +166,7 @@ describe('handlePrComment', () => {
     });
     mocks.findActiveGitHubPrReviewTask.mockResolvedValue(null);
     mocks.findReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
+    mocks.findGitHubPullRequestLinkedTask.mockResolvedValue(null);
     mocks.fetchGitHubLinkedReferences.mockResolvedValue([]);
     mocks.startSourceControlFastSessionTurn.mockResolvedValue({
       status: 'queued',
@@ -358,10 +361,9 @@ describe('handlePrComment', () => {
           message: 'fast_session_queued',
         }),
       );
-      expect(mocks.findReusableGitHubPrFollowUpOwner).toHaveBeenCalledWith({
+      expect(mocks.findGitHubPullRequestLinkedTask).toHaveBeenCalledWith({
         repoFullName: 'acme/api',
         prNumber: 42,
-        branchName: 'feature/ship',
         host: 'github.com',
       });
       // The gate's fetch is reused for the context; the parent is not
@@ -389,13 +391,15 @@ describe('handlePrComment', () => {
       );
     });
 
-    it('leaves replies on a Roomote-opened pull request to the review-feedback pipeline', async () => {
-      mocks.findReusableGitHubPrFollowUpOwner.mockResolvedValue({
+    it('leaves replies on a Roomote-opened pull request to the review-feedback pipeline, even after its task finished', async () => {
+      // The opening task is done and has no resumable snapshot, so the
+      // active-owner lookup finds nothing; the durable PR linkage still does.
+      mocks.findReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
+      mocks.findGitHubPullRequestLinkedTask.mockResolvedValue({
         taskId: 'task-owner',
         runId: 5,
-        status: 'running',
-        taskPhase: null,
-        delivery: 'attach',
+        type: 'standard_task',
+        status: 'completed',
       });
 
       const result = await handlePrComment(makeRoomoteThreadReplyPayload());

--- a/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
@@ -2,7 +2,7 @@ const mocks = vi.hoisted(() => ({
   getGitHubAutomationTargets: vi.fn(),
   getInstallationOctokit: vi.fn(),
   findActiveGitHubPrReviewTask: vi.fn(),
-  findGitHubPullRequestLinkedTask: vi.fn(),
+  findRoomoteOpenedPullRequestTask: vi.fn(),
   findReusableGitHubPrFollowUpOwner: vi.fn(),
   startSourceControlFastSessionTurn: vi.fn(),
   fetchGitHubLinkedReferences: vi.fn(),
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@roomote/db/server', () => ({
   findActiveGitHubPrReviewTask: mocks.findActiveGitHubPrReviewTask,
-  findGitHubPullRequestLinkedTask: mocks.findGitHubPullRequestLinkedTask,
+  findRoomoteOpenedPullRequestTask: mocks.findRoomoteOpenedPullRequestTask,
   findReusableGitHubPrFollowUpOwner: mocks.findReusableGitHubPrFollowUpOwner,
 }));
 
@@ -166,7 +166,7 @@ describe('handlePrComment', () => {
     });
     mocks.findActiveGitHubPrReviewTask.mockResolvedValue(null);
     mocks.findReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
-    mocks.findGitHubPullRequestLinkedTask.mockResolvedValue(null);
+    mocks.findRoomoteOpenedPullRequestTask.mockResolvedValue(null);
     mocks.fetchGitHubLinkedReferences.mockResolvedValue([]);
     mocks.startSourceControlFastSessionTurn.mockResolvedValue({
       status: 'queued',
@@ -361,7 +361,7 @@ describe('handlePrComment', () => {
           message: 'fast_session_queued',
         }),
       );
-      expect(mocks.findGitHubPullRequestLinkedTask).toHaveBeenCalledWith({
+      expect(mocks.findRoomoteOpenedPullRequestTask).toHaveBeenCalledWith({
         repoFullName: 'acme/api',
         prNumber: 42,
         host: 'github.com',
@@ -395,7 +395,7 @@ describe('handlePrComment', () => {
       // The opening task is done and has no resumable snapshot, so the
       // active-owner lookup finds nothing; the durable PR linkage still does.
       mocks.findReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
-      mocks.findGitHubPullRequestLinkedTask.mockResolvedValue({
+      mocks.findRoomoteOpenedPullRequestTask.mockResolvedValue({
         taskId: 'task-owner',
         runId: 5,
         type: 'standard_task',

--- a/apps/api/src/handlers/github/handlePrComment.ts
+++ b/apps/api/src/handlers/github/handlePrComment.ts
@@ -2,7 +2,10 @@ import {
   findActiveGitHubPrReviewTask,
   findReusableGitHubPrFollowUpOwner,
 } from '@roomote/db/server';
-import { getInstallationOctokit } from '@roomote/github';
+import {
+  getInstallationOctokit,
+  Schemas as GitHubSchemas,
+} from '@roomote/github';
 import {
   startSourceControlFastSessionTurn,
   type SourceControlFastDiscussion,
@@ -357,11 +360,18 @@ function buildReviewReplyTriggeringComment({
   commentBody: string;
   parentComment: ReviewCommentSnapshot;
 }): string {
+  const parentIsRoomote = GitHubSchemas.isRoomoteGitHubLogin(
+    parentComment.userLogin,
+  );
   const lines = [
-    `${commenter} mentioned Roomote in a reply to review comment #${parentComment.id}:`,
+    parentIsRoomote
+      ? `${commenter} replied to Roomote's review comment #${parentComment.id}:`
+      : `${commenter} mentioned Roomote in a reply to review comment #${parentComment.id}:`,
     formatQuotedText(commentBody),
     '',
-    `${parentComment.userLogin} wrote the following review comment that this reply is in response to:`,
+    parentIsRoomote
+      ? `Roomote (${parentComment.userLogin}) wrote the following review comment that this reply is in response to:`
+      : `${parentComment.userLogin} wrote the following review comment that this reply is in response to:`,
     formatQuotedText(parentComment.body),
   ];
 
@@ -384,6 +394,7 @@ async function buildTriggeringCommentContext({
   repositoryFullName,
   commenter,
   commentBody,
+  parentComment: knownParentComment,
 }: {
   eventPayload:
     | WebhookPullRequestCommentCreated
@@ -393,16 +404,20 @@ async function buildTriggeringCommentContext({
   repositoryFullName: string;
   commenter: string;
   commentBody: string;
+  /** The review thread parent when the mention gate already fetched it. */
+  parentComment?: ReviewCommentSnapshot | null;
 }): Promise<string> {
   if ('comment' in eventPayload && 'pull_request' in eventPayload) {
     const reviewComment = eventPayload.comment;
 
     if (reviewComment.in_reply_to_id) {
-      const parentComment = await fetchReviewCommentSnapshot({
-        installationId,
-        repositoryFullName,
-        commentId: reviewComment.in_reply_to_id,
-      });
+      const parentComment =
+        knownParentComment ??
+        (await fetchReviewCommentSnapshot({
+          installationId,
+          repositoryFullName,
+          commentId: reviewComment.in_reply_to_id,
+        }));
 
       if (parentComment) {
         return buildReviewReplyTriggeringComment({
@@ -659,9 +674,63 @@ async function resolvePullRequestActiveTasks({
 }
 
 /**
+ * A reply inside a review thread Roomote opened is addressed to Roomote the
+ * way GitHub trains people to reply to a reviewer, so it counts as a mention
+ * without the @-handle. Only pull requests no Roomote task owns qualify: on a
+ * Roomote-opened pull request the review-feedback pipeline already batches
+ * these replies into the owning Session with its Resolve / Dismiss actions,
+ * and handling them here too would answer twice.
+ */
+async function resolveImplicitReviewThreadMention({
+  eventPayload,
+  installationId,
+}: {
+  eventPayload: PullRequestMentionEvent;
+  installationId: number;
+}): Promise<{ parentComment: ReviewCommentSnapshot } | null> {
+  if (!('comment' in eventPayload) || !('pull_request' in eventPayload)) {
+    return null;
+  }
+  const { comment, pull_request: pullRequest, repository } = eventPayload;
+  const commenterLogin = comment.user?.login;
+  if (
+    !comment.in_reply_to_id ||
+    !commenterLogin ||
+    GitHubSchemas.isRoomoteGitHubLogin(commenterLogin)
+  ) {
+    return null;
+  }
+
+  const parentComment = await fetchReviewCommentSnapshot({
+    installationId,
+    repositoryFullName: repository.full_name,
+    commentId: comment.in_reply_to_id,
+  });
+  if (
+    !parentComment ||
+    !GitHubSchemas.isRoomoteGitHubLogin(parentComment.userLogin)
+  ) {
+    return null;
+  }
+
+  const owner = await findReusableGitHubPrFollowUpOwner({
+    repoFullName: repository.full_name,
+    prNumber: pullRequest.number,
+    branchName: pullRequest.head?.ref ?? '',
+    host: toHostFromUrl(pullRequest.html_url ?? '') ?? 'github.com',
+  }).catch(() => null);
+  if (owner) {
+    return null;
+  }
+
+  return { parentComment };
+}
+
+/**
  * Every @mention on a pull request enters the pull request's Fast Session.
  * The Session reads the discussion, replies as a comment, and delegates work
- * to a task on the pull request's branch when the request needs one.
+ * to a task on the pull request's branch when the request needs one. A reply
+ * in a review thread Roomote opened enters the same way without an @mention.
  */
 export async function handlePrComment(
   eventPayload: PullRequestMentionEvent,
@@ -669,17 +738,26 @@ export async function handlePrComment(
   const { installation, repository, sender, ...rest } = eventPayload;
   const isSubmittedReview = 'review' in rest;
   const mention = isSubmittedReview ? rest.review : rest.comment;
+  const githubInstallationId = installation?.id;
 
-  if (
-    !isMention({
-      body: mention.body ?? '',
-      user: mention.user ? { login: mention.user.login } : null,
-    })
-  ) {
-    return { status: 'ok', message: 'no_mention' };
+  const explicitMention = isMention({
+    body: mention.body ?? '',
+    user: mention.user ? { login: mention.user.login } : null,
+  });
+  let reviewThreadParent: ReviewCommentSnapshot | null = null;
+  if (!explicitMention) {
+    const implicitMention = githubInstallationId
+      ? await resolveImplicitReviewThreadMention({
+          eventPayload,
+          installationId: githubInstallationId,
+        })
+      : null;
+    if (!implicitMention) {
+      return { status: 'ok', message: 'no_mention' };
+    }
+    reviewThreadParent = implicitMention.parentComment;
   }
 
-  const githubInstallationId = installation?.id;
   const mentionResponseTarget = getMentionResponseTarget(eventPayload);
 
   if (!githubInstallationId) {
@@ -771,6 +849,7 @@ export async function handlePrComment(
         repositoryFullName: repository.full_name,
         commenter: sender.login,
         commentBody: mention.body ?? '',
+        parentComment: reviewThreadParent,
       }),
     ]);
 

--- a/apps/api/src/handlers/github/handlePrComment.ts
+++ b/apps/api/src/handlers/github/handlePrComment.ts
@@ -1,6 +1,6 @@
 import {
   findActiveGitHubPrReviewTask,
-  findGitHubPullRequestLinkedTask,
+  findRoomoteOpenedPullRequestTask,
   findReusableGitHubPrFollowUpOwner,
 } from '@roomote/db/server';
 import {
@@ -677,11 +677,12 @@ async function resolvePullRequestActiveTasks({
 /**
  * A reply inside a review thread Roomote opened is addressed to Roomote the
  * way GitHub trains people to reply to a reviewer, so it counts as a mention
- * without the @-handle. Only pull requests no Roomote task is linked to
- * qualify: on a Roomote-opened pull request the review-feedback pipeline
- * already batches these replies into the owning Session with its Resolve /
- * Dismiss actions, and handling them here too would answer twice. The
- * linkage is durable, so a finished task still owns its pull request.
+ * without the @-handle. Only pull requests Roomote did not open qualify: on a
+ * Roomote-opened pull request the review-feedback pipeline already batches
+ * these replies into the owning Session with its Resolve / Dismiss actions,
+ * and handling them here too would answer twice. Opening is recorded on the
+ * durable linkage row, so a finished task still owns its pull request, while
+ * a pull request a task merely mentioned stays human-opened.
  */
 async function resolveImplicitReviewThreadMention({
   eventPayload,
@@ -715,7 +716,7 @@ async function resolveImplicitReviewThreadMention({
     return null;
   }
 
-  const linkedTask = await findGitHubPullRequestLinkedTask({
+  const linkedTask = await findRoomoteOpenedPullRequestTask({
     repoFullName: repository.full_name,
     prNumber: pullRequest.number,
     host: toHostFromUrl(pullRequest.html_url ?? '') ?? 'github.com',

--- a/apps/api/src/handlers/github/handlePrComment.ts
+++ b/apps/api/src/handlers/github/handlePrComment.ts
@@ -1,5 +1,6 @@
 import {
   findActiveGitHubPrReviewTask,
+  findGitHubPullRequestLinkedTask,
   findReusableGitHubPrFollowUpOwner,
 } from '@roomote/db/server';
 import {
@@ -676,10 +677,11 @@ async function resolvePullRequestActiveTasks({
 /**
  * A reply inside a review thread Roomote opened is addressed to Roomote the
  * way GitHub trains people to reply to a reviewer, so it counts as a mention
- * without the @-handle. Only pull requests no Roomote task owns qualify: on a
- * Roomote-opened pull request the review-feedback pipeline already batches
- * these replies into the owning Session with its Resolve / Dismiss actions,
- * and handling them here too would answer twice.
+ * without the @-handle. Only pull requests no Roomote task is linked to
+ * qualify: on a Roomote-opened pull request the review-feedback pipeline
+ * already batches these replies into the owning Session with its Resolve /
+ * Dismiss actions, and handling them here too would answer twice. The
+ * linkage is durable, so a finished task still owns its pull request.
  */
 async function resolveImplicitReviewThreadMention({
   eventPayload,
@@ -713,13 +715,12 @@ async function resolveImplicitReviewThreadMention({
     return null;
   }
 
-  const owner = await findReusableGitHubPrFollowUpOwner({
+  const linkedTask = await findGitHubPullRequestLinkedTask({
     repoFullName: repository.full_name,
     prNumber: pullRequest.number,
-    branchName: pullRequest.head?.ref ?? '',
     host: toHostFromUrl(pullRequest.html_url ?? '') ?? 'github.com',
   }).catch(() => null);
-  if (owner) {
+  if (linkedTask) {
     return null;
   }
 

--- a/apps/docs/providers/source-control/github.mdx
+++ b/apps/docs/providers/source-control/github.mdx
@@ -233,6 +233,11 @@ Roomote runs the Review Code automation's structured review on the current
 head, posts the findings on the pull request, and reports back in the same
 discussion.
 
+Replying inside a review thread that Roomote opened counts as talking to
+Roomote, so no `@mention` is needed there; Roomote answers in that thread. On
+a pull request that a Roomote task opened, those replies are instead collected
+as review feedback for the owning Session, described below.
+
 When a Roomote task opens a pull request, actionable review feedback returns to
 the owning Session and appears in both Fast and standard web task transcripts.
 Use **Resolve these issues** to address the current feedback, **Auto-resolve on

--- a/packages/db/src/lib/__tests__/github-branch-activity.test.ts
+++ b/packages/db/src/lib/__tests__/github-branch-activity.test.ts
@@ -21,6 +21,7 @@ import {
   findActiveGitHubBranchWork,
   findReusableGitHubPrFollowUpOwner,
   findReusableGitHubIssueTaskOwner,
+  findRoomoteOpenedPullRequestTask,
   hasRecentGitHubBranchCommit,
 } from '../github-branch-activity';
 
@@ -38,6 +39,7 @@ async function createPrLinkedTask({
   sourceControlProvider = 'github',
   host,
   repositoryId,
+  createdByRoomote = false,
 }: {
   repoFullName: string;
   prNumber: number;
@@ -46,6 +48,7 @@ async function createPrLinkedTask({
   sourceControlProvider?: SourceControlProvider;
   host?: string | null;
   repositoryId?: string | null;
+  createdByRoomote?: boolean;
 }) {
   const task = await taskFactory.create({
     initiatorUserId: userId,
@@ -62,6 +65,7 @@ async function createPrLinkedTask({
     host: host ?? null,
     repositoryId: repositoryId ?? null,
     status: 'open',
+    createdByRoomote,
   });
 
   return task.id;
@@ -77,6 +81,7 @@ async function createPrLinkedTaskRun({
   prSha,
   sourceControlProvider,
   host,
+  createdByRoomote,
 }: {
   repoFullName: string;
   prNumber: number;
@@ -87,6 +92,7 @@ async function createPrLinkedTaskRun({
   prSha?: string;
   sourceControlProvider?: SourceControlProvider;
   host?: string | null;
+  createdByRoomote?: boolean;
 }) {
   const taskId = await createPrLinkedTask({
     repoFullName,
@@ -95,6 +101,7 @@ async function createPrLinkedTaskRun({
     prSha,
     sourceControlProvider,
     host,
+    createdByRoomote,
   });
 
   return runFactory.create({
@@ -1944,5 +1951,113 @@ describe('hasRecentGitHubBranchCommit', () => {
         now,
       }),
     ).toBe(false);
+  });
+});
+
+describe('findRoomoteOpenedPullRequestTask', () => {
+  it('returns the task that opened the pull request even after its run finished', async () => {
+    const { user } = await createActor();
+    const run = await createPrLinkedTaskRun({
+      repoFullName: 'acme/api',
+      prNumber: 42,
+      userId: user.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Completed,
+      createdByRoomote: true,
+    });
+
+    await expect(
+      findRoomoteOpenedPullRequestTask({
+        repoFullName: 'acme/api',
+        prNumber: 42,
+        host: 'github.com',
+      }),
+    ).resolves.toEqual({
+      runId: run.id,
+      taskId: run.taskId,
+      type: TaskPayloadKind.StandardTask,
+      status: RunStatus.Completed,
+    });
+  });
+
+  it('ignores a pull request a task merely mentioned', async () => {
+    const { user } = await createActor();
+    await createPrLinkedTaskRun({
+      repoFullName: 'acme/api',
+      prNumber: 43,
+      userId: user.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Completed,
+      createdByRoomote: false,
+    });
+
+    await expect(
+      findRoomoteOpenedPullRequestTask({
+        repoFullName: 'acme/api',
+        prNumber: 43,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('ignores review-pipeline and conflict-resolver linkage', async () => {
+    const { user } = await createActor();
+    for (const payloadKind of [
+      TaskPayloadKind.GithubPrReview,
+      TaskPayloadKind.GithubPrReviewSync,
+      TaskPayloadKind.GithubPrConflictResolve,
+    ]) {
+      await createPrLinkedTaskRun({
+        repoFullName: 'acme/api',
+        prNumber: 44,
+        userId: user.id,
+        payloadKind,
+        status: RunStatus.Running,
+        createdByRoomote: true,
+      });
+    }
+
+    await expect(
+      findRoomoteOpenedPullRequestTask({
+        repoFullName: 'acme/api',
+        prNumber: 44,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it('host-scopes the lookup, tolerating legacy null-host rows', async () => {
+    const { user } = await createActor();
+    await createPrLinkedTaskRun({
+      repoFullName: 'acme/api',
+      prNumber: 45,
+      userId: user.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Completed,
+      host: 'github.example.com',
+      createdByRoomote: true,
+    });
+    const legacy = await createPrLinkedTaskRun({
+      repoFullName: 'acme/api',
+      prNumber: 46,
+      userId: user.id,
+      payloadKind: TaskPayloadKind.StandardTask,
+      status: RunStatus.Completed,
+      host: null,
+      createdByRoomote: true,
+    });
+
+    await expect(
+      findRoomoteOpenedPullRequestTask({
+        repoFullName: 'acme/api',
+        prNumber: 45,
+        host: 'github.com',
+      }),
+    ).resolves.toBeNull();
+    await expect(
+      findRoomoteOpenedPullRequestTask({
+        repoFullName: 'acme/api',
+        prNumber: 46,
+        host: 'github.com',
+      }),
+    ).resolves.toEqual(expect.objectContaining({ taskId: legacy.taskId }));
   });
 });

--- a/packages/db/src/lib/github-branch-activity.ts
+++ b/packages/db/src/lib/github-branch-activity.ts
@@ -1,4 +1,14 @@
-import { and, desc, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm';
+import {
+  and,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  ne,
+  notInArray,
+  or,
+  sql,
+} from 'drizzle-orm';
 
 import {
   type TaskPayload,
@@ -500,6 +510,67 @@ export async function findActiveGitHubPrReviewTask({
     .limit(10);
 
   return pickActiveWork(reviewRows, 'task_pull_request');
+}
+
+export type GitHubPullRequestLinkedTask = {
+  runId: number;
+  taskId: string;
+  type: TaskPayloadKind;
+  status: RunStatus;
+};
+
+/**
+ * The newest Roomote task durably linked to the pull request, other than the
+ * review pipeline or a conflict resolver: the task that opened it or a
+ * follow-up on it, whether or not a run is still active or resumable.
+ *
+ * Review-feedback delivery keys on this linkage (every linked task's Fast
+ * parent hears human review comments), so a caller deciding whether the
+ * feedback pipeline already owns replies on the pull request must use this,
+ * not the active-run lookups above, which return null once the task finishes
+ * without a snapshot.
+ */
+export async function findGitHubPullRequestLinkedTask({
+  repoFullName,
+  prNumber,
+  sourceControlProvider = 'github',
+  host,
+}: {
+  repoFullName: string;
+  prNumber: number;
+  sourceControlProvider?: SourceControlProvider;
+  /** When given, only rows on this host (or legacy rows with no host) match. */
+  host?: string | null;
+}): Promise<GitHubPullRequestLinkedTask | null> {
+  const [row] = await db
+    .select(ACTIVE_WORK_COLUMNS)
+    .from(taskRuns)
+    .innerJoin(taskPullRequests, eq(taskPullRequests.taskId, taskRuns.taskId))
+    .where(
+      and(
+        notInArray(taskRuns.payloadKind, [
+          ...ACTIVE_PR_REVIEW_TYPES,
+          TaskPayloadKind.GithubPrConflictResolve,
+        ]),
+        eq(taskPullRequests.sourceControlProvider, sourceControlProvider),
+        eq(taskPullRequests.repository, repoFullName),
+        eq(taskPullRequests.prNumber, prNumber),
+        ...(host
+          ? [or(eq(taskPullRequests.host, host), isNull(taskPullRequests.host))]
+          : []),
+      ),
+    )
+    .orderBy(desc(taskRuns.createdAt))
+    .limit(1);
+
+  return row
+    ? {
+        runId: row.runId,
+        taskId: row.taskId,
+        type: row.type,
+        status: row.status,
+      }
+    : null;
 }
 
 async function fetchRunReuseMetadata(

--- a/packages/db/src/lib/github-branch-activity.ts
+++ b/packages/db/src/lib/github-branch-activity.ts
@@ -512,7 +512,7 @@ export async function findActiveGitHubPrReviewTask({
   return pickActiveWork(reviewRows, 'task_pull_request');
 }
 
-export type GitHubPullRequestLinkedTask = {
+export type RoomoteOpenedPullRequestTask = {
   runId: number;
   taskId: string;
   type: TaskPayloadKind;
@@ -520,17 +520,17 @@ export type GitHubPullRequestLinkedTask = {
 };
 
 /**
- * The newest Roomote task durably linked to the pull request, other than the
- * review pipeline or a conflict resolver: the task that opened it or a
- * follow-up on it, whether or not a run is still active or resumable.
+ * The newest Roomote task that opened the pull request, whether or not a run
+ * is still active or resumable. Only linkage rows stamped `createdByRoomote`
+ * count: a pull request merely mentioned in a task transcript is also linked
+ * to that task, but Roomote did not open it. Review-pipeline and
+ * conflict-resolver tasks never open pull requests and are excluded.
  *
- * Review-feedback delivery keys on this linkage (every linked task's Fast
- * parent hears human review comments), so a caller deciding whether the
- * feedback pipeline already owns replies on the pull request must use this,
- * not the active-run lookups above, which return null once the task finishes
- * without a snapshot.
+ * Use this, not the active-run lookups above, when deciding whether a pull
+ * request is Roomote-opened: those return null once the task finishes
+ * without a snapshot, while the linkage is durable.
  */
-export async function findGitHubPullRequestLinkedTask({
+export async function findRoomoteOpenedPullRequestTask({
   repoFullName,
   prNumber,
   sourceControlProvider = 'github',
@@ -541,13 +541,14 @@ export async function findGitHubPullRequestLinkedTask({
   sourceControlProvider?: SourceControlProvider;
   /** When given, only rows on this host (or legacy rows with no host) match. */
   host?: string | null;
-}): Promise<GitHubPullRequestLinkedTask | null> {
+}): Promise<RoomoteOpenedPullRequestTask | null> {
   const [row] = await db
     .select(ACTIVE_WORK_COLUMNS)
     .from(taskRuns)
     .innerJoin(taskPullRequests, eq(taskPullRequests.taskId, taskRuns.taskId))
     .where(
       and(
+        eq(taskPullRequests.createdByRoomote, true),
         notInArray(taskRuns.payloadKind, [
           ...ACTIVE_PR_REVIEW_TYPES,
           TaskPayloadKind.GithubPrConflictResolve,


### PR DESCRIPTION
## What changed

- A reply inside a GitHub review thread that Roomote opened now enters the pull request's Session without an `@mention`. The handler fetches the parent review comment once, requires it to be Roomote-authored, and reuses that fetch for the Session's context, which now says "replied to Roomote's review comment" instead of "mentioned Roomote".
- Only pull requests with no owning Roomote task qualify. On a Roomote-opened pull request the review-feedback pipeline already batches these replies into the owning Session with its Resolve / Auto-resolve / Dismiss actions, so the handler leaves them alone there to avoid answering twice.
- Top-level review comments, replies to comments written by people, and replies authored by Roomote itself still require an explicit mention or are ignored, as before.
- Docs: the GitHub source-control page describes the behavior and the Roomote-opened exception.

## Why

Replying to the reviewer is how GitHub trains people to use review threads. Before this change a reply to a Roomote review comment on a human-opened pull request was dropped: the mention gate rejected it and the feedback pipeline had no task to route it to.

## Scope note

GitHub only. GitLab, Bitbucket, Azure DevOps, and Gitea keep the explicit-mention rule for now; each needs a provider API call to learn the parent comment's author, and that is a follow-up.

## Validation

- Four new handler tests: enters the Session with the thread as reply target and a single parent fetch; leaves Roomote-opened pull requests to the feedback pipeline; ignores replies to human-authored comments; ignores top-level comments without a mention. Existing tests pass (11/11).
- `pnpm --filter @roomote/api run check-types`, `oxlint`, `oxfmt` pass.