### PR TITLE
[Fix] GitHub comment edits resolve their endpoint server-side

### DIFF
--- a/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/source-control-pull-request-writes.test.ts
@@ -1051,6 +1051,211 @@ describe('writeSourceControlPullRequestForTaskRun', () => {
     });
   });
 
+  function githubNotFound() {
+    return Object.assign(
+      new Error(
+        'Not Found - https://docs.github.com/rest/pulls/comments#update-a-review-comment-for-a-pull-request',
+      ),
+      { status: 404 },
+    );
+  }
+
+  it('edits a GitHub top-level comment even when threadId points at a review thread', async () => {
+    mockRepositoriesFindFirst.mockResolvedValue({
+      installationId: 'installation-1',
+      externalRepoId: null,
+      fullName: 'acme/backend',
+      htmlUrl: 'https://github.com/acme/backend',
+    });
+    mockCreateGitHubToken.mockResolvedValue('github-token');
+    const updateComment = vi.fn().mockResolvedValue({
+      data: {
+        id: 5534960823,
+        html_url:
+          'https://github.com/acme/backend/pull/93#issuecomment-5534960823',
+      },
+    });
+    const updateReviewComment = vi.fn().mockRejectedValue(githubNotFound());
+    mockGetOctokit.mockReturnValue({
+      rest: {
+        issues: { updateComment },
+        pulls: { updateReviewComment },
+      },
+    });
+
+    const result = await writeSourceControlPullRequestForTaskRun({
+      taskRun: makeTaskRun({
+        repo: 'acme/backend',
+        sourceControlProvider: 'github',
+      }),
+      input: {
+        action: 'update_pull_request_comment',
+        repositoryFullName: 'acme/backend',
+        prNumber: 93,
+        commentId: '5534960823',
+        threadId: 'unused',
+        body: 'Reviewing the PR now.',
+        sourceControlProvider: 'github',
+      },
+    });
+
+    expect(updateReviewComment).toHaveBeenCalledOnce();
+    expect(updateComment).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'backend',
+      comment_id: 5534960823,
+      body: 'Reviewing the PR now.',
+    });
+    expect(result).toMatchObject({
+      success: true,
+      threadId: null,
+      commentId: '5534960823',
+      url: 'https://github.com/acme/backend/pull/93#issuecomment-5534960823',
+      applied: true,
+    });
+  });
+
+  it('edits a GitHub review-thread comment even when threadId is omitted', async () => {
+    mockRepositoriesFindFirst.mockResolvedValue({
+      installationId: 'installation-1',
+      externalRepoId: null,
+      fullName: 'acme/backend',
+      htmlUrl: 'https://github.com/acme/backend',
+    });
+    mockCreateGitHubToken.mockResolvedValue('github-token');
+    const updateComment = vi.fn().mockRejectedValue(githubNotFound());
+    const updateReviewComment = vi.fn().mockResolvedValue({
+      data: {
+        id: 888,
+        html_url: 'https://github.com/acme/backend/pull/55#discussion_r888',
+      },
+    });
+    mockGetOctokit.mockReturnValue({
+      rest: {
+        issues: { updateComment },
+        pulls: { updateReviewComment },
+      },
+    });
+
+    const result = await writeSourceControlPullRequestForTaskRun({
+      taskRun: makeTaskRun({
+        repo: 'acme/backend',
+        sourceControlProvider: 'github',
+      }),
+      input: {
+        action: 'update_pull_request_comment',
+        repositoryFullName: 'acme/backend',
+        prNumber: 55,
+        commentId: '888',
+        body: 'Updated review thread reply.',
+        sourceControlProvider: 'github',
+      },
+    });
+
+    expect(updateComment).toHaveBeenCalledOnce();
+    expect(updateReviewComment).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'backend',
+      comment_id: 888,
+      body: 'Updated review thread reply.',
+    });
+    expect(result).toMatchObject({
+      success: true,
+      threadId: null,
+      commentId: '888',
+      url: 'https://github.com/acme/backend/pull/55#discussion_r888',
+    });
+  });
+
+  it('reports a 404 with guidance when GitHub knows neither kind of comment', async () => {
+    mockRepositoriesFindFirst.mockResolvedValue({
+      installationId: 'installation-1',
+      externalRepoId: null,
+      fullName: 'acme/backend',
+      htmlUrl: 'https://github.com/acme/backend',
+    });
+    mockCreateGitHubToken.mockResolvedValue('github-token');
+    mockGetOctokit.mockReturnValue({
+      rest: {
+        issues: { updateComment: vi.fn().mockRejectedValue(githubNotFound()) },
+        pulls: {
+          updateReviewComment: vi.fn().mockRejectedValue(githubNotFound()),
+        },
+      },
+    });
+
+    await expect(
+      writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'github',
+        }),
+        input: {
+          action: 'update_pull_request_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 55,
+          commentId: '999',
+          body: 'Orphaned edit.',
+          sourceControlProvider: 'github',
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: 'SourceControlWriteError',
+      httpStatus: 404,
+      message: expect.stringContaining('list_pull_request_comments'),
+    });
+  });
+
+  it('surfaces other GitHub request failures with their real status', async () => {
+    mockRepositoriesFindFirst.mockResolvedValue({
+      installationId: 'installation-1',
+      externalRepoId: null,
+      fullName: 'acme/backend',
+      htmlUrl: 'https://github.com/acme/backend',
+    });
+    mockCreateGitHubToken.mockResolvedValue('github-token');
+    const updateReviewComment = vi.fn();
+    mockGetOctokit.mockReturnValue({
+      rest: {
+        issues: {
+          updateComment: vi
+            .fn()
+            .mockRejectedValue(
+              Object.assign(
+                new Error('Resource not accessible by integration'),
+                { status: 403 },
+              ),
+            ),
+        },
+        pulls: { updateReviewComment },
+      },
+    });
+
+    await expect(
+      writeSourceControlPullRequestForTaskRun({
+        taskRun: makeTaskRun({
+          repo: 'acme/backend',
+          sourceControlProvider: 'github',
+        }),
+        input: {
+          action: 'update_pull_request_comment',
+          repositoryFullName: 'acme/backend',
+          prNumber: 55,
+          commentId: '777',
+          body: 'Forbidden edit.',
+          sourceControlProvider: 'github',
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: 'SourceControlWriteError',
+      httpStatus: 403,
+      message: expect.stringContaining(
+        'Resource not accessible by integration',
+      ),
+    });
+    expect(updateReviewComment).not.toHaveBeenCalled();
+  });
+
   it('updates a GitHub review comment when a real threadId is provided', async () => {
     mockRepositoriesFindFirst.mockResolvedValue({
       installationId: 'installation-1',

--- a/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
+++ b/packages/sdk/src/server/lib/pull-requests/source-control-pull-request-writes.ts
@@ -78,9 +78,10 @@ export const sourceControlPullRequestWriteInputSchema = z.object({
    * GitHub review thread GraphQL node ids, GitLab discussion ids, ADO
    * String(thread.id), Gitea String(review.id).
    *
-   * For update_pull_request_comment on GitHub: omit (or leave blank) for
-   * top-level issue comments; pass the review thread id only for
-   * review-thread comments.
+   * For update_pull_request_comment on GitHub it is only a hint: top-level
+   * issue comments and review-thread comments live on different endpoints,
+   * and the writer tries the other endpoint when the hinted one does not
+   * know the comment id.
    */
   threadId: optionalTrimmedNonEmptyStringSchema,
   /**
@@ -325,7 +326,11 @@ export async function writeSourceControlPullRequestForTaskRun({
   let result: SourceControlPullRequestWriteResult;
   switch (provider) {
     case 'github':
-      result = await writeGitHubPullRequest({ input, repository, provider });
+      try {
+        result = await writeGitHubPullRequest({ input, repository, provider });
+      } catch (error) {
+        throw toGitHubWriteError(input, error);
+      }
       break;
     case 'gitlab':
       result = await writeGitLabMergeRequest({
@@ -631,6 +636,81 @@ function getHttpErrorStatus(error: unknown): number | undefined {
   return undefined;
 }
 
+/**
+ * Octokit request failures carry the provider status but are not
+ * SourceControlWriteErrors, so without this they surface to the agent as a
+ * generic 500 that hides what GitHub actually said. Keep the real status and
+ * name the action so the agent can correct the call instead of retrying it.
+ */
+function toGitHubWriteError(
+  input: SourceControlPullRequestWriteInput,
+  error: unknown,
+): unknown {
+  if (error instanceof SourceControlWriteError) {
+    return error;
+  }
+  const status = getHttpErrorStatus(error);
+  if (status === undefined || status < 400) {
+    return error;
+  }
+  const detail = error instanceof Error ? error.message : String(error);
+  return new SourceControlWriteError(
+    status,
+    `GitHub rejected ${input.action} for pull request #${input.prNumber} in ${input.repositoryFullName}: ${detail}`,
+  );
+}
+
+/**
+ * GitHub keeps top-level issue comments and review-thread comments on
+ * different endpoints, but their ids share one id space and the writer can
+ * tell them apart itself. The caller's threadId only picks which endpoint to
+ * try first; a 404 there means the id belongs to the other kind, so the edit
+ * is retried on the other endpoint. A stale, filler, or missing threadId
+ * therefore never fails an edit of a comment that exists.
+ */
+async function updateGitHubPullRequestComment({
+  octokit,
+  owner,
+  repo,
+  input,
+}: {
+  octokit: ReturnType<typeof getOctokit>;
+  owner: string;
+  repo: string;
+  input: SourceControlPullRequestWriteInput;
+}): Promise<{ url: string | null; threadId: string | null }> {
+  const commentId = requireCommentId(input);
+  const body = requireBody(input);
+  const request = { owner, repo, comment_id: Number(commentId), body };
+  const asIssueComment = {
+    threadId: null,
+    run: () => octokit.rest.issues.updateComment(request),
+  };
+  const asReviewComment = {
+    threadId: input.threadId ?? null,
+    run: () => octokit.rest.pulls.updateReviewComment(request),
+  };
+  const attempts = input.threadId
+    ? [asReviewComment, asIssueComment]
+    : [asIssueComment, asReviewComment];
+
+  for (const attempt of attempts) {
+    try {
+      const { data } = await attempt.run();
+      return { url: data.html_url ?? null, threadId: attempt.threadId };
+    } catch (error) {
+      if (getHttpErrorStatus(error) !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  throw new SourceControlWriteError(
+    404,
+    `GitHub has no comment ${commentId} to update on pull request #${input.prNumber} in ${input.repositoryFullName} (checked both top-level and review-thread comments). Re-read list_pull_request_comments and retry with a comment id it returns.`,
+  );
+}
+
 function multiLineRangeWarnings(
   provider: SourceControlProvider,
   input: SourceControlPullRequestWriteInput,
@@ -822,30 +902,20 @@ async function writeGitHubPullRequest({
     }
     case 'update_pull_request_comment': {
       const commentId = requireCommentId(input);
-      const body = requireBody(input);
-      // A provided threadId marks the comment as a review-thread comment,
-      // which lives on the pulls API; plain issue comments live on issues.
-      const { data } = input.threadId
-        ? await octokit.rest.pulls.updateReviewComment({
-            owner,
-            repo,
-            comment_id: Number(commentId),
-            body,
-          })
-        : await octokit.rest.issues.updateComment({
-            owner,
-            repo,
-            comment_id: Number(commentId),
-            body,
-          });
+      const { url, threadId } = await updateGitHubPullRequestComment({
+        octokit,
+        owner,
+        repo,
+        input,
+      });
 
       return buildWriteResult({
         input,
         provider,
         repository,
-        threadId: input.threadId ?? null,
+        threadId,
         commentId,
-        url: data.html_url ?? null,
+        url,
       });
     }
     case 'resolve_pull_request_thread': {


### PR DESCRIPTION
## Problem

A PR review task spent ten consecutive `manage_source_control` calls failing to update its review summary comment. The model passed a placeholder `threadId` alongside a top-level issue comment id. The GitHub writer used `threadId` truthiness to choose `pulls.updateReviewComment` over `issues.updateComment`, so GitHub returned 404. Because octokit errors were not mapped, the api handler returned a generic 500 and the tool reported "500 Not Found", which gave the model nothing to correct, so it retried the identical call until it happened to drop `threadId`.

The same trap exists in the other direction: editing a review-thread comment without `threadId` also 404s.

## Fix

- **Resolve the endpoint server-side.** GitHub issue comments and review-thread comments share one id space, so the writer now uses `threadId` only as a hint for which endpoint to try first and retries the other on 404. If neither knows the id, it throws a 404 `SourceControlWriteError` that tells the agent to re-read `list_pull_request_comments`.
- **Surface real GitHub statuses.** Octokit request failures in the GitHub write path are wrapped as `SourceControlWriteError` with the provider status and the action name, so the tool result says what GitHub rejected instead of a generic 500. Existing `SourceControlWriteError`s (like the 422 anchor rejection) pass through unchanged.
- Other providers are unaffected: GitLab, Gitea, and Bitbucket already update by comment id regardless of `threadId`, and Azure DevOps requires it structurally.

## Tests

Four new cases in `source-control-pull-request-writes.test.ts`: filler `threadId` on a top-level comment, omitted `threadId` on a review comment, both endpoints 404, and a 403 surfacing with its real status.

`pnpm lint:fast`, `pnpm check-types:fast`, and `pnpm knip` pass.