### PR TITLE
[Fix] Seed the OpenCode plugin install in the app image

### DIFF
--- a/.changeset/opencode-plugin-seed.md
+++ b/.changeset/opencode-plugin-seed.md
@@ -1,0 +1,7 @@
+---
+'@roomote/web': patch
+'@roomote/api': patch
+'@roomote/bullmq': patch
+---
+
+The first Fast message after a deploy no longer stalls for minutes. OpenCode installs `@opencode-ai/plugin` from the npm registry into every config directory it loads and blocks its first request on that install, so a fresh container paid a cold install on its first Fast turn (two to five minutes, and a hard failure once it outran the 300s response timeout). The app image now bakes that install, and the OpenCode SDK server copies it into the global config directory and the shared Fast tools directory before starting, so OpenCode's own install check is a no-op. Non-task inference (routing, summaries, work-kind classification) gets the same head start.

--- a/.docker/app/Dockerfile
+++ b/.docker/app/Dockerfile
@@ -334,6 +334,34 @@ RUN export HOME=/tmp/opencode-build \
   && ln -sf /opt/opencode-cli/node_modules/.bin/opencode /usr/local/bin/opencode \
   && rm -rf /tmp/opencode-build
 
+# OpenCode Arborist-installs @opencode-ai/plugin into every config directory
+# it loads and blocks its first request on that install whenever a plugin is
+# configured. Fresh containers start with empty config dirs under /tmp, so the
+# first Fast turn after each deploy paid a cold registry install (minutes, or
+# a 300s timeout). Bake a complete install here; the runtime copies it into
+# each config dir before `opencode serve` (opencode-plugin-seed.ts), which
+# makes OpenCode's own install check a no-op. Same layout and path as the
+# worker image's sandbox seed. Root-owned and world-readable is enough: the
+# runtime only reads it.
+RUN export HOME=/tmp/opencode-build \
+  && mkdir -p /opt/roomote/opencode-plugin-seed \
+  && printf '%s\n' \
+    '{' \
+    '  "name": "opencode",' \
+    '  "private": true,' \
+    '  "dependencies": {' \
+    "    \"@opencode-ai/plugin\": \"${OPENCODE_CLI_VERSION}\"" \
+    '  }' \
+    '}' > /opt/roomote/opencode-plugin-seed/package.json \
+  && npm install --prefix /opt/roomote/opencode-plugin-seed \
+    --ignore-scripts --no-audit --no-fund \
+  && test -f /opt/roomote/opencode-plugin-seed/package-lock.json \
+  && test "$(node -p "require('/opt/roomote/opencode-plugin-seed/node_modules/@opencode-ai/plugin/package.json').version")" = "${OPENCODE_CLI_VERSION}" \
+  && chmod -R a+rX /opt/roomote \
+  && rm -rf /tmp/opencode-build
+
+ENV ROOMOTE_OPENCODE_PLUGIN_SEED_DIR=/opt/roomote/opencode-plugin-seed
+
 # GitHub PR prompt generation still uses the gh CLI in the API process. Keep
 # the installer isolated so only API-bearing runtime targets receive it.
 FROM runtime-base AS github-cli

