### PR TITLE
[Fix] GitHub mentions in skipped repositories get a response

### DIFF
--- a/apps/api/src/handlers/github/__tests__/index.test.ts
+++ b/apps/api/src/handlers/github/__tests__/index.test.ts
@@ -835,7 +835,7 @@ describe('github webhook router', () => {
     expect(mockHandlePrComment).toHaveBeenCalledWith(payload);
   });
 
-  it('notifies linked tasks about PR comments in skipped repositories without handling mentions', async () => {
+  it('still routes PR comments in skipped repositories to mention handling', async () => {
     mockIsRepoSkipped.mockReturnValue(true);
     const payload = {
       action: 'created',
@@ -874,7 +874,80 @@ describe('github webhook router', () => {
       payload,
       'delivery-skipped-pr-comment',
     );
+    // The skip list suppresses unsolicited automations only; the mention
+    // handler decides whether this comment addressed the app.
+    expect(mockHandlePrComment).toHaveBeenCalledWith(payload);
+  });
+
+  it('still routes plain issue comments in skipped repositories to mention handling', async () => {
+    mockIsRepoSkipped.mockReturnValue(true);
+    const payload = {
+      action: 'created',
+      installation: { id: 1 },
+      repository: { id: 10, full_name: 'test-org/test-repo' },
+      issue: { number: 43 },
+      comment: {
+        id: 9,
+        body: '@roomote can you take a look?',
+        user: { login: 'alice' },
+      },
+      sender: { login: 'alice' },
+    };
+
+    const response = await app.request('http://localhost/api/webhooks/github', {
+      method: 'POST',
+      headers: {
+        'x-github-delivery': 'delivery-skipped-issue-comment',
+        'x-github-event': 'issue_comment',
+        'x-hub-signature-256': 'sha256=test',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockHandleGitHubIssueComment).toHaveBeenCalledWith(payload);
     expect(mockHandlePrComment).not.toHaveBeenCalled();
+    expect(mockQueuePrReviewActivityNotification).not.toHaveBeenCalled();
+  });
+
+  it('handles body mentions but skips Triage Issues for opened issues in skipped repositories', async () => {
+    mockIsRepoSkipped.mockReturnValue(true);
+    mockHandleGitHubIssueComment.mockResolvedValue({
+      status: 'ok',
+      message: 'fast_session_queued',
+    });
+    const payload = {
+      action: 'opened',
+      installation: { id: 1 },
+      repository: { id: 10, full_name: 'test-org/test-repo' },
+      issue: {
+        number: 44,
+        title: 'Flaky retry',
+        body: '@roomote please investigate',
+        user: { login: 'alice' },
+      },
+      sender: { login: 'alice' },
+    };
+
+    const response = await app.request('http://localhost/api/webhooks/github', {
+      method: 'POST',
+      headers: {
+        'x-github-delivery': 'delivery-skipped-issue-opened',
+        'x-github-event': 'issues',
+        'x-hub-signature-256': 'sha256=test',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockHandleGitHubIssueComment).toHaveBeenCalledWith({
+      installation: payload.installation,
+      repository: payload.repository,
+      sender: payload.sender,
+      issue: payload.issue,
+      mentionBody: '@roomote please investigate',
+    });
+    expect(mockHandleGitHubIssueFixer).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -905,7 +978,7 @@ describe('github webhook router', () => {
       },
     },
   ])(
-    'notifies linked tasks for $event callbacks in skipped repositories without handling mentions',
+    'notifies linked tasks and still handles mentions for $event callbacks in skipped repositories',
     async ({ event, action, delivery, activity }) => {
       mockIsRepoSkipped.mockReturnValue(true);
       const payload = {
@@ -937,7 +1010,7 @@ describe('github webhook router', () => {
       expect(
         mockQueuePrReviewActivityNotification.mock.invocationCallOrder[0],
       ).toBeLessThan(mockRecordWebhook.mock.invocationCallOrder[0]!);
-      expect(mockHandlePrComment).not.toHaveBeenCalled();
+      expect(mockHandlePrComment).toHaveBeenCalledWith(payload);
     },
   );
 

--- a/apps/api/src/handlers/github/index.ts
+++ b/apps/api/src/handlers/github/index.ts
@@ -263,22 +263,12 @@ github.post('/', async (c) => {
         `${name}.${payload.action}`,
         payload,
         async () => {
+          // Mentions are not subject to the automated skip list: a person
+          // addressing this app by name gets a response even in repositories
+          // where unsolicited automations are suppressed. The handlers return
+          // `no_mention` for everything else.
           if (!payload.issue.pull_request) {
-            if (isRepoSkipped(payload.repository.full_name)) {
-              return {
-                status: 'ok' as const,
-                message: `Skipping comment webhook for ${payload.repository.full_name}`,
-              };
-            }
-
             return handleGitHubIssueComment(payload);
-          }
-
-          if (isRepoSkipped(payload.repository.full_name)) {
-            return {
-              status: 'ok' as const,
-              message: `Skipping automated comment handling for ${payload.repository.full_name}`,
-            };
           }
 
           return handlePrComment(payload);
@@ -312,13 +302,6 @@ github.post('/', async (c) => {
 
     webhooks.on('issues.opened', ({ id, name, payload }) =>
       recordWebhook(id, `${name}.${payload.action}`, payload, async () => {
-        if (isRepoSkipped(payload.repository.full_name)) {
-          return {
-            status: 'ok' as const,
-            message: `Skipping issue webhook for ${payload.repository.full_name}`,
-          };
-        }
-
         const mentionResult = await handleGitHubIssueComment({
           installation: payload.installation,
           repository: payload.repository,
@@ -326,6 +309,12 @@ github.post('/', async (c) => {
           issue: payload.issue,
           mentionBody: payload.issue.body ?? '',
         });
+
+        // Triage Issues is unsolicited automation, so the skip list applies
+        // to it but not to the body mention above.
+        if (isRepoSkipped(payload.repository.full_name)) {
+          return mentionResult;
+        }
 
         // Always run Triage Issues when enabled (immediate, like Review Code).
         // Mentions and Triage Issues are independent: a mention still starts a
@@ -561,16 +550,7 @@ github.post('/', async (c) => {
           id,
           `${name}.${payload.action}`,
           payload,
-          async () => {
-            if (isRepoSkipped(payload.repository.full_name)) {
-              return {
-                status: 'ok' as const,
-                message: `Skipping automated review handling for ${payload.repository.full_name}`,
-              };
-            }
-
-            return handlePrComment(payload);
-          },
+          async () => handlePrComment(payload),
         );
       },
     );
@@ -584,16 +564,7 @@ github.post('/', async (c) => {
           id,
           `${name}.${payload.action}`,
           payload,
-          async () => {
-            if (isRepoSkipped(payload.repository.full_name)) {
-              return {
-                status: 'ok' as const,
-                message: `Skipping automated comment handling for ${payload.repository.full_name}`,
-              };
-            }
-
-            return handlePrComment(payload);
-          },
+          async () => handlePrComment(payload),
         );
       },
     );

--- a/apps/docs/environment-variables.mdx
+++ b/apps/docs/environment-variables.mdx
@@ -309,8 +309,8 @@ as per-task auth tokens or workspace paths.
 | `R_GITHUB_CLIENT_SECRET`       | GitHub       | GitHub OAuth client secret.                                                                 |
 | `R_GITHUB_WEBHOOK_SECRET`      | GitHub       | GitHub webhook secret.                                                                      |
 | `GITHUB_MCP_SERVER_URL`        | Optional     | GitHub MCP server URL override.                                                             |
-| `GITHUB_AUTOMATED_SKIP_REPOS`  | Optional     | Repository skip list for automated GitHub processing.                                       |
-| `GITHUB_AUTOMATED_SKIP_OWNERS` | Optional     | Owner skip list for automated GitHub processing.                                            |
+| `GITHUB_AUTOMATED_SKIP_REPOS`  | Optional     | Repository skip list for unsolicited GitHub automations (reviews, triage, conflict checks). Mentions still get a response. |
+| `GITHUB_AUTOMATED_SKIP_OWNERS` | Optional     | Owner skip list for unsolicited GitHub automations. Mentions still get a response.          |
 | `GITLAB_BASE_URL`              | Optional     | GitLab base URL for self-managed GitLab.                                                    |
 | `GITLAB_CLIENT_ID`             | GitLab       | GitLab OAuth application ID.                                                                |
 | `GITLAB_CLIENT_SECRET`         | GitLab       | GitLab OAuth application secret.                                                            |

--- a/packages/github/src/is-repo-skipped.ts
+++ b/packages/github/src/is-repo-skipped.ts
@@ -4,6 +4,11 @@ import { Env } from '@roomote/env';
  * Comma-separated list of repository full names (e.g. "owner/repo") that
  * should be skipped for automated GitHub processing.
  *
+ * "Automated" means unsolicited work such as Review Code, Triage Issues,
+ * conflict checks, and workflow-run handling. Explicit mentions of this app
+ * and lifecycle notifications for tasks that already track a pull request are
+ * never skipped: someone addressing the app by name always gets a response.
+ *
  * The value comes from the optional `GITHUB_AUTOMATED_SKIP_REPOS` env var.
  */
 const skippedRepos: Set<string> = new Set(


### PR DESCRIPTION
## Problem

`GITHUB_AUTOMATED_SKIP_REPOS` / `GITHUB_AUTOMATED_SKIP_OWNERS` gated every GitHub webhook handler, including explicit mentions of the app. On a skipped repository, `@<app-slug>` in a PR comment, review comment, submitted review, issue comment, or opened issue body returned `ok` in a few milliseconds with no reaction, no reply, and no fallback comment. The `pull_request.closed` handler already documents the intended meaning ("skipped repositories suppress automated review work, not lifecycle notifications"), and the "Also respond to @roomote" setting anticipates two deployments sharing a repository, which is exactly the setup where one deployment is skip-listed and still gets addressed by name.

## Change

- The skip list now applies only to unsolicited automations: Review Code (open/reopen/synchronize/ready-for-review), Triage Issues (`issues.opened` and `issues.reopened`), push conflict checks, mergeability checks, and workflow-run handling.
- Mention paths always reach `handlePrComment` / `handleGitHubIssueComment`, which still return `no_mention` when nobody addressed the app.
- `issues.opened` runs the body-mention handler first and then applies the skip list to Triage Issues only.
- Updated the env var docs and the `isRepoSkipped` doc comment to say what "automated" means.

## Tests

- Flipped the three "skipped repositories without handling mentions" router tests to assert the mention handler is called.
- Added router tests for a plain issue comment and an opened issue in a skipped repository (mention handled, Triage Issues not launched).
- `apps/api` GitHub handler tests and `tsc` pass locally.
