### PR TITLE
[Fix] Session artifact links and images open the side panel instead of a new window

### DIFF
--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.client.test.tsx
@@ -16,6 +16,7 @@ import {
   type SessionInfo,
 } from './SessionWorkspace';
 import {
+  useOpenSessionArtifactViewer,
   useOpenSessionTaskPanel,
   useOpenSessionTasksPanel,
   useSessionRunningTaskCount,
@@ -314,6 +315,25 @@ function OpenNestedTask() {
   return (
     <button type="button" onClick={() => openTaskPanel?.('child-1')}>
       Open child
+    </button>
+  );
+}
+
+function OpenSessionArtifact() {
+  const openArtifactViewer = useOpenSessionArtifactViewer();
+
+  return (
+    <button
+      type="button"
+      onClick={() =>
+        openArtifactViewer?.({
+          owner: { sessionId: 'session-1' },
+          path: 'notes/decision.md',
+          version: 1,
+        })
+      }
+    >
+      Open decision link
     </button>
   );
 }
@@ -879,6 +899,39 @@ describe('SessionWorkspace', () => {
     expect(
       screen.getByRole('button', { name: 'Open Decision from Session' }),
     ).toBeVisible();
+  });
+
+  it('opens a transcript artifact link in the side panel and backs out to the gallery', async () => {
+    artifactQueryState.dataByPath['session-1:notes/decision.md'] = {
+      id: 'session-artifact',
+      taskId: null,
+      sessionId: 'session-1',
+      path: 'notes/decision.md',
+      version: 1,
+      artifactType: 'general',
+      contentType: 'text/markdown',
+      size: 100,
+      createdAt: new Date('2026-01-05T00:00:00.000Z'),
+      downloadUrl: '/api/artifacts/session-artifact/download',
+    };
+    renderWorkspace({ isMobile: false, children: <OpenSessionArtifact /> });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open decision link' }));
+
+    expect(screen.getByRole('heading', { name: 'Decision' })).toBeVisible();
+    expect(
+      await screen.findByText('Artifact preview: notes/decision.md'),
+    ).toBeVisible();
+    expect(artifactQueryInputs).toContainEqual({
+      sessionId: 'session-1',
+      path: 'notes/decision.md',
+      version: 1,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to artifacts' }));
+
+    expect(screen.getByRole('heading', { name: 'Artifacts' })).toBeVisible();
+    expect(screen.getByText('No artifacts in this session yet.')).toBeVisible();
   });
 
   it('shows the artifact gallery when a deep link matches no Session artifact', () => {

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.tsx
@@ -84,10 +84,12 @@ import {
 } from '../../use-sandbox-layout';
 import { NestedTaskSidePanel } from './NestedTaskSidePanel';
 import {
+  OpenSessionArtifactViewerContext,
   OpenSessionTaskPanelContext,
   OpenSessionTasksPanelContext,
   SessionRunningTaskCountContext,
   SessionTaskStateRevisionContext,
+  type SessionArtifactViewerSelection,
 } from './session-task-panel-context';
 import { DelegatedTaskCard } from '../../task/[taskId]/messages/acp/DelegatedTaskCard';
 import { useArtifactByPath } from '../../task/[taskId]/hooks/use-artifact-by-path';
@@ -355,11 +357,7 @@ function SessionArtifactViewer({
   onBack,
   onClose,
 }: {
-  selection: {
-    owner: { taskId: string } | { sessionId: string };
-    path: string;
-    version?: number;
-  };
+  selection: SessionArtifactViewerSelection;
   backLabel: string;
   closeLabel: string;
   onBack: () => void;
@@ -422,12 +420,6 @@ function SessionArtifactViewer({
     </>
   );
 }
-
-type SessionArtifactViewerSelection = {
-  owner: { taskId: string } | { sessionId: string };
-  path: string;
-  version?: number;
-};
 
 function SessionArtifactsPanel({
   tasks,
@@ -772,13 +764,10 @@ type BaseWorkspacePanel =
 
 type WorkspacePanel =
   | BaseWorkspacePanel
-  | {
+  | (SessionArtifactViewerSelection & {
       kind: 'artifact';
-      taskId: string;
-      path: string;
-      version?: number;
       returnTo: BaseWorkspacePanel | null;
-    };
+    });
 
 export function SessionWorkspace({
   session,
@@ -921,6 +910,19 @@ export function SessionWorkspace({
     setPanel({ kind: 'tasks' });
     selectTask(null);
   }, [selectTask, singleRunningTaskId]);
+  // Artifact links in the transcript open the viewer in the side panel instead
+  // of navigating; backing out lands on the Artifacts gallery.
+  const openArtifactViewer = useCallback(
+    (selection: SessionArtifactViewerSelection) => {
+      setPanel({
+        kind: 'artifact',
+        ...selection,
+        returnTo: { kind: 'artifacts' },
+      });
+      selectTask(null);
+    },
+    [selectTask],
+  );
   const closePanel = () => {
     setPanel(null);
     selectTask(null);
@@ -936,12 +938,12 @@ export function SessionWorkspace({
         surfaceClassName="relative flex flex-col overflow-hidden"
       >
         <SessionArtifactViewer
-          selection={{
-            owner: { taskId: panel.taskId },
-            path: panel.path,
-            version: panel.version,
-          }}
-          backLabel="Back to task"
+          selection={panel}
+          backLabel={
+            panel.returnTo?.kind === 'artifacts'
+              ? 'Back to artifacts'
+              : 'Back to task'
+          }
           closeLabel="Close artifact"
           onBack={() => setPanel(panel.returnTo)}
           onClose={closePanel}
@@ -956,7 +958,7 @@ export function SessionWorkspace({
         onOpenArtifact={(path, version) =>
           setPanel({
             kind: 'artifact',
-            taskId: selectedTask.taskId,
+            owner: { taskId: selectedTask.taskId },
             path,
             version,
             returnTo: null,
@@ -972,7 +974,7 @@ export function SessionWorkspace({
         onOpenArtifact={(path, version) =>
           setPanel({
             kind: 'artifact',
-            taskId: panel.taskId,
+            owner: { taskId: panel.taskId },
             path,
             version,
             returnTo: panel,
@@ -1004,85 +1006,94 @@ export function SessionWorkspace({
 
   return (
     <OpenSessionTaskPanelContext.Provider value={openTaskPanel}>
-      <WorkspaceSurface
-        className="relative"
-        sideActions={
-          <>
-            <SandboxSideActions isPanelOpen={panelOpen} onShowMain={closePanel}>
-              <SideNavItem
-                side="right"
-                label="Tasks"
-                tooltip="Tasks"
-                active={panel?.kind === 'tasks' && !selectedTask}
-                disabled={taskCards.length === 0}
-                icon={Rows4}
-                onClick={() => togglePanel('tasks')}
-              />
-              <SideNavItem
-                side="right"
-                label="Live Preview"
-                tooltip="Live Preview"
-                active={panel?.kind === 'previews' && !selectedTask}
-                disabled={sessionPreviewCount === 0}
-                icon={AppWindow}
-                onClick={() => togglePanel('previews')}
-              />
-              <SideNavItem
-                side="right"
-                label="Artifacts"
-                tooltip="Artifacts"
-                active={panel?.kind === 'artifacts' && !selectedTask}
-                icon={LayoutGrid}
-                onClick={() => togglePanel('artifacts')}
-              />
-              <SideNavItem
-                side="right"
-                label="Session info"
-                tooltip="Session info"
-                active={panel?.kind === 'info' && !selectedTask}
-                icon={Info}
-                onClick={() => togglePanel('info')}
-              />
-            </SandboxSideActions>
-            {!isSidebarVisible && !panelOpen ? (
-              <BasicTooltip content="Show sidebar">
-                <Button
-                  variant="ghost"
-                  className="absolute top-2.5 right-3 size-8 shrink-0 md:hidden"
-                  aria-label="Show sidebar"
-                  onClick={toggleSidebar}
+      <OpenSessionArtifactViewerContext.Provider value={openArtifactViewer}>
+        <WorkspaceSurface
+          className="relative"
+          sideActions={
+            <>
+              <SandboxSideActions
+                isPanelOpen={panelOpen}
+                onShowMain={closePanel}
+              >
+                <SideNavItem
+                  side="right"
+                  label="Tasks"
+                  tooltip="Tasks"
+                  active={panel?.kind === 'tasks' && !selectedTask}
+                  disabled={taskCards.length === 0}
+                  icon={Rows4}
+                  onClick={() => togglePanel('tasks')}
+                />
+                <SideNavItem
+                  side="right"
+                  label="Live Preview"
+                  tooltip="Live Preview"
+                  active={panel?.kind === 'previews' && !selectedTask}
+                  disabled={sessionPreviewCount === 0}
+                  icon={AppWindow}
+                  onClick={() => togglePanel('previews')}
+                />
+                <SideNavItem
+                  side="right"
+                  label="Artifacts"
+                  tooltip="Artifacts"
+                  active={panel?.kind === 'artifacts' && !selectedTask}
+                  icon={LayoutGrid}
+                  onClick={() => togglePanel('artifacts')}
+                />
+                <SideNavItem
+                  side="right"
+                  label="Session info"
+                  tooltip="Session info"
+                  active={panel?.kind === 'info' && !selectedTask}
+                  icon={Info}
+                  onClick={() => togglePanel('info')}
+                />
+              </SandboxSideActions>
+              {!isSidebarVisible && !panelOpen ? (
+                <BasicTooltip content="Show sidebar">
+                  <Button
+                    variant="ghost"
+                    className="absolute top-2.5 right-3 size-8 shrink-0 md:hidden"
+                    aria-label="Show sidebar"
+                    onClick={toggleSidebar}
+                  >
+                    <ArrowLeftFromLine className="size-4" />
+                  </Button>
+                </BasicTooltip>
+              ) : null}
+            </>
+          }
+        >
+          <ResponsiveWorkspacePanels
+            isPanelOpen={panelOpen}
+            mainSize={
+              panel?.kind === 'tasks' && panel.autoOpened ? 66.6667 : undefined
+            }
+            panelSize={
+              panel?.kind === 'tasks' && panel.autoOpened ? 33.3333 : undefined
+            }
+            main={
+              <SessionPullRequestsContext.Provider value={sessionPullRequests}>
+                <SessionRunningTaskCountContext.Provider
+                  value={runningTaskCount}
                 >
-                  <ArrowLeftFromLine className="size-4" />
-                </Button>
-              </BasicTooltip>
-            ) : null}
-          </>
-        }
-      >
-        <ResponsiveWorkspacePanels
-          isPanelOpen={panelOpen}
-          mainSize={
-            panel?.kind === 'tasks' && panel.autoOpened ? 66.6667 : undefined
-          }
-          panelSize={
-            panel?.kind === 'tasks' && panel.autoOpened ? 33.3333 : undefined
-          }
-          main={
-            <SessionPullRequestsContext.Provider value={sessionPullRequests}>
-              <SessionRunningTaskCountContext.Provider value={runningTaskCount}>
-                <SessionTaskStateRevisionContext.Provider
-                  value={taskStateRevision}
-                >
-                  <OpenSessionTasksPanelContext.Provider value={openTasksPanel}>
-                    {children}
-                  </OpenSessionTasksPanelContext.Provider>
-                </SessionTaskStateRevisionContext.Provider>
-              </SessionRunningTaskCountContext.Provider>
-            </SessionPullRequestsContext.Provider>
-          }
-          panel={panelContent}
-        />
-      </WorkspaceSurface>
+                  <SessionTaskStateRevisionContext.Provider
+                    value={taskStateRevision}
+                  >
+                    <OpenSessionTasksPanelContext.Provider
+                      value={openTasksPanel}
+                    >
+                      {children}
+                    </OpenSessionTasksPanelContext.Provider>
+                  </SessionTaskStateRevisionContext.Provider>
+                </SessionRunningTaskCountContext.Provider>
+              </SessionPullRequestsContext.Provider>
+            }
+            panel={panelContent}
+          />
+        </WorkspaceSurface>
+      </OpenSessionArtifactViewerContext.Provider>
     </OpenSessionTaskPanelContext.Provider>
   );
 }

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/session-task-panel-context.ts
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/session-task-panel-context.ts
@@ -8,6 +8,15 @@ export const OpenSessionTaskPanelContext = createContext<
 export const OpenSessionTasksPanelContext = createContext<(() => void) | null>(
   null,
 );
+/** Artifact the Session workspace can show in its side-panel viewer. */
+export type SessionArtifactViewerSelection = {
+  owner: { taskId: string } | { sessionId: string };
+  path: string;
+  version?: number;
+};
+export const OpenSessionArtifactViewerContext = createContext<
+  ((selection: SessionArtifactViewerSelection) => void) | null
+>(null);
 export const SessionRunningTaskCountContext = createContext(0);
 /** Fingerprint of the session's delegated-task state; see
  * `computeTaskStateRevision`. Drives composer-suggestion refreshes. */
@@ -19,6 +28,10 @@ export function useOpenSessionTaskPanel() {
 
 export function useOpenSessionTasksPanel() {
   return useContext(OpenSessionTasksPanelContext);
+}
+
+export function useOpenSessionArtifactViewer() {
+  return useContext(OpenSessionArtifactViewerContext);
 }
 
 export function useSessionRunningTaskCount() {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/hooks/services/acp-protocol-service.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/hooks/services/acp-protocol-service.ts
@@ -38,6 +38,7 @@ import { isNonTranscriptAcpEvent } from '../../acp-non-transcript';
 import { findStartedTodo } from '../../todo-status';
 import type {
   AcpUiMessage,
+  AcpUiMessageImageArtifact,
   AcpOtherUiMessage,
   AcpPlanUiMessage,
   AcpTodoSectionUiMessage,
@@ -133,6 +134,34 @@ function extractPayloadImageUris(payload: Record<string, unknown>): string[] {
   ]);
 
   return [...directPayloadImages, ...payloadBlockImages];
+}
+
+/**
+ * Fast reply images arrive with their backing artifact (see
+ * `attachFastSessionReplyImages`) so the transcript can open them in the
+ * artifact viewer. Malformed entries are dropped; the URL list still renders.
+ */
+function extractPayloadImageArtifacts(
+  payload: Record<string, unknown>,
+): AcpUiMessageImageArtifact[] | undefined {
+  if (!Array.isArray(payload.imageArtifacts)) return undefined;
+
+  const artifacts = payload.imageArtifacts.flatMap((value) => {
+    const record = asRecord(value);
+    if (!record) return [];
+    const url = asString(record.url);
+    const path = asString(record.path);
+    const ownerRecord = asRecord(record.owner);
+    const taskId = ownerRecord ? asString(ownerRecord.taskId) : undefined;
+    const sessionId = ownerRecord ? asString(ownerRecord.sessionId) : undefined;
+    const owner = taskId ? { taskId } : sessionId ? { sessionId } : null;
+    if (!url || !path || !owner || typeof record.version !== 'number') {
+      return [];
+    }
+    return [{ url, owner, path, version: record.version }];
+  });
+
+  return artifacts.length > 0 ? artifacts : undefined;
 }
 
 function extractMessageImageUris(
@@ -311,6 +340,7 @@ export function toAcpUiMessage(
           normalized.contentBlocks,
           payloadRecord,
         ),
+        imageArtifacts: extractPayloadImageArtifacts(payloadRecord),
         clientMessageId: getAcpClientMessageId(normalized) ?? undefined,
         data: payloadRecord,
       };

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpTextMessage.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/AcpTextMessage.tsx
@@ -46,6 +46,8 @@ import { TerminalProviderErrorMessage } from './TerminalProviderErrorMessage';
 import { PrReviewActionOffer } from '@/components/ai-elements/pr-review-action-offer';
 import { useMessageUiOptions } from '@/components/ai-elements/message-ui-options';
 import { SlackMessageText } from '@/components/ai-elements/slack-message-text';
+import { useOpenSessionArtifactViewer } from '@/app/(sandbox)/sessions/[sessionId]/session-task-panel-context';
+import { useArtifactLink } from '../../hooks/ArtifactLinkProvider';
 
 const UserMessageToggle = ({
   isExpanded,
@@ -195,6 +197,8 @@ export function AcpTextMessage({ msg }: AcpTextMessageProps) {
   );
   const showPersistentTimestamp = useInternalTranscriptRowsVisible();
   const { hidePrReviewActions } = useMessageUiOptions();
+  const openSessionArtifactViewer = useOpenSessionArtifactViewer();
+  const artifactLink = useArtifactLink();
   const isUser = msg.role === 'user';
   const baseContent =
     getReactionReceiptContent(msg) ??
@@ -252,6 +256,36 @@ export function AcpTextMessage({ msg }: AcpTextMessageProps) {
       ? 'Conversation image attachment'
       : `Conversation image attachment ${selectedImageIndex + 1}`;
 
+  // Images backed by an artifact open in the artifact viewer (Session side
+  // panel, or the task's own artifact panel); anything else falls back to the
+  // fullscreen media dialog.
+  const openImage = (index: number) => {
+    const url = msg.images?.[index];
+    const artifact = url
+      ? msg.imageArtifacts?.find((candidate) => candidate.url === url)
+      : undefined;
+    if (artifact && openSessionArtifactViewer) {
+      openSessionArtifactViewer({
+        owner: artifact.owner,
+        path: artifact.path,
+        version: artifact.version,
+      });
+      return;
+    }
+    if (
+      artifact &&
+      artifactLink &&
+      'taskId' in artifact.owner &&
+      artifactLink.artifacts.some(
+        (candidate) => candidate.path === artifact.path,
+      )
+    ) {
+      artifactLink.openArtifact(artifact.path, artifact.version);
+      return;
+    }
+    setSelectedImageIndex(index);
+  };
+
   if (!msg.partial && content === '' && !msg.images?.length) {
     return;
   }
@@ -282,7 +316,7 @@ export function AcpTextMessage({ msg }: AcpTextMessageProps) {
                   key={`${msg.ts}-${i}`}
                   type="button"
                   className="rounded-lg bg-transparent p-0 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-                  onClick={() => setSelectedImageIndex(i)}
+                  onClick={() => openImage(i)}
                   aria-label={`Open conversation image attachment ${i + 1}`}
                 >
                   <Attachment

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpTextMessage.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/__tests__/AcpTextMessage.client.test.tsx
@@ -10,6 +10,25 @@ const reviewActionMutate = vi.hoisted(() => vi.fn());
 const slackUsersState = vi.hoisted(() => ({
   users: {} as Record<string, { name: string; profileUrl: string | null }>,
 }));
+const artifactViewerState = vi.hoisted(() => ({
+  openSessionArtifactViewer: null as ReturnType<typeof vi.fn> | null,
+  artifactLink: null as {
+    openArtifact: ReturnType<typeof vi.fn>;
+    artifacts: Array<{ path: string }>;
+  } | null,
+}));
+
+vi.mock(
+  '@/app/(sandbox)/sessions/[sessionId]/session-task-panel-context',
+  () => ({
+    useOpenSessionArtifactViewer: () =>
+      artifactViewerState.openSessionArtifactViewer,
+  }),
+);
+
+vi.mock('../../../hooks/ArtifactLinkProvider', () => ({
+  useArtifactLink: () => artifactViewerState.artifactLink,
+}));
 
 vi.mock('@/trpc/client', () => ({
   useTRPCClient: () => ({
@@ -1035,6 +1054,101 @@ describe('AcpTextMessage', () => {
         name: 'Conversation image attachment 1',
       }),
     ).toBeVisible();
+  });
+
+  it('opens artifact-backed images in the Session artifact viewer instead of the media dialog', () => {
+    const openSessionArtifactViewer = vi.fn();
+    artifactViewerState.openSessionArtifactViewer = openSessionArtifactViewer;
+    const url = '/api/artifacts/artifact-1/raw?sig=abc&ts=7200';
+
+    try {
+      render(
+        <AcpTextMessage
+          msg={{
+            id: 'message-1',
+            ts: 123,
+            role: 'assistant',
+            kind: 'text',
+            partial: false,
+            sessionId: 'session-1',
+            updateType: 'roomote_runtime.assistant_message_chunk',
+            text: 'Here is the screenshot',
+            images: [url],
+            imageArtifacts: [
+              {
+                url,
+                owner: { taskId: 'task-1' },
+                path: 'proof/session.png',
+                version: 1,
+              },
+            ],
+            data: {},
+          }}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: 'Open conversation image attachment 1',
+        }),
+      );
+
+      expect(openSessionArtifactViewer).toHaveBeenCalledWith({
+        owner: { taskId: 'task-1' },
+        path: 'proof/session.png',
+        version: 1,
+      });
+      expect(screen.queryByTestId('media-viewer')).toBeNull();
+    } finally {
+      artifactViewerState.openSessionArtifactViewer = null;
+    }
+  });
+
+  it('opens artifact-backed images in the task artifact panel on a task page', () => {
+    const openArtifact = vi.fn();
+    artifactViewerState.artifactLink = {
+      openArtifact,
+      artifacts: [{ path: 'proof/session.png' }],
+    };
+    const url = '/api/artifacts/artifact-1/raw?sig=abc&ts=7200';
+
+    try {
+      render(
+        <AcpTextMessage
+          msg={{
+            id: 'message-1',
+            ts: 123,
+            role: 'assistant',
+            kind: 'text',
+            partial: false,
+            sessionId: 'session-1',
+            updateType: 'roomote_runtime.assistant_message_chunk',
+            text: 'Here is the screenshot',
+            images: [url],
+            imageArtifacts: [
+              {
+                url,
+                owner: { taskId: 'task-1' },
+                path: 'proof/session.png',
+                version: 1,
+              },
+            ],
+            data: {},
+          }}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: 'Open conversation image attachment 1',
+        }),
+      );
+
+      expect(openArtifact).toHaveBeenCalledWith('proof/session.png', 1);
+      expect(screen.queryByTestId('media-viewer')).toBeNull();
+    } finally {
+      artifactViewerState.artifactLink = null;
+    }
   });
 
   it('preserves leading and trailing whitespace in assistant action content', () => {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/types.ts
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/messages/acp/types.ts
@@ -7,6 +7,14 @@ import type {
   TaskMessageRole,
 } from '@roomote/types';
 
+/** Artifact backing an inline transcript image, when the server knows it. */
+export interface AcpUiMessageImageArtifact {
+  url: string;
+  owner: { taskId: string } | { sessionId: string };
+  path: string;
+  version: number;
+}
+
 interface AcpUiMessageBase {
   id: string;
   ts: number;
@@ -21,6 +29,7 @@ interface AcpUiMessageBase {
   updateType: AcpEventType;
   text?: string;
   images?: string[];
+  imageArtifacts?: AcpUiMessageImageArtifact[];
   toolCallId?: string;
   previousTs?: number;
   userId?: string;

--- a/apps/web/src/components/ai-elements/custom-link.client.test.tsx
+++ b/apps/web/src/components/ai-elements/custom-link.client.test.tsx
@@ -4,11 +4,14 @@ import { CustomLink } from './custom-link';
 
 const pushMock = vi.fn();
 const openArtifactMock = vi.fn();
+const openSessionArtifactViewerMock = vi.fn();
 
 let mockPathname = '/task/task-1';
 let mockArtifactLink: {
   openArtifact: (path: string, version?: number) => void;
 } | null = { openArtifact: openArtifactMock };
+let mockOpenSessionArtifactViewer: typeof openSessionArtifactViewerMock | null =
+  null;
 
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname,
@@ -19,11 +22,19 @@ vi.mock('@/app/(sandbox)/task/[taskId]/hooks/ArtifactLinkProvider', () => ({
   useArtifactLink: () => mockArtifactLink,
 }));
 
+vi.mock(
+  '@/app/(sandbox)/sessions/[sessionId]/session-task-panel-context',
+  () => ({
+    useOpenSessionArtifactViewer: () => mockOpenSessionArtifactViewer,
+  }),
+);
+
 describe('CustomLink', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPathname = '/task/task-1';
     mockArtifactLink = { openArtifact: openArtifactMock };
+    mockOpenSessionArtifactViewer = null;
   });
 
   it('opens same-task absolute artifact links in the current task panel', () => {
@@ -65,6 +76,64 @@ describe('CustomLink', () => {
     expect(openArtifactMock).not.toHaveBeenCalled();
     expect(pushMock).toHaveBeenCalledWith(
       '/task/task-2/artifacts/plans/demo-plan.md?v=3',
+      { scroll: false },
+    );
+  });
+
+  it('opens Session artifact links in the Session side panel', () => {
+    mockPathname = '/sessions/session-1';
+    mockArtifactLink = null;
+    mockOpenSessionArtifactViewer = openSessionArtifactViewerMock;
+    const href = `${window.location.origin}/sessions/session-1?artifact=notes%2Fdecision.md&v=2`;
+
+    render(<CustomLink href={href}>Open decision</CustomLink>);
+
+    const link = screen.getByRole('link', { name: 'Open decision' });
+    expect(link).not.toHaveAttribute('target');
+
+    fireEvent.click(link);
+
+    expect(openSessionArtifactViewerMock).toHaveBeenCalledWith({
+      owner: { sessionId: 'session-1' },
+      path: 'notes/decision.md',
+      version: 2,
+    });
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('opens task artifact links in the Session side panel when viewing a Session', () => {
+    mockPathname = '/sessions/session-1';
+    mockArtifactLink = null;
+    mockOpenSessionArtifactViewer = openSessionArtifactViewerMock;
+    const href = `${window.location.origin}/task/task-2/artifacts/plans/demo-plan.md?v=3`;
+
+    render(<CustomLink href={href}>Task artifact</CustomLink>);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Task artifact' }));
+
+    expect(openSessionArtifactViewerMock).toHaveBeenCalledWith({
+      owner: { taskId: 'task-2' },
+      path: 'plans/demo-plan.md',
+      version: 3,
+    });
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('navigates in-app for Session artifact links outside that Session', () => {
+    mockPathname = '/sessions/session-1';
+    mockOpenSessionArtifactViewer = openSessionArtifactViewerMock;
+    const href = `${window.location.origin}/sessions/session-2?artifact=notes%2Fdecision.md&v=1`;
+
+    render(<CustomLink href={href}>Other session artifact</CustomLink>);
+
+    const link = screen.getByRole('link', { name: 'Other session artifact' });
+    expect(link).not.toHaveAttribute('target');
+
+    fireEvent.click(link);
+
+    expect(openSessionArtifactViewerMock).not.toHaveBeenCalled();
+    expect(pushMock).toHaveBeenCalledWith(
+      '/sessions/session-2?artifact=notes%2Fdecision.md&v=1',
       { scroll: false },
     );
   });

--- a/apps/web/src/components/ai-elements/custom-link.client.test.tsx
+++ b/apps/web/src/components/ai-elements/custom-link.client.test.tsx
@@ -101,6 +101,23 @@ describe('CustomLink', () => {
     expect(pushMock).not.toHaveBeenCalled();
   });
 
+  it('opens the latest version when a Session artifact link has an invalid version', () => {
+    mockPathname = '/sessions/session-1';
+    mockArtifactLink = null;
+    mockOpenSessionArtifactViewer = openSessionArtifactViewerMock;
+    const href = `${window.location.origin}/sessions/session-1?artifact=notes%2Fdecision.md&v=1.5`;
+
+    render(<CustomLink href={href}>Open decision</CustomLink>);
+
+    fireEvent.click(screen.getByRole('link', { name: 'Open decision' }));
+
+    expect(openSessionArtifactViewerMock).toHaveBeenCalledWith({
+      owner: { sessionId: 'session-1' },
+      path: 'notes/decision.md',
+      version: undefined,
+    });
+  });
+
   it('opens task artifact links in the Session side panel when viewing a Session', () => {
     mockPathname = '/sessions/session-1';
     mockArtifactLink = null;

--- a/apps/web/src/components/ai-elements/custom-link.tsx
+++ b/apps/web/src/components/ai-elements/custom-link.tsx
@@ -4,9 +4,14 @@ import type { ComponentPropsWithoutRef } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { useArtifactLink } from '@/app/(sandbox)/task/[taskId]/hooks/ArtifactLinkProvider';
+import {
+  useOpenSessionArtifactViewer,
+  type SessionArtifactViewerSelection,
+} from '@/app/(sandbox)/sessions/[sessionId]/session-task-panel-context';
 
 const ARTIFACT_MARKER_PREFIX = 'https://__artifact__/';
 const TASK_ARTIFACT_PATH_PATTERN = /^\/task\/([^/]+)\/artifacts(?:\/(.+))?$/;
+const SESSION_PATH_PATTERN = /^\/sessions\/([^/]+)\/?$/;
 
 interface ParsedTaskArtifactUrl {
   taskId: string;
@@ -99,6 +104,66 @@ function parseTaskArtifactUrl(href: string): ParsedTaskArtifactUrl | null {
   };
 }
 
+interface ParsedSessionArtifactUrl {
+  sessionId: string;
+  path: string;
+  version?: number;
+  href: string;
+}
+
+/**
+ * Parse Session artifact deep links (`/sessions/<id>?artifact=<path>&v=<n>`),
+ * the shape `create_artifact` returns; mirrors `parseSessionArtifactSearchParams`.
+ */
+function parseSessionArtifactUrl(
+  href: string,
+): ParsedSessionArtifactUrl | null {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(href, 'http://localhost');
+  } catch {
+    return null;
+  }
+
+  if (
+    isAbsoluteUrl(href) &&
+    typeof window !== 'undefined' &&
+    parsedUrl.origin !== window.location.origin
+  ) {
+    return null;
+  }
+
+  const match = parsedUrl.pathname.match(SESSION_PATH_PATTERN);
+  if (!match || !match[1]) return null;
+
+  let sessionId: string;
+  try {
+    sessionId = decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
+
+  const path = parsedUrl.searchParams.get('artifact');
+  if (!path) return null;
+
+  const versionParam = parsedUrl.searchParams.get('v');
+  const parsedVersion = versionParam
+    ? Number.parseInt(versionParam, 10)
+    : undefined;
+  const version =
+    parsedVersion !== undefined && !Number.isNaN(parsedVersion)
+      ? parsedVersion
+      : undefined;
+
+  return {
+    sessionId,
+    path,
+    version,
+    href: `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`,
+  };
+}
+
 /**
  * Check if a URL is absolute (external link)
  */
@@ -173,6 +238,7 @@ type CustomLinkProps = ComponentPropsWithoutRef<'a'>;
  * Custom link component for Streamdown that handles URL transformation
  * - Artifact marker URLs open ArtifactDialog via ArtifactLinkContext (if available)
  * - Absolute task artifact URLs open in-app (same-task links use ArtifactLinkContext)
+ * - Artifact URLs on a Session page open the Session side-panel viewer
  * - External URLs open in new tab
  * - Internal task URLs (plans/, artifacts/) use client-side navigation
  * - Invalid URLs render as plain text
@@ -187,8 +253,17 @@ export const CustomLink = ({
   const pathname = usePathname();
   const router = useRouter();
   const artifactLink = useArtifactLink();
+  const openSessionArtifactViewer = useOpenSessionArtifactViewer();
   const parsedTaskArtifactUrl = href ? parseTaskArtifactUrl(href) : null;
+  const parsedSessionArtifactUrl = href ? parseSessionArtifactUrl(href) : null;
   const currentTaskId = pathname.match(/^\/task\/([^/]+)/)?.[1];
+  const currentSessionId = pathname.match(SESSION_PATH_PATTERN)?.[1];
+  // On a Session page, artifact links open the side-panel viewer in place.
+  const openInSessionViewer =
+    openSessionArtifactViewer && currentSessionId
+      ? (selection: SessionArtifactViewerSelection) =>
+          openSessionArtifactViewer(selection)
+      : null;
 
   // Handle artifact marker URLs produced by remark-artifact-links
   if (href && isArtifactMarkerUrl(href)) {
@@ -252,7 +327,43 @@ export const CustomLink = ({
             return;
           }
 
+          if (openInSessionViewer) {
+            openInSessionViewer({ owner: { taskId }, path, version });
+            return;
+          }
+
           router.push(taskArtifactHref, { scroll: false });
+        }}
+        className="text-primary underline underline-offset-2 hover:text-primary/80"
+        data-streamdown="link"
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  if (parsedSessionArtifactUrl) {
+    const {
+      sessionId,
+      path,
+      version,
+      href: sessionArtifactHref,
+    } = parsedSessionArtifactUrl;
+    const canOpenInCurrentSession =
+      openInSessionViewer && currentSessionId === sessionId;
+
+    return (
+      <a
+        href={sessionArtifactHref}
+        onClick={(e) => {
+          e.preventDefault();
+          if (canOpenInCurrentSession) {
+            openInSessionViewer({ owner: { sessionId }, path, version });
+            return;
+          }
+
+          router.push(sessionArtifactHref, { scroll: false });
         }}
         className="text-primary underline underline-offset-2 hover:text-primary/80"
         data-streamdown="link"

--- a/apps/web/src/components/ai-elements/custom-link.tsx
+++ b/apps/web/src/components/ai-elements/custom-link.tsx
@@ -8,6 +8,7 @@ import {
   useOpenSessionArtifactViewer,
   type SessionArtifactViewerSelection,
 } from '@/app/(sandbox)/sessions/[sessionId]/session-task-panel-context';
+import { parseSessionArtifactSearchParams } from '@/lib/artifact-view-urls';
 
 const ARTIFACT_MARKER_PREFIX = 'https://__artifact__/';
 const TASK_ARTIFACT_PATH_PATTERN = /^\/task\/([^/]+)\/artifacts(?:\/(.+))?$/;
@@ -113,7 +114,8 @@ interface ParsedSessionArtifactUrl {
 
 /**
  * Parse Session artifact deep links (`/sessions/<id>?artifact=<path>&v=<n>`),
- * the shape `create_artifact` returns; mirrors `parseSessionArtifactSearchParams`.
+ * the shape `create_artifact` returns. Shares the deep link's param parsing so
+ * a malformed version falls back to the latest version in both places.
  */
 function parseSessionArtifactUrl(
   href: string,
@@ -144,22 +146,12 @@ function parseSessionArtifactUrl(
     return null;
   }
 
-  const path = parsedUrl.searchParams.get('artifact');
-  if (!path) return null;
-
-  const versionParam = parsedUrl.searchParams.get('v');
-  const parsedVersion = versionParam
-    ? Number.parseInt(versionParam, 10)
-    : undefined;
-  const version =
-    parsedVersion !== undefined && !Number.isNaN(parsedVersion)
-      ? parsedVersion
-      : undefined;
+  const selection = parseSessionArtifactSearchParams(parsedUrl.searchParams);
+  if (!selection) return null;
 
   return {
     sessionId,
-    path,
-    version,
+    ...selection,
     href: `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`,
   };
 }

--- a/apps/web/src/lib/server/fast-sessions.test.ts
+++ b/apps/web/src/lib/server/fast-sessions.test.ts
@@ -276,17 +276,31 @@ describe('Fast session queries', () => {
     const expectedImages = [
       `/api/artifacts/${screenshot!.id}/raw?sig=sig-${screenshot!.id}-7200&ts=7200`,
     ];
+    const expectedImageArtifacts = [
+      {
+        url: expectedImages[0],
+        owner: { taskId: task.id },
+        path: 'proof/session.png',
+        version: 1,
+      },
+    ];
     const detail = await getFastSessionById(
       { userId: owner.id, isAdmin: false },
       session.id,
     );
     expect(detail?.messages.map((message) => message.payload)).toEqual([
-      expect.objectContaining({ images: expectedImages }),
+      expect.objectContaining({
+        images: expectedImages,
+        imageArtifacts: expectedImageArtifacts,
+      }),
     ]);
 
     const since = await getFastSessionMessagesSince(session.id, 0);
     expect(since.messages.map((message) => message.payload)).toEqual([
-      expect.objectContaining({ images: expectedImages }),
+      expect.objectContaining({
+        images: expectedImages,
+        imageArtifacts: expectedImageArtifacts,
+      }),
     ]);
   });
 

--- a/apps/web/src/lib/server/fast-sessions.ts
+++ b/apps/web/src/lib/server/fast-sessions.ts
@@ -157,7 +157,13 @@ async function attachFastSessionReplyImages<
   const lookupIds = [sessionId, ...(conversation?.legacyConversationIds ?? [])];
 
   const allowed = await db
-    .select({ id: taskArtifacts.id })
+    .select({
+      id: taskArtifacts.id,
+      taskId: taskArtifacts.taskId,
+      sessionId: taskArtifacts.sessionId,
+      path: taskArtifacts.path,
+      version: taskArtifacts.version,
+    })
     .from(taskArtifacts)
     .where(
       and(
@@ -182,8 +188,8 @@ async function attachFastSessionReplyImages<
         ),
       ),
     );
-  const allowedIds = new Set(allowed.map((row) => row.id));
-  if (allowedIds.size === 0) {
+  const allowedById = new Map(allowed.map((row) => [row.id, row]));
+  if (allowedById.size === 0) {
     return messages;
   }
 
@@ -192,20 +198,37 @@ async function attachFastSessionReplyImages<
     REPLY_IMAGE_SIGNATURE_WINDOW_SECONDS;
 
   return messages.map((message) => {
-    const images = readReplyImageArtifactIds(message.payload)
-      .filter((id) => allowedIds.has(id))
-      .map(
-        (id) =>
-          `/api/artifacts/${id}/raw?sig=${signArtifactId(id, signatureTimestamp)}&ts=${signatureTimestamp}`,
-      );
-    if (images.length === 0) {
+    // `imageArtifacts` carries the owner/path/version alongside each URL so
+    // the transcript can open the image in the artifact viewer.
+    const imageArtifacts = readReplyImageArtifactIds(message.payload).flatMap(
+      (id) => {
+        const artifact = allowedById.get(id);
+        if (!artifact) return [];
+        const owner = artifact.taskId
+          ? { taskId: artifact.taskId }
+          : artifact.sessionId
+            ? { sessionId: artifact.sessionId }
+            : null;
+        if (!owner) return [];
+        return [
+          {
+            url: `/api/artifacts/${id}/raw?sig=${signArtifactId(id, signatureTimestamp)}&ts=${signatureTimestamp}`,
+            owner,
+            path: artifact.path,
+            version: artifact.version,
+          },
+        ];
+      },
+    );
+    if (imageArtifacts.length === 0) {
       return message;
     }
     return {
       ...message,
       payload: {
         ...((message.payload as Record<string, unknown> | null) ?? {}),
-        images,
+        images: imageArtifacts.map((artifact) => artifact.url),
+        imageArtifacts,
       },
     };
   });


### PR DESCRIPTION
## Summary

Clicking an artifact link in a Session transcript opened a new browser window, and clicking an inline image opened a fullscreen media dialog. Both now open the artifact in the Session's side-panel viewer in place.

**Artifact links**
- `CustomLink` recognizes Session artifact links (`/sessions/<id>?artifact=<path>&v=<n>`, the shape `create_artifact` returns). On that Session's page they open the side-panel viewer via a new `OpenSessionArtifactViewerContext`. Task artifact links in a Session transcript open in the same panel instead of navigating away.
- Links to a different Session or task fall back to in-app navigation. Only external URLs still open in a new tab.
- `SessionWorkspace` generalizes the existing artifact panel to accept a task or Session owner, and the back button reads "Back to artifacts" when it returns to the gallery.

**Inline images**
- Fast reply images are signed raw artifact URLs. `attachFastSessionReplyImages` now also emits `payload.imageArtifacts` carrying the owner, path, and version next to each URL.
- `AcpTextMessage` opens artifact-backed images in the Session side-panel viewer, or in the task's own artifact panel on a task page. Images without a backing artifact (user uploads, data URIs) keep the media dialog.

The `SessionWorkspace.tsx` diff is mostly a re-indent from the new provider wrapper; `git diff -w` shows ~40 real lines.

## Test plan

- [x] New `CustomLink` tests: Session link opens the viewer, task link on a Session page opens the viewer, other-Session link navigates in-app, external links keep `_blank`.
- [x] New `SessionWorkspace` test: transcript link opens the viewer and backs out to the Artifacts gallery.
- [x] New `AcpTextMessage` tests: artifact-backed image opens the Session viewer / task artifact panel without the media dialog; plain images still open the dialog.
- [x] `fast-sessions` server test asserts `imageArtifacts` alongside `images`.
- [x] Full web client Vitest project passes (260 files / 2004 tests); web typecheck clean; oxlint clean; pre-push gates pass.
- [ ] Manual: in a Fast Session, click an artifact link and an inline reply image, confirm the side panel opens without a new window or dialog.