--- a/packages/cloud-agents/src/server/__tests__/helpers/opencode-plugin-seed-fixture.ts
+++ b/packages/cloud-agents/src/server/__tests__/helpers/opencode-plugin-seed-fixture.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { OPENCODE_PLUGIN_PACKAGE_NAME } from '../../opencode-plugin-seed';
+
+/**
+ * Writes the minimum tree OpenCode's `Npm.install` treats as already
+ * installed: package.json declaring the plugin, a lockfile whose root lists
+ * it, and the installed package's own package.json.
+ */
+export function writeOpenCodePluginSeedFixture(
+  dir: string,
+  version: string,
+  options: { installedVersion?: string; lockRootDependencies?: string[] } = {},
+): void {
+  const pluginDir = path.join(
+    dir,
+    'node_modules',
+    ...OPENCODE_PLUGIN_PACKAGE_NAME.split('/'),
+  );
+  mkdirSync(pluginDir, { recursive: true });
+  writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({
+      name: 'opencode',
+      private: true,
+      dependencies: { [OPENCODE_PLUGIN_PACKAGE_NAME]: version },
+    }),
+  );
+  const lockRoot = options.lockRootDependencies ?? [
+    OPENCODE_PLUGIN_PACKAGE_NAME,
+  ];
+  writeFileSync(
+    path.join(dir, 'package-lock.json'),
+    JSON.stringify({
+      name: 'opencode',
+      lockfileVersion: 3,
+      packages: {
+        '': {
+          dependencies: Object.fromEntries(
+            lockRoot.map((name) => [name, version]),
+          ),
+        },
+        [`node_modules/${OPENCODE_PLUGIN_PACKAGE_NAME}`]: { version },
+      },
+    }),
+  );
+  writeFileSync(
+    path.join(pluginDir, 'package.json'),
+    JSON.stringify({
+      name: OPENCODE_PLUGIN_PACKAGE_NAME,
+      version: options.installedVersion ?? version,
+    }),
+  );
+  writeFileSync(path.join(pluginDir, 'index.js'), 'export {};\n');
+}

