### PR TITLE
[Fix] Silent Fast completions settle as ignored instead of posting a turn-budget closeout

### DIFF
--- a/.changeset/fast-silent-completion.md
+++ b/.changeset/fast-silent-completion.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fast turns that end with nothing to say no longer post "I could not complete that request within the available turn." When the model ends its turn with no reply and no tool call in a situation where ignoring would have been allowed, such as a link pasted right after an aside between people, the turn now settles silently exactly as an explicit ignore does. When a request directed at Roomote goes unanswered, the closeout says so plainly and asks for a rephrase instead of describing a turn budget that does not exist.

--- a/apps/api/src/handlers/discord/fast-agent.ts
+++ b/apps/api/src/handlers/discord/fast-agent.ts
@@ -210,6 +210,7 @@ export async function processDiscordFastAgentMessage(
         input.sender.global_name ??
         input.sender.username,
       senderExternalId: input.sender.id,
+      directedAtRoomote: Boolean(input.directedAtRoomote),
     };
     let durableTurn: FastAgentDurableTurn | null = null;
     if (!releaseFastAgentLock) {

--- a/apps/api/src/handlers/slack/events/fast-agent.ts
+++ b/apps/api/src/handlers/slack/events/fast-agent.ts
@@ -258,6 +258,7 @@ export async function processFastAgentMessage(params: {
         ? { senderDisplayName: currentMessage.username }
         : {}),
       ...(event.user ? { senderExternalId: event.user } : {}),
+      directedAtRoomote,
     };
     let durableTurn: FastAgentDurableTurn | null = null;
     if (needsCanonicalAdmission) {

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -1640,6 +1640,183 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     }
   });
 
