### PR TITLE
[Fix] Fast Sessions can create artifacts on every turn

### DIFF
--- a/apps/api/src/handlers/slack/events/fast-agent-reaction.test.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent-reaction.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   acquireLock: vi.fn(),
   answerQuestion: vi.fn(),
+  createArtifact: vi.fn(),
   createActivity: vi.fn(() => ({ start: vi.fn(), settle: vi.fn() })),
   findConversation: vi.fn(),
   findSession: vi.fn(),
@@ -33,6 +34,7 @@ vi.mock('@roomote/communication', () => ({
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
+  buildFastAgentArtifactCreator: vi.fn(() => mocks.createArtifact),
   findFastAgentSessionForProviderMessage: mocks.findSession,
   persistFastAgentInlineHumanTurn: mocks.persistAdmission,
   recordFastAgentConversationMessageBestEffort: mocks.recordProviderMessage,
@@ -147,6 +149,7 @@ describe('Fast Slack reaction input', () => {
         durableAdmission: { eventId: 'row-1' },
         resumedAfterInterruption: true,
         adapter: expect.objectContaining({
+          createArtifact: mocks.createArtifact,
           requestDurableResume: expect.any(Function),
           requestDurableRetry: expect.any(Function),
         }),

--- a/apps/api/src/handlers/slack/events/fast-agent-reaction.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent-reaction.ts
@@ -13,6 +13,7 @@ import {
   resolveFastSessionReplyFooterContext,
 } from '@roomote/communication';
 import {
+  buildFastAgentArtifactCreator,
   findFastAgentSessionForProviderMessage,
   persistFastAgentInlineHumanTurn,
   recordFastAgentConversationMessageBestEffort,
@@ -159,6 +160,7 @@ async function processFastAgentReaction(params: {
                 ),
             }
           : {}),
+        createArtifact: buildFastAgentArtifactCreator(session.id),
         activity: createFastAgentSlackSessionActivity({
           slack: context.slack,
           workspaceId: context.teamId,

--- a/apps/web/src/trpc/commands/fast-sessions/index.test.ts
+++ b/apps/web/src/trpc/commands/fast-sessions/index.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   getFastSessionTasks: vi.fn(),
   currentEpochSeconds: vi.fn(),
   createSessionArtifact: vi.fn(),
+  createConversationArtifact: vi.fn(),
   dbUpdate: vi.fn(),
   dbSet: vi.fn(),
   dbWhere: vi.fn(),
@@ -37,6 +38,7 @@ vi.mock('@roomote/cloud-agents/server', () => ({
 }));
 
 vi.mock('@roomote/sdk/server', () => ({
+  buildFastAgentArtifactCreator: vi.fn(() => mocks.createConversationArtifact),
   buildFastAgentSurfaceReplyDelivery: mocks.buildReplyDelivery,
   createFastAgentSessionArtifact: mocks.createSessionArtifact,
   persistFastAgentInlineHumanTurn: vi.fn().mockResolvedValue(null),
@@ -459,6 +461,9 @@ describe('startSetupFastSessionCommand', () => {
         platformEventKind: 'setup',
         platformEventVisibility: 'required',
         currentMessageId: 'setup-kickoff:setup-conversation-1',
+        adapter: expect.objectContaining({
+          createArtifact: mocks.createConversationArtifact,
+        }),
       }),
     );
     // The kickoff is admitted durably with its platform framing, so a

--- a/apps/web/src/trpc/commands/fast-sessions/index.ts
+++ b/apps/web/src/trpc/commands/fast-sessions/index.ts
@@ -16,6 +16,7 @@ import {
   upsertFastAgentMessage,
 } from '@roomote/cloud-agents/server';
 import {
+  buildFastAgentArtifactCreator,
   buildFastAgentSurfaceReplyDelivery,
   createFastAgentSessionArtifact,
   persistFastAgentInlineHumanTurn,
@@ -548,6 +549,7 @@ export async function startSetupFastSessionCommand(
       delivery: {
         conversation,
         adapter: {
+          createArtifact: buildFastAgentArtifactCreator(session.id),
           launchTask: createFastAgentWebTaskLauncher({
             userId: auth.userId,
             conversation,
@@ -842,6 +844,7 @@ export async function submitFastSessionUserInputCommand(
           conversationId: session.conversationId,
         },
         adapter: {
+          createArtifact: buildFastAgentArtifactCreator(session.id),
           launchTask: createFastAgentWebTaskLauncher({
             userId: session.userId,
             conversation: {

--- a/apps/web/src/trpc/commands/setup/setup-session.ts
+++ b/apps/web/src/trpc/commands/setup/setup-session.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import { type FastAgentTurnAdapter } from '@roomote/cloud-agents/server';
+import { buildFastAgentArtifactCreator } from '@roomote/sdk/server';
 import {
   and,
   db,
@@ -378,6 +379,9 @@ async function buildSetupPlatformEventTurn(
         conversationId: conversation.conversationId,
       },
       adapter: {
+        createArtifact: buildFastAgentArtifactCreator(
+          conversation.fastConversationId,
+        ),
         launchTask: (
           await import('@roomote/cloud-agents/server')
         ).createFastAgentWebTaskLauncher({

--- a/packages/sdk/src/server/index.ts
+++ b/packages/sdk/src/server/index.ts
@@ -113,6 +113,7 @@ export {
   createFastAgentSessionArtifact,
   createSessionArtifact,
 } from './lib/artifacts/create-session-artifact';
+export { buildFastAgentArtifactCreator } from './lib/artifacts/fast-agent-artifact-creator';
 export {
   notifyFastAgentParentOnArtifact,
   type FastArtifactNotificationResult,

--- a/packages/sdk/src/server/lib/artifacts/fast-agent-artifact-creator.ts
+++ b/packages/sdk/src/server/lib/artifacts/fast-agent-artifact-creator.ts
@@ -1,0 +1,17 @@
+import { createFastAgentConversationArtifact } from './create-session-artifact';
+
+type FastAgentArtifactInput = Omit<
+  Parameters<typeof createFastAgentConversationArtifact>[0],
+  'fastConversationId'
+>;
+
+/**
+ * Builds the `createArtifact` adapter for a Fast turn from its conversation
+ * id. The `create_artifact` tool is always in the model's catalog, so every
+ * path that runs a turn (surface follow-ups, durable queue resumes,
+ * platform-event turns) must carry this or the call fails as unavailable.
+ */
+export function buildFastAgentArtifactCreator(fastConversationId: string) {
+  return (artifact: FastAgentArtifactInput) =>
+    createFastAgentConversationArtifact({ fastConversationId, ...artifact });
+}

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -49,6 +49,7 @@ const mocks = vi.hoisted(() => ({
   postSourceControlComment: vi.fn(),
   updateSourceControlComment: vi.fn(),
   linearEmitResponse: vi.fn(),
+  createConversationArtifact: vi.fn(),
 }));
 
 vi.mock('@roomote/redis', async (importOriginal) => {
@@ -164,6 +165,10 @@ vi.mock('./task-runs/pr-review-action', () => ({
     mocks.attachPendingPrReviewActionMessage,
   retirePrReviewActionMessagesBestEffort:
     mocks.retirePrReviewActionMessagesBestEffort,
+}));
+
+vi.mock('./artifacts/create-session-artifact', () => ({
+  createFastAgentConversationArtifact: mocks.createConversationArtifact,
 }));
 
 vi.mock('./artifacts/raw-url', () => ({
@@ -517,6 +522,45 @@ describe('deliverFastAgentParentEvent', () => {
       }),
     );
     expect(mocks.answerQuestion.mock.calls[1]?.[0]).not.toHaveProperty('input');
+  });
+
+  it('lets a queued web turn create artifacts in its Session', async () => {
+    const webParent = {
+      sessionId: parent.sessionId,
+      conversation: {
+        surface: 'web' as const,
+        workspaceId: 'user-1',
+        conversationId: 'session-1',
+      },
+    };
+    mocks.createConversationArtifact.mockResolvedValue({ id: 'artifact-1' });
+    mocks.answerQuestion.mockImplementation(async ({ adapter }) =>
+      adapter.createArtifact({
+        path: 'notes/decision.md',
+        content: '# Decision',
+        contentType: 'text/markdown',
+        artifactType: 'general',
+      }),
+    );
+
+    await deliverFastAgentParentEvent({
+      parent: webParent,
+      event: {
+        type: 'human_follow_up',
+        eventId: 'web-message-1',
+        currentMessageId: 'web-message-1',
+        userId: 'user-1',
+        question: 'Write up the decision',
+      },
+    });
+
+    expect(mocks.createConversationArtifact).toHaveBeenCalledWith({
+      fastConversationId: parent.sessionId,
+      path: 'notes/decision.md',
+      content: '# Decision',
+      contentType: 'text/markdown',
+      artifactType: 'general',
+    });
   });
 
   it('passes a canonical review offer into the web transcript payload', async () => {

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -90,6 +90,7 @@ import {
   buildSignedArtifactRawUrl,
   currentEpochSeconds,
 } from './artifacts/raw-url';
+import { buildFastAgentArtifactCreator } from './artifacts/fast-agent-artifact-creator';
 import { createDiscordCommunicationProviderFromRuntimeCredentials } from './discord-communication';
 import { createTeamsCommunicationProviderFromRuntimeCredentials } from './teams-communication';
 import { createTelegramCommunicationProviderFromRuntimeCredentials } from './telegram-communication';
@@ -2087,6 +2088,7 @@ export async function deliverFastAgentParentEventWithLock(
           }
         : {}),
       adapter: {
+        createArtifact: buildFastAgentArtifactCreator(params.parent.sessionId),
         ...parentTurn.adapter,
         launchTask,
         resolveMcpServerConfigs: () =>

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.test.ts
@@ -18,6 +18,11 @@ const mocks = vi.hoisted(() => ({
   linearGetIssue: vi.fn(),
   buildSourceControlDelivery: vi.fn(),
   sourceControlPostComment: vi.fn(),
+  createConversationArtifact: vi.fn(),
+}));
+
+vi.mock('./artifacts/create-session-artifact', () => ({
+  createFastAgentConversationArtifact: mocks.createConversationArtifact,
 }));
 
 vi.mock('@roomote/slack', () => ({
@@ -176,6 +181,38 @@ describe('buildFastAgentSurfaceReplyDelivery', () => {
     await expect(
       delivery!.adapter.postReply({ purpose: 'closeout', message: 'hi' }),
     ).resolves.toBeUndefined();
+  });
+
+  it('lets web follow-up turns create artifacts in the Session', async () => {
+    const user = await userFactory.create();
+    const conversation = await createConversation({
+      userId: user.id,
+      surface: 'web',
+    });
+    mocks.createConversationArtifact.mockResolvedValue({ id: 'artifact-1' });
+
+    const delivery = await buildFastAgentSurfaceReplyDelivery({
+      sessionId: conversation.id,
+      userId: user.id,
+      senderDisplayName: 'Matt',
+      question: 'Write this up as a plan',
+    });
+
+    await expect(
+      delivery!.adapter.createArtifact!({
+        path: 'plans/flying-animals.md',
+        content: '# Plan',
+        contentType: 'text/markdown',
+        artifactType: 'plan',
+      }),
+    ).resolves.toEqual({ id: 'artifact-1' });
+    expect(mocks.createConversationArtifact).toHaveBeenCalledWith({
+      fastConversationId: conversation.id,
+      path: 'plans/flying-animals.md',
+      content: '# Plan',
+      contentType: 'text/markdown',
+      artifactType: 'plan',
+    });
   });
 
   it('reports durable admission failures instead of acknowledging the queued follow-up', async () => {

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
@@ -14,7 +14,6 @@ import {
 import {
   and,
   db,
-  ensureSessionForFastConversation,
   eq,
   slackInstallations,
 } from '@roomote/db/server';
@@ -72,7 +71,7 @@ import {
   buildSourceControlFastDelivery,
   buildSourceControlReplyQuote,
 } from './source-control-fast-delivery';
-import { createFastAgentSessionArtifact } from './artifacts/create-session-artifact';
+import { buildFastAgentArtifactCreator } from './artifacts/fast-agent-artifact-creator';
 
 const SLACK_QUOTE_MAX_LENGTH = 100;
 const DISCORD_QUOTE_MAX_LENGTH = 280;
@@ -218,6 +217,7 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
     return null;
   }
   const conversation = session.conversation;
+  const createArtifact = buildFastAgentArtifactCreator(session.id);
 
   if (conversation.surface === 'web' || conversation.surface === 'automation') {
     // No side channel to post into: the canonical transcript the service
@@ -226,6 +226,7 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
     return {
       conversation,
       adapter: {
+        createArtifact,
         launchTask: createFastAgentWebTaskLauncher({
           userId: params.userId,
           conversation,
@@ -272,6 +273,7 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
     return {
       conversation,
       adapter: {
+        createArtifact,
         ...(senderSubject
           ? {
               createReplyStream: () =>
@@ -374,6 +376,7 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
         });
 
     const adapter: FastAgentTurnAdapter = {
+      createArtifact,
       launchTask: createFastAgentDiscordTaskLauncher({
         provider,
         userId: params.userId,
@@ -460,6 +463,7 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
     return {
       conversation,
       adapter: {
+        createArtifact,
         launchTask: createFastAgentCommunicationTaskLauncher({
           userId: params.userId,
           conversation,
@@ -508,6 +512,7 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
     return {
       conversation,
       adapter: {
+        createArtifact,
         launchTask: createFastAgentLinearTaskLauncher({
           userId: params.userId,
           conversation,
@@ -533,15 +538,18 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
     }
     return {
       conversation,
-      adapter: buildSourceControlFastAdapter({
-        conversation,
-        delivery,
-        userId: params.userId,
-        sessionId: session.id,
-        quote: params.externalInput
-          ? null
-          : buildSourceControlReplyQuote({ text: params.question }),
-      }),
+      adapter: {
+        createArtifact,
+        ...buildSourceControlFastAdapter({
+          conversation,
+          delivery,
+          userId: params.userId,
+          sessionId: session.id,
+          quote: params.externalInput
+            ? null
+            : buildSourceControlReplyQuote({ text: params.question }),
+        }),
+      },
     };
   }
 
@@ -555,6 +563,7 @@ export async function buildFastAgentSurfaceReplyDelivery(params: {
     return {
       conversation,
       adapter: {
+        createArtifact,
         launchTask: createFastAgentCommunicationTaskLauncher({
           userId: params.userId,
           conversation,
@@ -766,16 +775,7 @@ async function runFastAgentSurfaceReply(
                 ),
             }
           : {}),
-        createArtifact: async (artifact) => {
-          const unifiedSession = await ensureSessionForFastConversation(
-            db,
-            params.sessionId,
-          );
-          return createFastAgentSessionArtifact({
-            sessionId: unifiedSession.id,
-            ...artifact,
-          });
-        },
+        createArtifact: buildFastAgentArtifactCreator(params.sessionId),
         ...delivery.adapter,
       },
     }).catch((error: unknown) => {

--- a/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
+++ b/packages/sdk/src/server/lib/fast-agent-surface-reply.ts
@@ -11,12 +11,7 @@ import {
   type FastAgentReactionExternalInput,
   type FastAgentTurnAdapter,
 } from '@roomote/cloud-agents/server';
-import {
-  and,
-  db,
-  eq,
-  slackInstallations,
-} from '@roomote/db/server';
+import { and, db, eq, slackInstallations } from '@roomote/db/server';
 import {
   isFastAgentSourceControlConversation,
   type FastAgentHumanFollowUpEvent,


### PR DESCRIPTION
## Problem

PR #2143 added the \`create_artifact\` native tool, but only three entry points wired the \`createArtifact\` adapter: the first message of a web Session, the Slack entry, and the Discord entry. Every other turn left it out, so the model (which always sees the tool in its catalog) called it and got "Artifact creation is unavailable for this Session":

- web follow-up messages (the adapter comes from \`buildFastAgentSurfaceReplyDelivery\`, whose web branch only had \`launchTask\` and \`postReply\`)
- durable queue resumes for any surface (\`deliverFastAgentParentEventWithLock\`)
- web setup kickoffs, setup platform events, and structured-input responses
- Slack reaction turns
- Teams, Telegram, Linear, and source-control follow-ups

## Fix

- Add \`buildFastAgentArtifactCreator(fastConversationId)\` in the sdk and export it.
- Carry \`createArtifact\` on every branch of \`buildFastAgentSurfaceReplyDelivery\` (web/automation, Slack, Discord, Teams, Linear, source control, Telegram).
- Add it as a fallback in the queued parent-event path so durable resumes on every surface have it.
- Wire the remaining web platform turns (setup kickoff, setup platform events, input responses) and the Slack reaction turn.
- The inline surface-reply fallback now uses the shared helper.

## Tests

- sdk: web surface-reply delivery creates an artifact bound to the Fast conversation; a queued web \`human_follow_up\` turn can create an artifact.
- api: Slack reaction turn adapter carries \`createArtifact\`.
- web: setup kickoff adapter carries \`createArtifact\`.

\`pnpm lint:fast\`, \`pnpm check-types:fast\`, and \`pnpm knip\` pass.