--- a/packages/cloud-agents/src/server/__tests__/opencode-plugin-seed.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-plugin-seed.test.ts
@@ -1,0 +1,158 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { writeOpenCodePluginSeedFixture } from './helpers/opencode-plugin-seed-fixture';
+import {
+  isOpenCodePluginSeedComplete,
+  OPENCODE_PLUGIN_SEED_DIR_ENV,
+  resolveOpenCodePluginInstallDirs,
+  seedOpenCodePluginDependencies,
+  seedOpenCodePluginDependenciesForEnv,
+} from '../opencode-plugin-seed';
+
+describe('OpenCode plugin seed', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'opencode-plugin-seed-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('recognises a complete seed and rejects incomplete or stale ones', () => {
+    const complete = path.join(root, 'complete');
+    writeOpenCodePluginSeedFixture(complete, '1.18.10');
+    expect(isOpenCodePluginSeedComplete(complete)).toBe(true);
+
+    const bareDir = path.join(root, 'bare');
+    mkdirSync(bareDir);
+    writeFileSync(
+      path.join(bareDir, 'package.json'),
+      JSON.stringify({ private: true, type: 'module' }),
+    );
+    expect(isOpenCodePluginSeedComplete(bareDir)).toBe(false);
+
+    const unlocked = path.join(root, 'unlocked');
+    writeOpenCodePluginSeedFixture(unlocked, '1.18.10', {
+      lockRootDependencies: [],
+    });
+    expect(isOpenCodePluginSeedComplete(unlocked)).toBe(false);
+
+    const stale = path.join(root, 'stale');
+    writeOpenCodePluginSeedFixture(stale, '1.18.10', {
+      installedVersion: '1.17.0',
+    });
+    expect(isOpenCodePluginSeedComplete(stale)).toBe(false);
+  });
+
+  it('copies the baked seed into a config directory once', () => {
+    const seedDir = path.join(root, 'seed');
+    writeOpenCodePluginSeedFixture(seedDir, '1.18.10');
+    const configDir = path.join(root, 'config', 'opencode');
+    const env = { [OPENCODE_PLUGIN_SEED_DIR_ENV]: seedDir };
+
+    expect(seedOpenCodePluginDependencies(configDir, env)).toBe('copied');
+    expect(isOpenCodePluginSeedComplete(configDir)).toBe(true);
+    expect(
+      readFileSync(
+        path.join(
+          configDir,
+          'node_modules',
+          '@opencode-ai',
+          'plugin',
+          'index.js',
+        ),
+        'utf8',
+      ),
+    ).toBe('export {};\n');
+    expect(seedOpenCodePluginDependencies(configDir, env)).toBe(
+      'already-complete',
+    );
+  });
+
+  it('keeps a bare shared tools directory intact when copying into it', () => {
+    const seedDir = path.join(root, 'seed');
+    writeOpenCodePluginSeedFixture(seedDir, '1.18.10');
+    const configDir = path.join(root, 'shared-tools');
+    mkdirSync(path.join(configDir, 'tools'), { recursive: true });
+    writeFileSync(path.join(configDir, 'tools', 'send_chat_reply.js'), 'tool');
+    writeFileSync(
+      path.join(configDir, 'package.json'),
+      JSON.stringify({ private: true, type: 'module' }),
+    );
+
+    expect(
+      seedOpenCodePluginDependencies(configDir, {
+        [OPENCODE_PLUGIN_SEED_DIR_ENV]: seedDir,
+      }),
+    ).toBe('copied');
+    expect(
+      readFileSync(path.join(configDir, 'tools', 'send_chat_reply.js'), 'utf8'),
+    ).toBe('tool');
+    expect(isOpenCodePluginSeedComplete(configDir)).toBe(true);
+  });
+
+  it('leaves the directory alone when no usable seed is baked', () => {
+    const configDir = path.join(root, 'config', 'opencode');
+    expect(
+      seedOpenCodePluginDependencies(configDir, {
+        [OPENCODE_PLUGIN_SEED_DIR_ENV]: path.join(root, 'missing'),
+      }),
+    ).toBe('no-seed');
+    expect(existsSync(configDir)).toBe(false);
+
+    const incompleteSeed = path.join(root, 'incomplete-seed');
+    mkdirSync(incompleteSeed);
+    writeFileSync(path.join(incompleteSeed, 'package.json'), '{}');
+    expect(
+      seedOpenCodePluginDependencies(configDir, {
+        [OPENCODE_PLUGIN_SEED_DIR_ENV]: incompleteSeed,
+      }),
+    ).toBe('no-seed');
+    expect(existsSync(configDir)).toBe(false);
+  });
+
+  it('seeds both the XDG global config dir and OPENCODE_CONFIG_DIR for a server env', () => {
+    const seedDir = path.join(root, 'seed');
+    writeOpenCodePluginSeedFixture(seedDir, '1.18.10');
+    const home = path.join(root, 'home');
+    const sharedTools = path.join(root, 'shared-tools');
+    const env: NodeJS.ProcessEnv = {
+      HOME: home,
+      OPENCODE_CONFIG_DIR: sharedTools,
+      [OPENCODE_PLUGIN_SEED_DIR_ENV]: seedDir,
+    };
+
+    expect(resolveOpenCodePluginInstallDirs(env)).toEqual([
+      sharedTools,
+      path.join(home, '.config', 'opencode'),
+    ]);
+    expect(
+      resolveOpenCodePluginInstallDirs({
+        HOME: home,
+        XDG_CONFIG_HOME: path.join(root, 'xdg'),
+      }),
+    ).toEqual([path.join(root, 'xdg', 'opencode')]);
+
+    expect(seedOpenCodePluginDependenciesForEnv(env)).toEqual({
+      [sharedTools]: 'copied',
+      [path.join(home, '.config', 'opencode')]: 'copied',
+    });
+    expect(isOpenCodePluginSeedComplete(sharedTools)).toBe(true);
+    expect(
+      isOpenCodePluginSeedComplete(path.join(home, '.config', 'opencode')),
+    ).toBe(true);
+  });
+});

--- a/packages/cloud-agents/src/server/__tests__/opencode-plugin-seed.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-plugin-seed.test.ts
@@ -98,10 +98,24 @@ describe('OpenCode plugin seed', () => {
         [OPENCODE_PLUGIN_SEED_DIR_ENV]: seedDir,
       }),
     ).toBe('copied');
