### PR TITLE
[Fix] Bound OpenCode's own plugin install when the baked seed does not apply

### DIFF
--- a/.changeset/opencode-npm-config-bounds.md
+++ b/.changeset/opencode-npm-config-bounds.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Bounds the plugin install OpenCode runs on its own when the image-baked seed does not apply, such as local development or an OpenCode version bump shipped without a rebuilt seed. Each config directory OpenCode installs into now carries npm settings that prefer the local cache, give up on a stalled registry request after 15 seconds, and retry once, so a missing seed costs seconds instead of the five-minute stall that dead-ended the first Fast turn after a deploy.

--- a/packages/cloud-agents/src/server/__tests__/opencode-plugin-seed.test.ts
+++ b/packages/cloud-agents/src/server/__tests__/opencode-plugin-seed.test.ts
@@ -17,6 +17,7 @@ import {
   OPENCODE_PLUGIN_SEED_DIR_ENV,
   resolveOpenCodePluginInstallDirs,
   seedOpenCodePluginDependencies,
+  OPENCODE_NPM_CONFIG_CONTENT,
   seedOpenCodePluginDependenciesForEnv,
 } from '../opencode-plugin-seed';
 
@@ -168,5 +169,56 @@ describe('OpenCode plugin seed', () => {
     expect(
       isOpenCodePluginSeedComplete(path.join(home, '.config', 'opencode')),
     ).toBe(true);
+    // Both directories also carry the bounded npm settings, so a future
+    // stale seed falls back to a short install rather than a 300s stall.
+    for (const dir of [sharedTools, path.join(home, '.config', 'opencode')]) {
+      expect(readFileSync(path.join(dir, '.npmrc'), 'utf8')).toBe(
+        OPENCODE_NPM_CONFIG_CONTENT,
+      );
+    }
+  });
+
+  it('bounds the install OpenCode runs itself when no seed applies', () => {
+    const home = path.join(root, 'home');
+    const sharedTools = path.join(root, 'shared-tools');
+    const env: NodeJS.ProcessEnv = {
+      HOME: home,
+      OPENCODE_CONFIG_DIR: sharedTools,
+      [OPENCODE_PLUGIN_SEED_DIR_ENV]: path.join(root, 'missing'),
+    };
+
+    expect(seedOpenCodePluginDependenciesForEnv(env)).toEqual({
+      [sharedTools]: 'no-seed',
+      [path.join(home, '.config', 'opencode')]: 'no-seed',
+    });
+    // No seed to copy, but OpenCode's own install must not wait out npm's
+    // default 300s per stalled registry request.
+    for (const dir of [sharedTools, path.join(home, '.config', 'opencode')]) {
+      expect(readFileSync(path.join(dir, '.npmrc'), 'utf8')).toContain(
+        'fetch-timeout=15000',
+      );
+      expect(existsSync(path.join(dir, 'node_modules'))).toBe(false);
+    }
+  });
+
+  it('leaves an existing .npmrc alone', () => {
+    const seedDir = path.join(root, 'seed');
+    writeOpenCodePluginSeedFixture(seedDir, '1.18.10');
+    const home = path.join(root, 'home');
+    const globalDir = path.join(home, '.config', 'opencode');
+    mkdirSync(globalDir, { recursive: true });
+    writeFileSync(
+      path.join(globalDir, '.npmrc'),
+      'registry=https://npm.example.test\n',
+    );
+
+    seedOpenCodePluginDependenciesForEnv({
+      HOME: home,
+      [OPENCODE_PLUGIN_SEED_DIR_ENV]: seedDir,
+    });
+
+    expect(readFileSync(path.join(globalDir, '.npmrc'), 'utf8')).toBe(
+      'registry=https://npm.example.test\n',
+    );
   });
 });

--- a/packages/cloud-agents/src/server/opencode-plugin-seed.ts
+++ b/packages/cloud-agents/src/server/opencode-plugin-seed.ts
@@ -192,12 +192,50 @@ export function seedOpenCodePluginDependencies(
   return 'copied';
 }
 
