### PR TITLE
[Fix] GitHub account linking rejected by GitHub; completed deployments re-prompt for inference on /setup

### DIFF
--- a/apps/web/src/app/(centered)/layout.client.test.tsx
+++ b/apps/web/src/app/(centered)/layout.client.test.tsx
@@ -44,6 +44,18 @@ vi.mock('@/components/layout', () => ({
 
 import Layout from './layout';
 
+/**
+ * Mirrors the `<base64url payload>.<signature>` shape produced by
+ * createSignedGitHubAuthState; the layout never verifies the signature.
+ */
+function encodeSignedStyleState(payload: Record<string, unknown>): string {
+  const encoded = btoa(JSON.stringify(payload))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/u, '');
+  return `${encoded}.signature`;
+}
+
 describe('Centered layout', () => {
   beforeEach(() => {
     framedSurfaceMock.mockClear();
@@ -77,6 +89,68 @@ describe('Centered layout', () => {
 
   it('uses the basic framed surface when the callback requests the regular background', () => {
     state.searchParams = new URLSearchParams('bg=background');
+
+    render(
+      <Layout>
+        <div>child</div>
+      </Layout>,
+    );
+
+    expect(framedSurfaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'basic',
+      }),
+      undefined,
+    );
+  });
+
+  it('reads the background hint from a signed account-link state', () => {
+    state.searchParams = new URLSearchParams({
+      state: encodeSignedStyleState({
+        mode: 'auth',
+        redirect: '/settings',
+        bg: 'accent',
+      }),
+    });
+
+    render(
+      <Layout>
+        <div>child</div>
+      </Layout>,
+    );
+
+    expect(framedSurfaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'bold',
+      }),
+      undefined,
+    );
+  });
+
+  it('uses the bold framed surface for setup-originated signed states', () => {
+    state.searchParams = new URLSearchParams({
+      state: encodeSignedStyleState({
+        mode: 'auth',
+        redirect: '/setup?step=source-control-config',
+      }),
+    });
+
+    render(
+      <Layout>
+        <div>child</div>
+      </Layout>,
+    );
+
+    expect(framedSurfaceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'bold',
+      }),
+      undefined,
+    );
+  });
+
+  it('falls back to the basic framed surface for an unreadable state', () => {
+    state.searchParams = new URLSearchParams({ state: 'not.base64.json' });
 
     render(
       <Layout>

--- a/apps/web/src/app/(centered)/layout.tsx
+++ b/apps/web/src/app/(centered)/layout.tsx
@@ -6,17 +6,49 @@ import { decodeRecord } from '@/lib';
 
 import { FramedSurface, UserMenu } from '@/components/layout';
 
+type CallbackState = Record<string, string>;
+
+function decodeBase64UrlJson(value: string): CallbackState | undefined {
+  try {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const parsed: unknown = JSON.parse(atob(normalized));
+    return parsed && typeof parsed === 'object'
+      ? (parsed as CallbackState)
+      : undefined;
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+/**
+ * Reads the presentation hints (`redirect`, `bg`) from the OAuth `state`
+ * parameter. Install flows carry a plain encoded record; account-link flows
+ * carry a signed `<base64url payload>.<signature>` state whose payload is
+ * decoded here without verification because only cosmetic hints are read.
+ * The server verifies the signature before acting on the state.
+ */
+function readCallbackState(
+  encodedState: string | null,
+): CallbackState | undefined {
+  if (!encodedState) return undefined;
+
+  const decoded = decodeRecord<CallbackState>(encodedState);
+  if (decoded) return decoded;
+
+  const [payload, signature, ...rest] = encodedState.split('.');
+  if (!payload || !signature || rest.length > 0) return undefined;
+
+  return decodeBase64UrlJson(payload);
+}
+
 export default function OnboardingLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   const searchParams = useSearchParams();
-  const requestedBackground = searchParams.get('bg');
-  const encodedState = searchParams.get('state');
-  const decodedState = encodedState
-    ? decodeRecord<Record<string, string>>(encodedState)
-    : undefined;
+  const decodedState = readCallbackState(searchParams.get('state'));
+  const requestedBackground = searchParams.get('bg') ?? decodedState?.bg;
   const redirect = decodedState?.redirect ?? '';
   const isOnboardingOrigin =
     redirect.startsWith('/setup') || redirect.startsWith('/onboarding');

--- a/apps/web/src/app/(onboarding)/setup/SetupSignedInFlow.client.test.tsx
+++ b/apps/web/src/app/(onboarding)/setup/SetupSignedInFlow.client.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen, waitFor } from '@testing-library/react';
+
+const { replaceMock, setupStatusState, createSessionState, flowState } =
+  vi.hoisted(() => ({
+    replaceMock: vi.fn(),
+    setupStatusState: {
+      current: {
+        data: null as Record<string, unknown> | null,
+        isLoading: false,
+        isError: false,
+      },
+    },
+    createSessionState: {
+      current: {
+        mutate: vi.fn(),
+        isPending: false,
+        isError: false,
+        data: undefined as { sessionId: string } | undefined,
+        error: null,
+      },
+    },
+    flowState: {
+      current: {
+        step: 'inference' as const,
+        status: null as Record<string, unknown> | null,
+        isLoading: false,
+        isError: false,
+      },
+    },
+  }));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock, push: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useUser', () => ({
+  useUser: () => ({
+    authStatus: 'signed-in',
+    isSignedIn: true,
+    user: { isAdmin: true },
+  }),
+}));
+
+vi.mock('@/trpc/client', () => ({
+  useTRPC: () => ({
+    setup: {
+      status: { queryOptions: () => ({ queryKey: ['setup.status'] }) },
+      getOrCreateSession: {
+        mutationOptions: (options: Record<string, unknown>) => options,
+      },
+    },
+    setupNew: {
+      trackWelcomeSeen: { mutationOptions: () => ({}) },
+    },
+  }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => setupStatusState.current,
+  useMutation: (options: { onSuccess?: unknown }) =>
+    options && 'onSuccess' in options
+      ? createSessionState.current
+      : { mutate: vi.fn(), isPending: false },
+}));
+
+vi.mock('./hooks', () => ({
+  useSetupFlow: () => ({
+    ...flowState.current,
+    transitionDirection: 1,
+    entryContext: {
+      openrouterOauthStatus: null,
+      openrouterOauthErrorReason: null,
+    },
+    goToStep: vi.fn(),
+    goToPreviousStep: vi.fn(),
+    goToNextStep: vi.fn(),
+    canGoBack: false,
+    readSetupSearchParams: () => new URLSearchParams(),
+    commitSetupUrl: vi.fn(),
+  }),
+}));
+
+vi.mock('./SetupBootstrapFlow', () => ({
+  LoadingSetupFlow: () => <div>loading-setup</div>,
+  stepTransitionVariants: {},
+}));
+
+vi.mock('./StepWelcome', () => ({
+  StepWelcome: () => <div>step-welcome</div>,
+}));
+vi.mock('./StepConfigureInference', () => ({
+  StepConfigureInference: () => <div>step-configure-inference</div>,
+}));
+vi.mock('./StepInferenceProvider', () => ({
+  StepInferenceProvider: () => <div>step-inference-provider</div>,
+}));
+
+import { SetupSignedInFlow } from './SetupSignedInFlow';
+
+function buildFlowStatus(overrides: Record<string, unknown> = {}) {
+  return {
+    setupCompletedAt: null,
+    modelSetup: { setupSatisfied: false, setupSatisfiedByRuntimeEnv: false },
+    setupNewState: { modelProvider: null },
+    ...overrides,
+  };
+}
+
+describe('SetupSignedInFlow', () => {
+  beforeEach(() => {
+    replaceMock.mockClear();
+    createSessionState.current = {
+      mutate: vi.fn(),
+      isPending: false,
+      isError: false,
+      data: undefined,
+      error: null,
+    };
+    flowState.current = {
+      step: 'inference',
+      status: buildFlowStatus(),
+      isLoading: false,
+      isError: false,
+    };
+    setupStatusState.current = {
+      data: { setupCompletedAt: null },
+      isLoading: false,
+      isError: false,
+    };
+  });
+
+  it('shows the inference step while setup is still open', () => {
+    render(<SetupSignedInFlow />);
+
+    expect(screen.getByText('step-configure-inference')).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
+  it('holds the spinner until the completion check resolves', () => {
+    setupStatusState.current = { data: null, isLoading: true, isError: false };
+
+    render(<SetupSignedInFlow />);
+
+    expect(screen.getByText('loading-setup')).toBeInTheDocument();
+    expect(
+      screen.queryByText('step-configure-inference'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('sends admins Home instead of re-prompting for inference once setup is complete', async () => {
+    setupStatusState.current = {
+      data: { setupCompletedAt: '2026-09-04T12:02:14.782Z' },
+      isLoading: false,
+      isError: false,
+    };
+    flowState.current.status = buildFlowStatus({
+      setupCompletedAt: '2026-09-04T12:02:14.782Z',
+      modelSetup: { setupSatisfied: true, setupSatisfiedByRuntimeEnv: false },
+    });
+
+    render(<SetupSignedInFlow />);
+
+    expect(screen.getByText('loading-setup')).toBeInTheDocument();
+    expect(
+      screen.queryByText('step-configure-inference'),
+    ).not.toBeInTheDocument();
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith('/'));
+    expect(createSessionState.current.mutate).not.toHaveBeenCalled();
+  });
+
+  it('leaves the setup Session hand-off alone when it is in flight', () => {
+    setupStatusState.current = {
+      data: { setupCompletedAt: '2026-09-04T12:02:14.782Z' },
+      isLoading: false,
+      isError: false,
+    };
+    createSessionState.current.data = { sessionId: 'session-1' };
+
+    render(<SetupSignedInFlow />);
+
+    expect(screen.getByText('loading-setup')).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalledWith('/');
+  });
+});

--- a/apps/web/src/app/(onboarding)/setup/SetupSignedInFlow.tsx
+++ b/apps/web/src/app/(onboarding)/setup/SetupSignedInFlow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { AnimatePresence, motion } from 'motion/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
@@ -87,16 +87,14 @@ export function SetupSignedInFlow() {
     setupStatus.data != null
       ? getSetupRedirectPath(setupStatus.data)
       : null;
-  const observedIncompleteSetupRef = useRef(false);
-
-  useEffect(() => {
-    if (
-      setupStatus.data?.setupCompletedAt == null &&
-      setupStatus.data != null
-    ) {
-      observedIncompleteSetupRef.current = true;
-    }
-  }, [setupStatus.data]);
+  // Setup is complete once the setup Session records it. This page only
+  // bootstraps inference for a fresh deployment, so a completed deployment
+  // (for example an admin reopening the Cloud "open your deployment" link)
+  // has nothing left to show here.
+  const setupAlreadyCompleted =
+    shouldEvaluateSetupRedirect &&
+    !setupStatus.isError &&
+    setupStatus.data?.setupCompletedAt != null;
 
   useEffect(() => {
     if (authStatus === 'signed-in' && !isAdmin) {
@@ -112,12 +110,20 @@ export function SetupSignedInFlow() {
         router.replace(setupRedirectPath);
         return;
       }
-      if (setupRedirectPath === null && !observedIncompleteSetupRef.current) {
+      // Leave the hand-off to the setup Session alone when it is in flight;
+      // otherwise a completed deployment goes Home.
+      if (
+        setupRedirectPath === null &&
+        !createSession.isPending &&
+        !createSession.data
+      ) {
         router.replace('/');
       }
     }
     if (isError) router.replace('/');
   }, [
+    createSession.data,
+    createSession.isPending,
     authStatus,
     isAdmin,
     isError,
@@ -162,6 +168,14 @@ export function SetupSignedInFlow() {
     );
   }
   if (isLoading || !status) return <LoadingSetupFlow />;
+  // Hold the spinner instead of flashing the inference prompts while the
+  // completion check is in flight or the redirect Home is pending.
+  if (
+    shouldEvaluateSetupRedirect &&
+    (setupStatus.isLoading || setupAlreadyCompleted)
+  ) {
+    return <LoadingSetupFlow />;
+  }
 
   if (conversationalSetupReady) {
     if (createSession.isError) {

--- a/apps/web/src/trpc/commands/github/mutations.test.ts
+++ b/apps/web/src/trpc/commands/github/mutations.test.ts
@@ -634,6 +634,39 @@ describe('startAuthenticateGitHubAccountCommand', () => {
     });
   });
 
+  it('keeps the background hint out of redirect_uri and carries it in the signed state', async () => {
+    mockResolveDeploymentEnvVar.mockImplementation(async (name: string) =>
+      name === 'R_GITHUB_CLIENT_ID' ? 'Iv1.resolved-client' : null,
+    );
+
+    const result = await startAuthenticateGitHubAccountCommand(
+      buildMockAuth(),
+      { redirect: '/settings', bg: 'background' },
+    );
+
+    expect(result.success).toBe(true);
+
+    if (!result.success) {
+      return;
+    }
+
+    const url = new URL(result.url);
+    // GitHub Apps reject any redirect_uri that is not an exact match for a
+    // registered callback URL, including one with extra query parameters.
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://roomote.example.com/github/callback',
+    );
+    const [encodedPayload] = (url.searchParams.get('state') ?? '').split('.');
+    const payload = JSON.parse(
+      Buffer.from(encodedPayload!, 'base64url').toString('utf8'),
+    ) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      mode: 'auth',
+      redirect: '/settings',
+      bg: 'background',
+    });
+  });
+
   it('prefers R_PUBLIC_URL for the OAuth redirect_uri when R_APP_URL is loopback', async () => {
     mockEnvState.R_APP_URL = 'http://127.0.0.1:13000';
     mockEnvState.R_PUBLIC_URL = 'https://customer.example';

--- a/apps/web/src/trpc/commands/github/mutations.ts
+++ b/apps/web/src/trpc/commands/github/mutations.ts
@@ -875,16 +875,14 @@ export async function startAuthenticateGitHubAccountCommand(
     });
 
     if (baseUrl) {
-      const redirectUri = new URL('/github/callback', baseUrl);
-
-      if (
-        callbackBackground === 'accent' ||
-        callbackBackground === 'background'
-      ) {
-        redirectUri.searchParams.set('bg', callbackBackground);
-      }
-
-      params.set('redirect_uri', redirectUri.toString());
+      // GitHub Apps require `redirect_uri` to match a registered callback URL
+      // exactly, with no extra query parameters; anything else is rejected
+      // with "The redirect_uri is not associated with this application".
+      // The callback background hint travels in the signed state instead.
+      params.set(
+        'redirect_uri',
+        new URL('/github/callback', baseUrl).toString(),
+      );
     }
 
     return {


### PR DESCRIPTION
## Problem

Two admin-facing issues seen on a managed deployment after setup completed:

1. **Link GitHub account fails.** Settings → Personal → Linked Accounts → Link sends the user to GitHub, which shows "Be careful! The redirect_uri is not associated with this application." Every caller of the account-link flow passes a callback background hint, and the server appended it to `redirect_uri` as `?bg=background`. GitHub Apps require `redirect_uri` to be an exact match for a registered callback URL and reject extra query parameters ([docs](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app)). The manifest only registers the bare `/github/callback` URL.
2. **Reopening the Cloud deployment link re-prompts for inference keys.** The Cloud link lands on `/setup?token=…`. For a signed-in admin on an already-completed deployment, the signed-in setup flow rendered the inference steps before the completion check kicked in, and the `observedIncompleteSetup` ref could keep it there.

## Fix

- `startAuthenticateGitHubAccountCommand` sends the bare callback URL as `redirect_uri`. The background hint was already in the signed `state`, so the centered callback layout now reads `bg`/`redirect` from the signed state payload as well as from the plain encoded record (cosmetic only; the server still verifies the signature).
- `SetupSignedInFlow` holds the spinner while the completion check is loading or setup is already complete, and redirects Home unless the hand-off to the setup Session is in flight. The ref-based guard is replaced by checking the session mutation state directly.

## Tests

- `mutations.test.ts`: redirect_uri stays parameter-free when a background hint is requested; the hint lands in the signed state.
- `layout.client.test.tsx`: signed-state `bg`/`redirect` drive the surface variant; unreadable states fall back to basic.
- New `SetupSignedInFlow.client.test.tsx`: spinner while loading, Home redirect with no inference prompt once complete, hand-off left alone when in flight.

`pnpm --filter @roomote/web check-types`, oxlint, residual ESLint, and the three test files pass.