+    // The ESM tool files depend on `type: "module"` surviving the seed; only
+    // the dependency declarations come from the baked package.json.
+    expect(
+      JSON.parse(readFileSync(path.join(configDir, 'package.json'), 'utf8')),
+    ).toEqual({
+      private: true,
+      type: 'module',
+      dependencies: { '@opencode-ai/plugin': '1.18.10' },
+    });
     expect(
       readFileSync(path.join(configDir, 'tools', 'send_chat_reply.js'), 'utf8'),
     ).toBe('tool');
     expect(isOpenCodePluginSeedComplete(configDir)).toBe(true);
+    expect(
+      seedOpenCodePluginDependencies(configDir, {
+        [OPENCODE_PLUGIN_SEED_DIR_ENV]: seedDir,
+      }),
+    ).toBe('already-complete');
   });
 
   it('leaves the directory alone when no usable seed is baked', () => {

--- a/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-runtime.test.ts
@@ -11,6 +11,11 @@ import {
   NON_TASK_TOOL_PERMISSION_DENIALS,
   readOpenCodeDebugConfig,
 } from '../opencode-runtime';
+import {
+  isOpenCodePluginSeedComplete,
+  OPENCODE_PLUGIN_SEED_DIR_ENV,
+} from '../opencode-plugin-seed';
+import { writeOpenCodePluginSeedFixture } from './helpers/opencode-plugin-seed-fixture';
 
 describe('buildOpenCodeCliEnv', () => {
   const managedKeys = [
@@ -802,5 +807,50 @@ describe('OpenCode SDK server shutdown', () => {
     expect(process.listenerCount('SIGTERM')).toBeGreaterThanOrEqual(1);
     expect(process.listenerCount('SIGINT')).toBeGreaterThanOrEqual(1);
     expect(process.listenerCount('SIGHUP')).toBeGreaterThanOrEqual(1);
+  });
+
+  it('seeds the plugin install into every config dir before spawning the server', async () => {
+    const fixturePath = path.join(fixtureDir, 'fixture-server.cjs');
+    const pidFilePath = path.join(fixtureDir, 'pids.json');
+    writeFileSync(fixturePath, FIXTURE_SERVER_SOURCE);
+    process.env.OPENCODE_COMMAND = `${process.execPath} ${fixturePath}`;
+    const seedDir = path.join(fixtureDir, 'seed');
+    writeOpenCodePluginSeedFixture(seedDir, '1.18.10');
+    const home = path.join(fixtureDir, 'home');
+    const sharedTools = path.join(fixtureDir, 'shared-tools');
+
+    const lease = await leaseOpenCodeSdkServer({
+      env: {
+        OPENCODE_FIXTURE_PID_FILE: pidFilePath,
+        HOME: home,
+        OPENCODE_CONFIG_DIR: sharedTools,
+        [OPENCODE_PLUGIN_SEED_DIR_ENV]: seedDir,
+      },
+      startTimeoutMs: 15_000,
+    });
+
+    try {
+      expect(
+        await waitFor(() => {
+          try {
+            readFileSync(pidFilePath, 'utf8');
+            return true;
+          } catch {
+            return false;
+          }
+        }, 5_000),
+      ).toBe(true);
+      const { serverPid, grandchildPid } = JSON.parse(
+        readFileSync(pidFilePath, 'utf8'),
+      ) as { serverPid: number; grandchildPid: number };
+      trackedPids = [serverPid, grandchildPid];
+
+      expect(isOpenCodePluginSeedComplete(sharedTools)).toBe(true);
+      expect(
+        isOpenCodePluginSeedComplete(path.join(home, '.config', 'opencode')),
+      ).toBe(true);
+    } finally {
+      lease.release();
+    }
   });
 });

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
@@ -1184,12 +1184,14 @@ function createSharedToolsDirectory(): string {
   const toolsDirectory = join(directory, 'tools');
   mkdirSync(toolsDirectory, { recursive: true, mode: 0o700 });
   chmodSync(directory, 0o700);
-  // OpenCode installs `@opencode-ai/plugin` (and with it the zod major it
-  // validates tool arguments against) into this directory the first time it
-  // boots here, then reuses the install for every later conversation on the
-  // host. The tools' `zod` import must resolve to that copy: pointing it at
-  // the app's own zod 3 made OpenCode's zod 4 validator reject array
-  // arguments. Leave package.json without a lockfile so the install runs.
+  // `@opencode-ai/plugin` (and with it the zod major OpenCode validates tool
+  // arguments against) must be installed in this directory: the tools' `zod`
+  // import has to resolve to that copy, because pointing it at the app's own
+  // zod 3 made OpenCode's zod 4 validator reject array arguments. The SDK
+  // server spawn copies the image-baked install in (opencode-plugin-seed.ts)
+  // so OpenCode never fetches it at runtime; where no seed is baked (local
+  // dev), leaving package.json without a lockfile lets OpenCode's own install
+  // run on first boot as before.
   if (!existsSync(join(directory, 'package.json'))) {
     writeFileSync(
       join(directory, 'package.json'),

--- a/packages/cloud-agents/src/server/opencode-plugin-seed.ts
+++ b/packages/cloud-agents/src/server/opencode-plugin-seed.ts
@@ -1,0 +1,171 @@
+import { cpSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * OpenCode Arborist-installs `@opencode-ai/plugin` into every config
+ * directory it loads (the XDG global one and `OPENCODE_CONFIG_DIR`) and, when
+ * any plugin is configured, blocks instance bootstrap on that install. In a
+ * fresh container those directories start empty, so the first request after
+ * every deploy paid a cold registry install (minutes on a slow path, and a
+ * hard failure once it outran the SDK's 300s headers timeout). The app image
+ * bakes a complete install; this module copies it into place before the
+ * server is spawned so OpenCode's own `Npm.install` check no-ops.
+ */
+
+export const OPENCODE_PLUGIN_PACKAGE_NAME = '@opencode-ai/plugin';
+export const OPENCODE_PLUGIN_SEED_DIR_ENV = 'ROOMOTE_OPENCODE_PLUGIN_SEED_DIR';
+/** Image bake path shared with the worker image's sandbox seed. */
+const DEFAULT_OPENCODE_PLUGIN_SEED_DIR = '/opt/roomote/opencode-plugin-seed';
+
+const SEED_ENTRIES = ['package.json', 'package-lock.json', 'node_modules'];
+
+type OpenCodePluginSeedResult = 'already-complete' | 'copied' | 'no-seed';
+
+type DependencyMaps = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+};
+
+function readJson(filePath: string): unknown {
+  try {
+    return JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function dependencyNames(maps: DependencyMaps): Set<string> {
+  return new Set([
+    ...Object.keys(maps.dependencies ?? {}),
+    ...Object.keys(maps.devDependencies ?? {}),
+    ...Object.keys(maps.peerDependencies ?? {}),
+    ...Object.keys(maps.optionalDependencies ?? {}),
+  ]);
+}
+
+/**
+ * Mirrors OpenCode's `Npm.install` short-circuit: `node_modules` exists and
+ * the lockfile root lists every declared dependency, including the plugin
+ * OpenCode itself adds. Also requires the installed plugin to match the
+ * declared version so a stale seed never masquerades as complete.
+ */
+export function isOpenCodePluginSeedComplete(configDir: string): boolean {
+  const packageJson = readJson(join(configDir, 'package.json'));
+  const lock = readJson(join(configDir, 'package-lock.json'));
+  const installed = readJson(
+    join(
+      configDir,
+      'node_modules',
+      ...OPENCODE_PLUGIN_PACKAGE_NAME.split('/'),
+      'package.json',
+    ),
+  );
+  if (!isRecord(packageJson) || !isRecord(lock) || !isRecord(installed)) {
+    return false;
+  }
+
+  const declared = dependencyNames(packageJson as DependencyMaps);
+  declared.add(OPENCODE_PLUGIN_PACKAGE_NAME);
+  const packages = isRecord(lock.packages) ? lock.packages : {};
+  const root = isRecord(packages['']) ? packages[''] : {};
+  const locked = dependencyNames(root as DependencyMaps);
+  for (const name of declared) {
+    if (!locked.has(name)) return false;
+  }
+
+  const declaredVersion = (packageJson as DependencyMaps).dependencies?.[
+    OPENCODE_PLUGIN_PACKAGE_NAME
+  ]
+    ?.trim()
+    .replace(/^[\^~>=<\s]+/u, '');
+  return (
+    typeof installed.version === 'string' &&
+    installed.version.trim() !== '' &&
+    (declaredVersion === undefined ||
+      installed.version.trim() === declaredVersion)
+  );
+}
+
+function resolveOpenCodePluginSeedSourceDir(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return (
+    env[OPENCODE_PLUGIN_SEED_DIR_ENV]?.trim() ||
+    DEFAULT_OPENCODE_PLUGIN_SEED_DIR
+  );
+}
+
+/**
+ * The directories OpenCode will install into for a server launched with
+ * `env`: `OPENCODE_CONFIG_DIR` when set, plus the XDG global config dir
+ * (`$XDG_CONFIG_HOME/opencode`, else `$HOME/.config/opencode`).
+ */
+export function resolveOpenCodePluginInstallDirs(
+  env: NodeJS.ProcessEnv,
+): string[] {
+  const xdgConfigHome =
+    env.XDG_CONFIG_HOME?.trim() ||
+    join(env.HOME?.trim() || homedir(), '.config');
+  const globalDir = join(xdgConfigHome, 'opencode');
+  const configDir = env.OPENCODE_CONFIG_DIR?.trim();
+  return configDir && configDir !== globalDir
+    ? [configDir, globalDir]
+    : [globalDir];
+}
+
+let missingSeedWarned = false;
+
+/**
+ * Copies the image-baked plugin install into `configDir` unless it is already
+ * complete. Returns `no-seed` (and keeps OpenCode's own install as the
+ * fallback) when the image has no usable seed, which is the local-dev case.
+ */
+export function seedOpenCodePluginDependencies(
+  configDir: string,
+  env: NodeJS.ProcessEnv = process.env,
+): OpenCodePluginSeedResult {
+  if (isOpenCodePluginSeedComplete(configDir)) return 'already-complete';
+
+  const sourceDir = resolveOpenCodePluginSeedSourceDir(env);
+  if (!existsSync(sourceDir) || !isOpenCodePluginSeedComplete(sourceDir)) {
+    if (!missingSeedWarned && existsSync(DEFAULT_OPENCODE_PLUGIN_SEED_DIR)) {
+      missingSeedWarned = true;
+      console.warn(
+        `[OpenCode] Plugin seed at ${sourceDir} is incomplete; OpenCode will install ${OPENCODE_PLUGIN_PACKAGE_NAME} from the registry on first boot.`,
+      );
+    }
+    return 'no-seed';
+  }
+
+  mkdirSync(configDir, { recursive: true });
+  for (const entry of SEED_ENTRIES) {
+    cpSync(join(sourceDir, entry), join(configDir, entry), {
+      recursive: true,
+      force: true,
+    });
+  }
+  if (!isOpenCodePluginSeedComplete(configDir)) {
+    throw new Error(
+      `Copied the OpenCode plugin seed from ${sourceDir} into ${configDir}, but the result is still incomplete.`,
+    );
+  }
+  return 'copied';
+}
+
+/** Seeds every directory OpenCode would install into for a server spawned with `env`. */
+export function seedOpenCodePluginDependenciesForEnv(
+  env: NodeJS.ProcessEnv,
+): Record<string, OpenCodePluginSeedResult> {
+  const results: Record<string, OpenCodePluginSeedResult> = {};
+  for (const dir of resolveOpenCodePluginInstallDirs(env)) {
+    results[dir] = seedOpenCodePluginDependencies(dir, env);
+  }
+  return results;
+}

--- a/packages/cloud-agents/src/server/opencode-plugin-seed.ts
+++ b/packages/cloud-agents/src/server/opencode-plugin-seed.ts
@@ -1,4 +1,10 @@
-import { cpSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -18,7 +24,8 @@ export const OPENCODE_PLUGIN_SEED_DIR_ENV = 'ROOMOTE_OPENCODE_PLUGIN_SEED_DIR';
 /** Image bake path shared with the worker image's sandbox seed. */
 const DEFAULT_OPENCODE_PLUGIN_SEED_DIR = '/opt/roomote/opencode-plugin-seed';
 
-const SEED_ENTRIES = ['package.json', 'package-lock.json', 'node_modules'];
+/** Copied verbatim; package.json is merged instead (see below). */
+const SEED_COPY_ENTRIES = ['package-lock.json', 'node_modules'];
 
 type OpenCodePluginSeedResult = 'already-complete' | 'copied' | 'no-seed';
 
@@ -145,12 +152,38 @@ export function seedOpenCodePluginDependencies(
   }
 
   mkdirSync(configDir, { recursive: true });
-  for (const entry of SEED_ENTRIES) {
+  // Merge rather than replace package.json: the shared Fast tools directory
+  // already carries `type: "module"` for its ESM tool files (as OpenCode's
+  // own Arborist install would have preserved), so only the dependency
+  // declarations come from the seed.
+  const existingPackageJson = readJson(join(configDir, 'package.json'));
+  const seedPackageJson = readJson(join(sourceDir, 'package.json'));
+  for (const entry of SEED_COPY_ENTRIES) {
     cpSync(join(sourceDir, entry), join(configDir, entry), {
       recursive: true,
       force: true,
     });
   }
+  const mergedPackageJson = {
+    ...(isRecord(existingPackageJson)
+      ? existingPackageJson
+      : isRecord(seedPackageJson)
+        ? seedPackageJson
+        : {}),
+    dependencies: {
+      ...(isRecord(existingPackageJson) &&
+      isRecord(existingPackageJson.dependencies)
+        ? existingPackageJson.dependencies
+        : {}),
+      ...(isRecord(seedPackageJson) && isRecord(seedPackageJson.dependencies)
+        ? seedPackageJson.dependencies
+        : {}),
+    },
+  };
+  writeFileSync(
+    join(configDir, 'package.json'),
+    `${JSON.stringify(mergedPackageJson, null, 2)}\n`,
+  );
   if (!isOpenCodePluginSeedComplete(configDir)) {
     throw new Error(
       `Copied the OpenCode plugin seed from ${sourceDir} into ${configDir}, but the result is still incomplete.`,

--- a/packages/cloud-agents/src/server/opencode-runtime.ts
+++ b/packages/cloud-agents/src/server/opencode-runtime.ts
@@ -35,6 +35,7 @@ import {
 } from '../opencode-prompt-subagents';
 import { OPENCODE_IDENTITY_PLUGIN_SCRIPT } from '../opencode-identity-plugin';
 import { FAST_AGENT_SUBAGENT_TOOL_FILTER } from './fast-agent/fast-agent-tool-policy';
+import { seedOpenCodePluginDependenciesForEnv } from './opencode-plugin-seed';
 
 const ESCAPE_CHARACTER = String.fromCharCode(27);
 const BELL_CHARACTER = String.fromCharCode(7);
@@ -824,8 +825,22 @@ async function startManagedOpenCodeSdkServer(
     `--hostname=${OPENCODE_SDK_SERVER_HOSTNAME}`,
     `--port=${port}`,
   ]);
+  const env = buildOpenCodeCliEnv(extraEnv, options);
+  // OpenCode blocks its first request on an `@opencode-ai/plugin` registry
+  // install into each config directory it loads; a fresh container after a
+  // deploy paid that in full (minutes, or a 300s timeout). Copy the
+  // image-baked install into place first so that check no-ops.
+  try {
+    seedOpenCodePluginDependenciesForEnv(env);
+  } catch (error) {
+    console.warn(
+      `[OpenCode] Failed to seed plugin dependencies before starting the SDK server: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
   const proc = spawn(command.command, command.args, {
-    env: buildOpenCodeCliEnv(extraEnv, options),
+    env,
     stdio: ['ignore', 'pipe', 'pipe'],
     // Own process group, so shutdown can signal the entire tree (shell
     // wrappers included) via the negative pid.


### PR DESCRIPTION
## Problem

OpenCode runs an npm install of `@opencode-ai/plugin` (via Arborist) into every config directory it loads, and when any plugin is configured its instance bootstrap awaits that install before serving the first request. The app image starts every container with empty config directories under `/tmp`, so the first Fast turn after each deploy paid a cold registry install. On three consecutive deploys of the same day the first Fast turn spent 143s, 221s, and 305s inside `opencode_setup`; the 305s case failed outright when session validation hit the SDK's headers timeout. In the UI this reads as a session stuck on "Thinking" with no notice, because nothing was interrupted and the reconcile job has nothing to fix.

The `[Fast Agent] Turn finished.` line shows it directly: `sandboxlessStartupDurationMs=225047 inferenceSetupDurationMs=221190` on a turn whose actual inference took 5s. Later turns on the same container are fast even after the OpenCode server respawns from its idle timeout, because `node_modules` persists in `/tmp` for the container's life.

The same cold install also hits non-task inference on a fresh container (routing, summaries, work-kind classification), where it shows up as `NonTaskOpenCodePromptTimeoutError` on the first call.

## Fix

- **`.docker/app/Dockerfile`**: bake a complete `@opencode-ai/plugin@${OPENCODE_CLI_VERSION}` install at `/opt/roomote/opencode-plugin-seed` (package.json, package-lock.json, node_modules) and export `ROOMOTE_OPENCODE_PLUGIN_SEED_DIR`. Same layout and path as the worker image's existing sandbox seed. The build asserts the installed plugin version matches the OpenCode CLI version.
- **`opencode-plugin-seed.ts`** (new, cloud-agents): resolves the directories OpenCode will install into for a given server env (`OPENCODE_CONFIG_DIR` plus the XDG global config dir) and copies the seed into each unless it is already complete. Completeness mirrors OpenCode's own `Npm.install` short-circuit (node_modules present, lockfile root lists every declared dependency, installed version matches the declared one).
- **`opencode-runtime.ts`**: seed before spawning the managed SDK server. A seeding failure is logged and does not block the spawn.
- **`fast-agent-native-tool-bridge.ts`**: comment update only. The shared tools directory still ships a bare `package.json` so OpenCode's install remains the fallback where no seed is baked (local dev).

## Validation

- `vitest`: new `opencode-plugin-seed.test.ts` (completeness checks, copy-once, no-seed fallback, both install dirs), plus a lease-level test in `opencode-runtime.test.ts` that spawns the fixture server and asserts both config dirs are seeded before it starts. Bridge tests unchanged and passing.
- `pnpm check-types:fast`, `pnpm lint:fast`, `pnpm knip` clean.
- Not run: a full image build. The Dockerfile step is a copy of the worker image's proven seed recipe with the app image's disposable-`HOME` convention.

## Follow-ups (not in this PR)

- The worker keeps its own copy of the seed helper; it could import the cloud-agents one.
- `cold_resume` after a deploy is guaranteed to fail (the persisted OpenCode session id belongs to the previous container) and could skip validation when the config dir was just created.
- A visible "starting up" notice when inference setup exceeds a few seconds would stop the next slow path from reading as a hang.