-/** Seeds every directory OpenCode would install into for a server spawned with `env`. */
+const OPENCODE_NPM_CONFIG_FILE = '.npmrc';
+
+/**
+ * npm settings OpenCode's own Arborist install reads from the directory it
+ * installs into. They only matter when the seed is absent or stale (local
+ * development, or an OpenCode bump shipped without a rebuilt seed): npm's
+ * defaults wait 300s for a stalled registry response and retry twice, which
+ * is what turned a missing seed into a five-minute dead Fast turn. Prefer
+ * the local cache, give up on a stalled request in 15s, and retry once, so
+ * the fallback install costs seconds. Measured locally with OpenCode 1.18.10
+ * against an unseeded global config dir: 500s without this file, 3s with it.
+ */
+export const OPENCODE_NPM_CONFIG_CONTENT = [
+  'prefer-offline=true',
+  'fetch-timeout=15000',
+  'fetch-retries=1',
+  'audit=false',
+  'fund=false',
+  '',
+].join('\n');
+
+/**
+ * Writes the bounded npm settings into `configDir` unless the directory
+ * already carries its own `.npmrc`, which is left alone as operator intent.
+ */
+export function writeOpenCodeNpmConfigIfMissing(configDir: string): boolean {
+  const target = join(configDir, OPENCODE_NPM_CONFIG_FILE);
+  if (existsSync(target)) return false;
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(target, OPENCODE_NPM_CONFIG_CONTENT);
+  return true;
+}
+
+/**
+ * Seeds every directory OpenCode would install into for a server spawned
+ * with `env`, and bounds the install OpenCode runs itself wherever the seed
+ * does not apply.
+ */
 export function seedOpenCodePluginDependenciesForEnv(
   env: NodeJS.ProcessEnv,
 ): Record<string, OpenCodePluginSeedResult> {
   const results: Record<string, OpenCodePluginSeedResult> = {};
   for (const dir of resolveOpenCodePluginInstallDirs(env)) {
+    writeOpenCodeNpmConfigIfMissing(dir);
     results[dir] = seedOpenCodePluginDependencies(dir, env);
   }
   return results;


### PR DESCRIPTION
## Summary

Safety net behind #2180. That PR fixed the primary cause of the stalled first Fast turn after a deploy by baking the `@opencode-ai/plugin` install into the image and copying it into both config directories before OpenCode is spawned. This PR bounds the install OpenCode still runs on its own whenever that seed does not apply: local development, or an OpenCode version bump shipped without a rebuilt seed.

Each directory OpenCode installs into now carries an `.npmrc` with `prefer-offline=true`, `fetch-timeout=15000`, `fetch-retries=1`, `audit=false`, `fund=false`. npm's defaults wait 300s per stalled registry request and retry twice, which is exactly what turned a missing seed into a five-minute dead turn that outran the SDK's 300s headers timeout. An existing `.npmrc` is left alone.

## Why

OpenCode runs `Npm.install` for every config directory it loads (the XDG global one and `OPENCODE_CONFIG_DIR`) and blocks instance bootstrap on it when custom tool files exist. Staging stalls between 22:32Z and 04:45Z on 2026-09-03/04 each lined up with the first human Fast turn after an API deploy, when the fresh container's config directories were empty.

Measured locally with OpenCode 1.18.10 against an unseeded global config dir:

| Setup | First boot |
| --- | --- |
| No `.npmrc` | ~500s |
| This `.npmrc` | ~3s |

## Test plan

- [x] `opencode-plugin-seed.test.ts`: both dirs get the `.npmrc` alongside the seed, `no-seed` dirs still get it without any `node_modules`, an existing `.npmrc` is preserved
- [x] `opencode-runtime.test.ts` still passes
- [x] oxfmt, oxlint, `tsc --noEmit` on cloud-agents (only pre-existing faker type errors in `packages/db` fixtures, unrelated)
- [ ] Staging: first Fast turn after the next deploy stays fast