+  it('settles an ambient turn silently when the model ends a steered aside with nothing to say', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.getPendingHumanFollowUp
+        .mockResolvedValueOnce([
+          {
+            id: '2b6d0e0a-5f0e-4d8b-9d0c-6a4a1a1b2c3d',
+            createdAt: new Date('2026-09-04T16:56:45.000Z'),
+            parent: { sessionId: 'conversation-1' },
+            event: {
+              type: 'human_follow_up',
+              eventId: '100.4',
+              currentMessageId: '100.4',
+              userId: 'user-1',
+              question: 'https://example.com/deploy/123',
+              directedAtRoomote: false,
+            },
+          },
+        ])
+        .mockResolvedValue([]);
+
+      let continueGeneration: (() => void) | undefined;
+      const generationPaused = new Promise<void>((resolve) => {
+        continueGeneration = resolve;
+      });
+      const adapter = callbacks();
+      mocks.generateText.mockImplementation(
+        async (_params, _session, options) => {
+          await options.onSessionReady('opencode-session-1');
+          options.onPromptStarted?.();
+          options.onNativeSteerReady?.(mocks.nativeSteer);
+          options.onAssistantMessageStarted?.({
+            id: 'assistant-ignores-aside',
+            sessionId: 'opencode-session-1',
+            parentId: 'initial-user-message',
+            createdAtMs: 100,
+          });
+          // The opener is an aside between people; the model ignores it.
+          await invokeTool(
+            nativeToolNames.ignoreEvent,
+            {},
+            undefined,
+            'assistant-ignores-aside',
+          );
+          await generationPaused;
+          // The steered link opens a new instruction; the model says nothing.
+          options.onAssistantMessageStarted?.({
+            id: 'assistant-after-steer',
+            sessionId: 'opencode-session-1',
+            parentId: 'steered-user-message',
+            createdAtMs: 200,
+          });
+          return '';
+        },
+      );
+
+      const resultPromise = answerFastAgentQuestion({
+        ...baseParams,
+        allowSilentAmbientReply: true,
+        adapter,
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.waitFor(() => expect(mocks.nativeSteer).toHaveBeenCalledOnce());
+      continueGeneration?.();
+      await expect(resultPromise).resolves.toBe('');
+
+      expect(adapter.postReply).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still closes out when a steered follow-up directed at Roomote goes unanswered', async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.getPendingHumanFollowUp
+        .mockResolvedValueOnce([
+          {
+            id: '3c7e1f1b-6a1f-4e9c-8e1d-7b5b2b2c3d4e',
+            createdAt: new Date('2026-09-04T16:56:45.000Z'),
+            parent: { sessionId: 'conversation-1' },
+            event: {
+              type: 'human_follow_up',
+              eventId: '100.4',
+              currentMessageId: '100.4',
+              userId: 'user-1',
+              question: '<@UBOT> can you check the deploy?',
+              directedAtRoomote: true,
+            },
+          },
+        ])
+        .mockResolvedValue([]);
+
+      let continueGeneration: (() => void) | undefined;
+      const generationPaused = new Promise<void>((resolve) => {
+        continueGeneration = resolve;
+      });
+      const adapter = callbacks();
+      mocks.generateText.mockImplementation(
+        async (_params, _session, options) => {
+          await options.onSessionReady('opencode-session-1');
+          options.onPromptStarted?.();
+          options.onNativeSteerReady?.(mocks.nativeSteer);
+          options.onAssistantMessageStarted?.({
+            id: 'assistant-ignores-aside',
+            sessionId: 'opencode-session-1',
+            parentId: 'initial-user-message',
+            createdAtMs: 100,
+          });
+          await invokeTool(
+            nativeToolNames.ignoreEvent,
+            {},
+            undefined,
+            'assistant-ignores-aside',
+          );
+          await generationPaused;
+          options.onAssistantMessageStarted?.({
+            id: 'assistant-after-steer',
+            sessionId: 'opencode-session-1',
+            parentId: 'steered-user-message',
+            createdAtMs: 200,
+          });
+          return '';
+        },
+      );
+
+      const resultPromise = answerFastAgentQuestion({
+        ...baseParams,
+        allowSilentAmbientReply: true,
+        adapter,
+      });
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.waitFor(() => expect(mocks.nativeSteer).toHaveBeenCalledOnce());
+      continueGeneration?.();
+      await resultPromise;
+
+      expect(adapter.postReply).toHaveBeenCalledTimes(1);
+      expect(adapter.postReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          purpose: 'closeout',
+          message:
+            'I didn’t have a response to that. Could you rephrase it or add a bit more detail?',
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('tells the user plainly when a directed request ends with no response', async () => {
+    const adapter = callbacks();
+    mocks.generateText.mockImplementation(
+      async (_params, _session, options) => {
+        await options.onSessionReady('opencode-session-1');
+        options.onPromptStarted?.();
+        options.onAssistantMessageStarted?.({
+          id: 'assistant-silent',
+          sessionId: 'opencode-session-1',
+          parentId: 'initial-user-message',
+          createdAtMs: 100,
+        });
+        return '';
+      },
+    );
+
+    await answerFastAgentQuestion({ ...baseParams, adapter });
+
+    expect(adapter.postReply).toHaveBeenCalledTimes(1);
+    expect(adapter.postReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        purpose: 'closeout',
+        message:
+          'I didn’t have a response to that. Could you rephrase it or add a bit more detail?',
+      }),
+    );
+  });
+
   it('ignores plain terminal text from an assistant superseded by a native steer', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -1505,6 +1505,21 @@ export async function answerFastAgentQuestion({
   let currentInstructionVersion = 0;
   const assistantInstructionVersions = new Map<string, number>();
   const closedInstructionVersions = new Set<number>();
+  // Set once a native steer injects a follow-up its surface did not mark as
+  // ambient. Ending silently after that drops a request, so it is never
+  // settled as an ignore.
+  let steeredDirectedFollowUp = false;
+  /**
+   * Mirrors the `ignore_event` tool's rule: the turn may end without any
+   * visible reply only when an explicit ignore would have been accepted for
+   * it, and no steered follow-up since then was directed at Roomote.
+   */
+  const silentCompletionAllowed = () =>
+    !(platformEvent && platformEventVisibility === 'required') &&
+    (Boolean(reactionInput) ||
+      Boolean(platformEvent) ||
+      allowSilentAmbientReply) &&
+    !steeredDirectedFollowUp;
   const getInstructionVersion = (messageId?: string) =>
     (messageId ? assistantInstructionVersions.get(messageId) : undefined) ??
     currentInstructionVersion;
@@ -2038,6 +2053,12 @@ export async function answerFastAgentQuestion({
         `[Fast Agent] Native steer accepted. conversationId="${canonicalConversationId}" followUpCount=${batch.length}`,
       );
       for (const { row } of batch) injectedHumanFollowUpIds.add(row.id);
+      // Only a surface that classified the message as ambient may leave it
+      // unanswered; an unmarked follow-up (web, PR, older rows) counts as
+      // directed.
+      if (batch.some(({ followUp }) => followUp.directedAtRoomote !== false)) {
+        steeredDirectedFollowUp = true;
+      }
       injectedHumanFollowUpMessages.push(...batchMessages);
       injectedHumanFollowUpFiles.push(...batchFiles);
       // Native steering starts a new human instruction boundary inside the
@@ -4550,18 +4571,31 @@ export async function answerFastAgentQuestion({
           ),
         );
       } else if (!visibleUpdatePosted) {
-        // A delivered update is already a complete visible response. Stay
-        // silent rather than append a generic closeout that contradicts it.
-        const fallback =
-          'I could not complete that request within the available turn.';
-        await postRecordedSystemCloseout(fallback, () =>
-          postReply(
-            { purpose: 'closeout', message: fallback },
-            false,
-            undefined,
-            terminalInstructionVersion,
-          ),
-        );
+        // The model ended the newest instruction with nothing to show: no
+        // reply tool, no undelivered text. Where an explicit ignore would
+        // have been accepted (an ambient message between people, an optional
+        // platform event, a reaction) settle exactly as an ignore does. The
+        // steered URL after an ignored aside is the typical case. Otherwise a
+        // request went unanswered, so say that plainly rather than narrate a
+        // budget that never existed.
+        if (silentCompletionAllowed()) {
+          closedInstructionVersions.add(terminalInstructionVersion);
+          diagnostics.recordSilentCompletion();
+          console.info(
+            `[Fast Agent] Silent completion settled as ignored. conversationId="${canonicalConversationId}" turnId="${turnId}" instructionVersion=${terminalInstructionVersion}`,
+          );
+        } else {
+          const fallback =
+            'I didn’t have a response to that. Could you rephrase it or add a bit more detail?';
+          await postRecordedSystemCloseout(fallback, () =>
+            postReply(
+              { purpose: 'closeout', message: fallback },
+              false,
+              undefined,
+              terminalInstructionVersion,
+            ),
+          );
+        }
       } else if (platformEvent && platformEventVisibility === 'required') {
         // A visibility-required platform event promises a closeout even when
         // an intro ack or launch kickoff already posted a visible update

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-turn-diagnostics.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-turn-diagnostics.ts
@@ -104,6 +104,7 @@ export class FastAgentTurnDiagnostics {
   private tokenTotals: TokenTotals | undefined;
   private maxContextTokens: number | undefined;
   private abortedAfterCloseout = false;
+  private silentCompletion = false;
   private openCodeProviderRetryEventCount = 0;
   private firstOpenCodeProviderRetryElapsedMs: number | undefined;
   private lastOpenCodeProviderRetryElapsedMs: number | undefined;
@@ -162,6 +163,11 @@ export class FastAgentTurnDiagnostics {
   /** The trailing model request after the closeout was cut short. */
   recordCloseoutAbort(): void {
     this.abortedAfterCloseout = true;
+  }
+
+  /** The model ended with nothing visible and the turn settled as ignored. */
+  recordSilentCompletion(): void {
+    this.silentCompletion = true;
   }
 
   /** One model request per assistant message OpenCode starts in the turn. */
@@ -478,6 +484,7 @@ export class FastAgentTurnDiagnostics {
       firstModelResponseDurationMs,
       postReplyInferenceDurationMs,
       abortedAfterCloseout: this.abortedAfterCloseout,
+      silentCompletion: this.silentCompletion,
       inputTokens: this.tokenTotals?.input,
       cacheReadTokens: this.tokenTotals?.cacheRead,
       cacheWriteTokens: this.tokenTotals?.cacheWrite,

--- a/packages/types/src/fast-agent.ts
+++ b/packages/types/src/fast-agent.ts
@@ -240,6 +240,13 @@ export const fastAgentHumanFollowUpEventSchema = z.object({
   senderDisplayName: z.string().min(1).optional(),
   senderExternalId: z.string().min(1).optional(),
   /**
+   * Whether the surface classified the message as addressed to Roomote (a
+   * mention, a DM, a reply to it) rather than ambient conversation between
+   * people. When this message is steered into a running turn, only `false`
+   * lets that turn end without a visible reply; absent means directed.
+   */
+  directedAtRoomote: z.boolean().optional(),
+  /**
    * Surface context the model reads with the message (the pull request a
    * mention is on, for example). Persisted so a queued or resumed turn keeps
    * the context the inline turn would have had.


### PR DESCRIPTION
## Summary

Removes the "I could not complete that request within the available turn." closeout. It was posted whenever the model ended the newest instruction of a turn with no reply tool call and no undelivered text, and nothing visible had been posted yet. Nothing times out on that path; the wording described a budget that does not exist.

Observed on staging on 2026-09-04: a person posted an aside between people and, one second later, a bare URL. The model ignored the aside with `ignore_event`; the URL was steered into the same turn as a new instruction; the model ended that instruction with nothing to say (2 model requests, 39 output tokens, no tool call), and the fallback line was posted into the thread.

## Behavior now

- **Silence settles as an ignore where an explicit ignore would have been accepted.** The gate mirrors the `ignore_event` tool's rule: a reaction, an optional platform event, or an unmentioned message in a multi-participant thread. The instruction is closed, nothing is posted, the turn log carries `silentCompletion=true`, and an info line names the conversation and turn.
- **A steered follow-up directed at Roomote disables the silent settle.** Surfaces that classify directedness (Slack and Discord) now record `directedAtRoomote` on the human follow-up event. In the steer drain, any injected follow-up not explicitly marked `false` counts as directed, so unmarked rows (web, PR, older queued rows) stay conservative.
- **Where a request goes unanswered, the closeout says so plainly:** "I didn’t have a response to that. Could you rephrase it or add a bit more detail?"

## Tests

- New: ambient opener ignored, steered link marked ambient, model ends silently. No reply is posted and the turn resolves. Fails before this change with the old fallback line.
- New: same shape but the steered follow-up is directed. The plain closeout is posted once.
- New: a directed opener that ends with no response gets the plain closeout.
- Service suite 182 tests, diagnostics suite, Slack and Discord Fast handler suites pass. One pre-existing service test, "reports local storage exhaustion instead of a generic Fast error", fails identically on a clean develop checkout on this machine and is unrelated.
- oxfmt, oxlint, and `tsc --noEmit` on types, api, and cloud-agents are clean.
