### PR TITLE
[Fix] Show Fast reply images in the web Session transcript

### DIFF
--- a/apps/docs/fast-sessions.mdx
+++ b/apps/docs/fast-sessions.mdx
@@ -56,7 +56,9 @@ task with documents created directly during the conversation, labels each item
 by its Session or task source, and opens previews without leaving the Session.
 Links to a Session-created artifact, including the link the Session shares when
 it creates one, open that artifact directly in the Artifacts panel. Individual
-task details continue to show their own artifacts.
+task details continue to show their own artifacts. When a reply attaches
+screenshots or other images captured by a task, they appear inline with that
+reply in the transcript.
 
 **Session info** shows the total inference cost for the conversation and its
 attached tasks. Open the cost breakdown to separate direct Session orchestration

--- a/apps/web/src/lib/server/fast-sessions.test.ts
+++ b/apps/web/src/lib/server/fast-sessions.test.ts
@@ -13,6 +13,11 @@ import {
 } from '@roomote/db/server';
 import { ACP_ENVELOPE_EVENT_TYPES, RunStatus } from '@roomote/types';
 
+vi.mock('./artifact-signature', () => ({
+  currentEpochSeconds: () => 7_300,
+  signArtifactId: (artifactId: string, ts: number) => `sig-${artifactId}-${ts}`,
+}));
+
 import {
   findAccessibleFastSession,
   getFastSessionPrReviewOfferStatus,
@@ -196,6 +201,91 @@ describe('Fast session queries', () => {
     await expect(
       getFastSessionById({ userId: otherUser.id, isAdmin: true }, session.id),
     ).resolves.toMatchObject({ id: session.id, userId: owner.id });
+  });
+
+  it('resolves reply image artifacts to signed raw URLs', async () => {
+    const owner = await userFactory.create();
+    const session = await createFastSession({
+      userId: owner.id,
+      conversationId: 'reply-images-session',
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    const task = await taskFactory.create({
+      title: 'Screenshot task',
+      state: 'active',
+    });
+    await runFactory.create({
+      taskId: task.id,
+      status: RunStatus.Completed,
+      payload: {
+        repo: 'acme/widgets',
+        description: 'Capture a screenshot',
+        fastAgentSessionId: session.id,
+      },
+    });
+    const foreignTask = await taskFactory.create({
+      title: 'Unrelated task',
+      state: 'active',
+    });
+    const [screenshot, report, foreignImage] = await db
+      .insert(taskArtifacts)
+      .values([
+        {
+          taskId: task.id,
+          path: 'proof/session.png',
+          version: 1,
+          contentType: 'image/png',
+          size: 2_048,
+          uploaded: true,
+        },
+        {
+          taskId: task.id,
+          path: 'reports/result.md',
+          version: 1,
+          contentType: 'text/markdown',
+          size: 200,
+          uploaded: true,
+        },
+        {
+          taskId: foreignTask.id,
+          path: 'proof/other.png',
+          version: 1,
+          contentType: 'image/png',
+          size: 2_048,
+          uploaded: true,
+        },
+      ])
+      .returning({ id: taskArtifacts.id });
+    await createFastMessage({
+      conversationId: session.id,
+      eventId: 'turn-1:assistant:0',
+      turnSeq: 1,
+      payload: {
+        purpose: 'closeout',
+        imageArtifactIds: [
+          screenshot!.id,
+          report!.id,
+          foreignImage!.id,
+          crypto.randomUUID(),
+        ],
+      },
+    });
+
+    const expectedImages = [
+      `/api/artifacts/${screenshot!.id}/raw?sig=sig-${screenshot!.id}-7200&ts=7200`,
+    ];
+    const detail = await getFastSessionById(
+      { userId: owner.id, isAdmin: false },
+      session.id,
+    );
+    expect(detail?.messages.map((message) => message.payload)).toEqual([
+      expect.objectContaining({ images: expectedImages }),
+    ]);
+
+    const since = await getFastSessionMessagesSince(session.id, 0);
+    expect(since.messages.map((message) => message.payload)).toEqual([
+      expect.objectContaining({ images: expectedImages }),
+    ]);
   });
 
   it('lists every task associated with a Fast session', async () => {

--- a/apps/web/src/lib/server/fast-sessions.test.ts
+++ b/apps/web/src/lib/server/fast-sessions.test.ts
@@ -267,6 +267,8 @@ describe('Fast session queries', () => {
           report!.id,
           foreignImage!.id,
           crypto.randomUUID(),
+          'not-a-uuid',
+          '',
         ],
       },
     });

--- a/apps/web/src/lib/server/fast-sessions.ts
+++ b/apps/web/src/lib/server/fast-sessions.ts
@@ -111,11 +111,22 @@ const fastSessionMessageUserJoin = sql`${users.id}::text = ${fastAgentMessages.m
 /** Signed raw URLs are bucketed so a polling transcript stays byte-stable. */
 const REPLY_IMAGE_SIGNATURE_WINDOW_SECONDS = 60 * 60;
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+/**
+ * The reply schema only requires strings, and web turns have no surface-side
+ * artifact lookup, so a model-authored id can be anything. Keep only
+ * UUID-shaped ids: `task_artifacts.id` is a uuid column and a malformed value
+ * would make Postgres reject the whole lookup instead of dropping that id.
+ */
 function readReplyImageArtifactIds(payload: unknown): string[] {
   const ids = (payload as { imageArtifactIds?: unknown } | null)
     ?.imageArtifactIds;
   return Array.isArray(ids)
-    ? ids.filter((id): id is string => typeof id === 'string' && id !== '')
+    ? ids.filter(
+        (id): id is string => typeof id === 'string' && UUID_PATTERN.test(id),
+      )
     : [];
 }
 

--- a/apps/web/src/lib/server/fast-sessions.ts
+++ b/apps/web/src/lib/server/fast-sessions.ts
@@ -28,6 +28,7 @@ import {
 import type { FastAgentMessage } from '@roomote/db';
 
 import type { UserAuthSuccess } from '@/types';
+import { currentEpochSeconds, signArtifactId } from './artifact-signature';
 import { COMPOSER_SUGGESTION_HISTORY_LIMIT } from './composer-suggestion-history';
 import {
   buildSessionTaskPreviews,
@@ -106,6 +107,98 @@ const fastSessionMessageSelection = {
 };
 
 const fastSessionMessageUserJoin = sql`${users.id}::text = ${fastAgentMessages.metadata} ->> 'userId'`;
+
+/** Signed raw URLs are bucketed so a polling transcript stays byte-stable. */
+const REPLY_IMAGE_SIGNATURE_WINDOW_SECONDS = 60 * 60;
+
+function readReplyImageArtifactIds(payload: unknown): string[] {
+  const ids = (payload as { imageArtifactIds?: unknown } | null)
+    ?.imageArtifactIds;
+  return Array.isArray(ids)
+    ? ids.filter((id): id is string => typeof id === 'string' && id !== '')
+    : [];
+}
+
+/**
+ * Fast replies reference the images they attach by artifact id (chat
+ * surfaces post the files themselves). The web transcript renders
+ * `payload.images` URLs, so resolve the ids here to signed raw URLs. Only
+ * uploaded image artifacts from this Session's own tasks (or the Session
+ * itself) qualify; anything else is dropped rather than signed.
+ */
+async function attachFastSessionReplyImages<
+  T extends Pick<FastSessionMessage, 'payload'>,
+>(sessionId: string, messages: T[]): Promise<T[]> {
+  const requestedIds = new Set(
+    messages.flatMap((message) => readReplyImageArtifactIds(message.payload)),
+  );
+  if (requestedIds.size === 0) {
+    return messages;
+  }
+
+  const [conversation] = await db
+    .select({
+      legacyConversationIds: fastAgentConversations.legacyConversationIds,
+    })
+    .from(fastAgentConversations)
+    .where(eq(fastAgentConversations.id, sessionId))
+    .limit(1);
+  const lookupIds = [sessionId, ...(conversation?.legacyConversationIds ?? [])];
+
+  const allowed = await db
+    .select({ id: taskArtifacts.id })
+    .from(taskArtifacts)
+    .where(
+      and(
+        inArray(taskArtifacts.id, [...requestedIds]),
+        eq(taskArtifacts.uploaded, true),
+        sql`${taskArtifacts.contentType} like 'image/%'`,
+        or(
+          inArray(
+            taskArtifacts.taskId,
+            db
+              .select({ taskId: taskRuns.taskId })
+              .from(taskRuns)
+              .where(inArray(taskRuns.fastAgentSessionId, lookupIds)),
+          ),
+          inArray(
+            taskArtifacts.sessionId,
+            db
+              .select({ id: sessions.id })
+              .from(sessions)
+              .where(inArray(sessions.fastConversationId, lookupIds)),
+          ),
+        ),
+      ),
+    );
+  const allowedIds = new Set(allowed.map((row) => row.id));
+  if (allowedIds.size === 0) {
+    return messages;
+  }
+
+  const signatureTimestamp =
+    Math.floor(currentEpochSeconds() / REPLY_IMAGE_SIGNATURE_WINDOW_SECONDS) *
+    REPLY_IMAGE_SIGNATURE_WINDOW_SECONDS;
+
+  return messages.map((message) => {
+    const images = readReplyImageArtifactIds(message.payload)
+      .filter((id) => allowedIds.has(id))
+      .map(
+        (id) =>
+          `/api/artifacts/${id}/raw?sig=${signArtifactId(id, signatureTimestamp)}&ts=${signatureTimestamp}`,
+      );
+    if (images.length === 0) {
+      return message;
+    }
+    return {
+      ...message,
+      payload: {
+        ...((message.payload as Record<string, unknown> | null) ?? {}),
+        images,
+      },
+    };
+  });
+}
 
 export function buildFastSessionPrReviewDestinationKey(session: {
   surface: string;
@@ -439,10 +532,13 @@ export async function getFastSessionMessagesSince(
     );
 
   let cursor = sinceMs;
-  const messages = rows.map(({ updatedAtMs, ...row }) => {
-    cursor = Math.max(cursor, Number(updatedAtMs));
-    return sanitizeFastSessionMessageRow(row);
-  });
+  const messages = await attachFastSessionReplyImages(
+    sessionId,
+    rows.map(({ updatedAtMs, ...row }) => {
+      cursor = Math.max(cursor, Number(updatedAtMs));
+      return sanitizeFastSessionMessageRow(row);
+    }),
+  );
 
   return { messages, cursor };
 }
@@ -556,9 +652,12 @@ export async function getFastSessionById(
   // Sanitize at the read boundary, matching the task transcript path: the DB
   // stores full payloads, but oversized tool output is truncated before it is
   // serialized into the RSC payload.
-  const messages = windowed
-    .reverse()
-    .map((row): FastSessionMessage => sanitizeFastSessionMessageRow(row));
+  const messages = await attachFastSessionReplyImages(
+    session.id,
+    windowed
+      .reverse()
+      .map((row): FastSessionMessage => sanitizeFastSessionMessageRow(row)),
+  );
 
   // Fast usage events carry the OpenCode session id; a conversation can span
   // several (cold rebuilds), so sum across every session id the transcript


### PR DESCRIPTION
## Problem

When a delegated task captures a screenshot, the Fast reply attaches it via `imageArtifactIds`. Slack, Discord, Teams, and Telegram parent turns resolve those ids and post the files. The web Session transcript only renders `payload.images` URLs and never read `imageArtifactIds`, so a reply like "Here's the screenshot" rendered as text with no image.

## Fix

- The two transcript loaders (`getFastSessionById` for the initial page and `getFastSessionMessagesSince` for the SSE stream) now resolve each reply's `imageArtifactIds` to signed `/api/artifacts/<id>/raw` URLs and attach them as `payload.images`, which the existing transcript rendering already displays.
- Only uploaded `image/*` artifacts that belong to the Session's own tasks (via `taskRuns.fastAgentSessionId`, including legacy conversation ids) or to the Session itself are signed. Unknown, non-image, or foreign artifact ids are dropped.
- Signatures use an hourly bucketed timestamp so polled rows stay byte-stable across refreshes.
- The lookup only runs when new rows actually carry image ids, so the 1s stream poll is unaffected otherwise.
- Docs note that reply images appear inline.

## Tests

- `fast-sessions.test.ts`: a reply referencing an image artifact, a markdown artifact, an image from an unrelated task, and a missing id yields exactly one signed URL through both loaders.

`pnpm lint:fast`, `pnpm check-types:fast`, and `pnpm knip` pass.