### PR TITLE
[Fix] Fast Sessions reject every message from a participant who is not the owner

### DIFF
--- a/.changeset/fast-participant-turns.md
+++ b/.changeset/fast-participant-turns.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fixes Fast Sessions rejecting every message from anyone other than the Session owner. A coworker replying in a bound Slack thread, or a second person writing in a shared Session, was dropped before their message reached the transcript: silently on chat surfaces, and with a generic error on the web. Only callers that assert an explicit owner are now checked against the conversation's owner; a plain sender is treated as a participant.

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-conversation-repository.test.ts
@@ -315,6 +315,66 @@ describe('Fast conversation repository', () => {
     expect(rows).toEqual([{ id: sessions[0]!.id }]);
   });
 
+  it('lets another participant take a turn in a user-owned conversation', async () => {
+    const owner = await createUser();
+    const participant = await createUser();
+    const conversation = {
+      surface: 'slack' as const,
+      workspaceId: 'team-participant-test',
+      conversationId: `thread-participant-${owner.id}`,
+      replyTarget: {
+        channelId: 'channel-participant-test',
+        threadId: `thread-participant-${owner.id}`,
+      },
+    };
+    const created = await fastAgentConversationRepository.getOrCreate({
+      userId: owner.id,
+      conversation,
+    });
+    expect(created.created).toBe(true);
+
+    // A coworker replying in the bound thread is a participant, not a new
+    // owner: the turn reuses the conversation and ownership is unchanged.
+    const reused = await fastAgentConversationRepository.getOrCreate({
+      userId: participant.id,
+      conversation,
+    });
+    expect(reused).toMatchObject({ id: created.id, created: false });
+    expect(reused.owner).toEqual({ kind: 'user', userId: owner.id });
+    expect(reused.userId).toBe(owner.id);
+  });
+
+  it('rejects an explicit owner that does not match the conversation', async () => {
+    const owner = await createUser();
+    const other = await createUser();
+    const conversation = {
+      surface: 'slack' as const,
+      workspaceId: 'team-owner-mismatch-test',
+      conversationId: `thread-owner-mismatch-${owner.id}`,
+      replyTarget: {
+        channelId: 'channel-owner-mismatch-test',
+        threadId: `thread-owner-mismatch-${owner.id}`,
+      },
+    };
+    await fastAgentConversationRepository.getOrCreate({
+      owner: { kind: 'user', userId: owner.id },
+      conversation,
+    });
+
+    await expect(
+      fastAgentConversationRepository.getOrCreate({
+        owner: { kind: 'user', userId: other.id },
+        conversation,
+      }),
+    ).rejects.toThrow('Fast conversation owner does not match the caller.');
+    await expect(
+      fastAgentConversationRepository.getOrCreate({
+        owner: { kind: 'automation', automationKey: 'custom_automation' },
+        conversation,
+      }),
+    ).rejects.toThrow('Fast conversation owner does not match the caller.');
+  });
+
   it('returns the persisted Fast conversation title', async () => {
     const user = await createUser();
     const session = await fastAgentConversationRepository.getOrCreate({

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
@@ -1008,13 +1008,20 @@ export const fastAgentConversationRepository: FastAgentConversationRepository =
         if (!record) {
           throw new Error('Failed to create or load Fast conversation.');
         }
+        // Only an explicit owner asserts who the conversation belongs to. A
+        // bare userId is the acting sender: it becomes the owner when this
+        // call creates the conversation, and otherwise it is a participant
+        // taking a turn in someone else's thread (a coworker replying in a
+        // bound Slack thread, a human replying to an automation-owned
+        // Session), which must not be rejected.
         if (
-          (resolvedOwner.kind === 'user' &&
-            (record.userId !== resolvedOwner.userId ||
+          owner &&
+          ((owner.kind === 'user' &&
+            (record.userId !== owner.userId ||
               record.ownerAutomation !== null)) ||
-          (resolvedOwner.kind === 'automation' &&
-            (record.userId !== null ||
-              record.ownerAutomation !== resolvedOwner.automationKey))
+            (owner.kind === 'automation' &&
+              (record.userId !== null ||
+                record.ownerAutomation !== owner.automationKey)))
         ) {
           throw new Error('Fast conversation owner does not match the caller.');
         }


### PR DESCRIPTION
## Summary

Since #2200, `fastAgentConversationRepository.getOrCreate` compares the caller's user id against the conversation's owner and throws `Fast conversation owner does not match the caller.` on any mismatch. The Fast turn service calls it with the *sender's* id, so every message from anyone other than the Session owner is rejected on every surface. The throw happens before the human prompt row is persisted, so:

- on Slack, Discord, Teams, and Telegram the reply is dropped with only a `Background fast-agent response failed` log line and no reply to the user
- on the web the turn posts the generic "I hit an error while handling that request" closeout and leaves no transcript row

Observed on staging on 2026-09-04: three thread replies and one web message from a second participant in a bound Slack thread, all rejected within about 2s of arrival, zero model requests, while the owner's messages kept working.

## Fix

Only an explicit `owner` argument asserts who the conversation belongs to, and only that path is checked against the stored owner. A bare `userId` is the acting sender: it becomes the owner when the call creates the conversation, and otherwise it is a participant taking a turn in someone else's thread, which is the pre-#2200 behavior. The explicit-owner check still rejects a user-owned conversation claimed by an automation and vice versa, so the automation-owned Session behavior #2200 introduced is unchanged. Today the only caller that passes an explicit owner is the custom-automation launch.

## Tests

- New: a second user takes a turn in a user-owned conversation and gets the same conversation back with ownership unchanged. Fails on develop with the owner-mismatch error, passes here.
- New: an explicit owner that does not match (another user, or an automation) is still rejected.
- `fast-agent-conversation-repository.test.ts` 36 passed, `custom-automations.test.ts` 45 passed, web `fast-sessions` suites 40 passed. oxfmt, oxlint, and `tsc --noEmit` on cloud-agents are clean.
