### PR TITLE
[Fix] GitHub review replies require an @mention and skip the redundant quote

### DIFF
--- a/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
+++ b/apps/api/src/handlers/github/__tests__/handlePrComment.test.ts
@@ -2,7 +2,6 @@ const mocks = vi.hoisted(() => ({
   getGitHubAutomationTargets: vi.fn(),
   getInstallationOctokit: vi.fn(),
   findActiveGitHubPrReviewTask: vi.fn(),
-  findRoomoteOpenedPullRequestTask: vi.fn(),
   findReusableGitHubPrFollowUpOwner: vi.fn(),
   startSourceControlFastSessionTurn: vi.fn(),
   fetchGitHubLinkedReferences: vi.fn(),
@@ -10,7 +9,6 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@roomote/db/server', () => ({
   findActiveGitHubPrReviewTask: mocks.findActiveGitHubPrReviewTask,
-  findRoomoteOpenedPullRequestTask: mocks.findRoomoteOpenedPullRequestTask,
   findReusableGitHubPrFollowUpOwner: mocks.findReusableGitHubPrFollowUpOwner,
 }));
 
@@ -192,7 +190,6 @@ describe('handlePrComment', () => {
     });
     mocks.findActiveGitHubPrReviewTask.mockResolvedValue(null);
     mocks.findReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
-    mocks.findRoomoteOpenedPullRequestTask.mockResolvedValue(null);
     mocks.fetchGitHubLinkedReferences.mockResolvedValue([]);
     mocks.startSourceControlFastSessionTurn.mockResolvedValue({
       status: 'queued',
@@ -367,116 +364,16 @@ describe('handlePrComment', () => {
     expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
   });
 
-  describe('replies in a review thread Roomote opened', () => {
-    function makeRoomoteThreadReplyPayload(): WebhookPullRequestCommentCreated {
-      const payload = makeReviewCommentPayload();
-      payload.comment.body = 'Can you make this loop bounded instead?';
-      return payload;
-    }
+  it('ignores replies in a review thread Roomote opened when they carry no @mention', async () => {
+    const payload = makeReviewCommentPayload();
+    payload.comment.body = 'Fixed in 5756284.';
 
-    beforeEach(() => {
-      request.mockImplementation(async (route: string) => {
-        if (route.startsWith('GET /repos/{owner}/{repo}/pulls/comments/')) {
-          return {
-            data: {
-              id: 800,
-              body: 'This loop never terminates.',
-              path: 'src/retry.ts',
-              diff_hunk: '@@ -1 +1 @@\n-old\n+new',
-              user: { login: 'roomote[bot]' },
-            },
-          };
-        }
-        return { data: {} };
-      });
-    });
+    const result = await handlePrComment(payload);
 
-    it('enters the Session without an @mention when no task owns the pull request', async () => {
-      const result = await handlePrComment(makeRoomoteThreadReplyPayload());
-
-      expect(result).toEqual(
-        expect.objectContaining({
-          status: 'ok',
-          message: 'fast_session_queued',
-        }),
-      );
-      expect(mocks.findRoomoteOpenedPullRequestTask).toHaveBeenCalledWith({
-        repoFullName: 'acme/api',
-        prNumber: 42,
-        host: 'github.com',
-      });
-      // The gate's fetch is reused for the context; the parent is not
-      // fetched a second time.
-      expect(
-        request.mock.calls.filter(([route]) =>
-          String(route).startsWith('GET /repos/{owner}/{repo}/pulls/comments/'),
-        ),
-      ).toHaveLength(1);
-      expect(createForPullRequestReviewComment).toHaveBeenCalledWith(
-        expect.objectContaining({ comment_id: 900, content: 'eyes' }),
-      );
-      expect(mocks.startSourceControlFastSessionTurn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          discussion: expect.objectContaining({
-            kind: 'pull',
-            number: 42,
-            reviewCommentId: '800',
-          }),
-          question: 'Can you make this loop bounded instead?',
-          agentContext: expect.stringContaining(
-            "alice replied to Roomote's review comment #800",
-          ),
-        }),
-      );
-    });
-
-    it('leaves replies on a Roomote-opened pull request to the review-feedback pipeline, even after its task finished', async () => {
-      // The opening task is done and has no resumable snapshot, so the
-      // active-owner lookup finds nothing; the durable PR linkage still does.
-      mocks.findReusableGitHubPrFollowUpOwner.mockResolvedValue(null);
-      mocks.findRoomoteOpenedPullRequestTask.mockResolvedValue({
-        taskId: 'task-owner',
-        runId: 5,
-        type: 'standard_task',
-        status: 'completed',
-      });
-
-      const result = await handlePrComment(makeRoomoteThreadReplyPayload());
-
-      expect(result).toEqual({ status: 'ok', message: 'no_mention' });
-      expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
-      expect(createForPullRequestReviewComment).not.toHaveBeenCalled();
-    });
-
-    it('ignores replies to review comments written by people', async () => {
-      request.mockImplementation(async (route: string) => {
-        if (route.startsWith('GET /repos/{owner}/{repo}/pulls/comments/')) {
-          return {
-            data: {
-              id: 800,
-              body: 'This loop never terminates.',
-              user: { login: 'carol' },
-            },
-          };
-        }
-        return { data: {} };
-      });
-
-      const result = await handlePrComment(makeRoomoteThreadReplyPayload());
-
-      expect(result).toEqual({ status: 'ok', message: 'no_mention' });
-      expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
-    });
-
-    it('ignores top-level review comments without a mention', async () => {
-      const payload = makeRoomoteThreadReplyPayload();
-      delete (payload.comment as { in_reply_to_id?: number }).in_reply_to_id;
-
-      const result = await handlePrComment(payload);
-
-      expect(result).toEqual({ status: 'ok', message: 'no_mention' });
-      expect(request).not.toHaveBeenCalled();
-      expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
-    });
+    expect(result).toEqual({ status: 'ok', message: 'no_mention' });
+    // Nothing is fetched or acknowledged: the thread is left to the humans.
+    expect(request).not.toHaveBeenCalled();
+    expect(createForPullRequestReviewComment).not.toHaveBeenCalled();
+    expect(mocks.startSourceControlFastSessionTurn).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/github/handlePrComment.ts
+++ b/apps/api/src/handlers/github/handlePrComment.ts
@@ -1,6 +1,5 @@
 import {
   findActiveGitHubPrReviewTask,
-  findRoomoteOpenedPullRequestTask,
   findReusableGitHubPrFollowUpOwner,
 } from '@roomote/db/server';
 import {
@@ -395,7 +394,6 @@ async function buildTriggeringCommentContext({
   repositoryFullName,
   commenter,
   commentBody,
-  parentComment: knownParentComment,
 }: {
   eventPayload:
     | WebhookPullRequestCommentCreated
@@ -405,20 +403,16 @@ async function buildTriggeringCommentContext({
   repositoryFullName: string;
   commenter: string;
   commentBody: string;
-  /** The review thread parent when the mention gate already fetched it. */
-  parentComment?: ReviewCommentSnapshot | null;
 }): Promise<string> {
   if ('comment' in eventPayload && 'pull_request' in eventPayload) {
     const reviewComment = eventPayload.comment;
 
     if (reviewComment.in_reply_to_id) {
-      const parentComment =
-        knownParentComment ??
-        (await fetchReviewCommentSnapshot({
-          installationId,
-          repositoryFullName,
-          commentId: reviewComment.in_reply_to_id,
-        }));
+      const parentComment = await fetchReviewCommentSnapshot({
+        installationId,
+        repositoryFullName,
+        commentId: reviewComment.in_reply_to_id,
+      });
 
       if (parentComment) {
         return buildReviewReplyTriggeringComment({
@@ -675,64 +669,11 @@ async function resolvePullRequestActiveTasks({
 }
 
 /**
- * A reply inside a review thread Roomote opened is addressed to Roomote the
- * way GitHub trains people to reply to a reviewer, so it counts as a mention
- * without the @-handle. Only pull requests Roomote did not open qualify: on a
- * Roomote-opened pull request the review-feedback pipeline already batches
- * these replies into the owning Session with its Resolve / Dismiss actions,
- * and handling them here too would answer twice. Opening is recorded on the
- * durable linkage row, so a finished task still owns its pull request, while
- * a pull request a task merely mentioned stays human-opened.
- */
-async function resolveImplicitReviewThreadMention({
-  eventPayload,
-  installationId,
-}: {
-  eventPayload: PullRequestMentionEvent;
-  installationId: number;
-}): Promise<{ parentComment: ReviewCommentSnapshot } | null> {
-  if (!('comment' in eventPayload) || !('pull_request' in eventPayload)) {
-    return null;
-  }
-  const { comment, pull_request: pullRequest, repository } = eventPayload;
-  const commenterLogin = comment.user?.login;
-  if (
-    !comment.in_reply_to_id ||
-    !commenterLogin ||
-    GitHubSchemas.isRoomoteGitHubLogin(commenterLogin)
-  ) {
-    return null;
-  }
-
-  const parentComment = await fetchReviewCommentSnapshot({
-    installationId,
-    repositoryFullName: repository.full_name,
-    commentId: comment.in_reply_to_id,
-  });
-  if (
-    !parentComment ||
-    !GitHubSchemas.isRoomoteGitHubLogin(parentComment.userLogin)
-  ) {
-    return null;
-  }
-
-  const linkedTask = await findRoomoteOpenedPullRequestTask({
-    repoFullName: repository.full_name,
-    prNumber: pullRequest.number,
-    host: toHostFromUrl(pullRequest.html_url ?? '') ?? 'github.com',
-  }).catch(() => null);
-  if (linkedTask) {
-    return null;
-  }
-
-  return { parentComment };
-}
-
-/**
  * Every @mention on a pull request enters the pull request's Fast Session.
  * The Session reads the discussion, replies as a comment, and delegates work
- * to a task on the pull request's branch when the request needs one. A reply
- * in a review thread Roomote opened enters the same way without an @mention.
+ * to a task on the pull request's branch when the request needs one. Only an
+ * explicit @mention counts: a reply inside a review thread without one is
+ * left alone, so people can discuss a finding without summoning Roomote.
  */
 export async function handlePrComment(
   eventPayload: PullRequestMentionEvent,
@@ -742,22 +683,13 @@ export async function handlePrComment(
   const mention = isSubmittedReview ? rest.review : rest.comment;
   const githubInstallationId = installation?.id;
 
-  const explicitMention = isMention({
-    body: mention.body ?? '',
-    user: mention.user ? { login: mention.user.login } : null,
-  });
-  let reviewThreadParent: ReviewCommentSnapshot | null = null;
-  if (!explicitMention) {
-    const implicitMention = githubInstallationId
-      ? await resolveImplicitReviewThreadMention({
-          eventPayload,
-          installationId: githubInstallationId,
-        })
-      : null;
-    if (!implicitMention) {
-      return { status: 'ok', message: 'no_mention' };
-    }
-    reviewThreadParent = implicitMention.parentComment;
+  if (
+    !isMention({
+      body: mention.body ?? '',
+      user: mention.user ? { login: mention.user.login } : null,
+    })
+  ) {
+    return { status: 'ok', message: 'no_mention' };
   }
 
   const mentionResponseTarget = getMentionResponseTarget(eventPayload);
@@ -851,7 +783,6 @@ export async function handlePrComment(
         repositoryFullName: repository.full_name,
         commenter: sender.login,
         commentBody: mention.body ?? '',
-        parentComment: reviewThreadParent,
       }),
     ]);
 

--- a/apps/docs/providers/source-control/github.mdx
+++ b/apps/docs/providers/source-control/github.mdx
@@ -233,10 +233,11 @@ Roomote runs the Review Code automation's structured review on the current
 head, posts the findings on the pull request, and reports back in the same
 discussion.
 
-Replying inside a review thread that Roomote opened counts as talking to
-Roomote, so no `@mention` is needed there; Roomote answers in that thread. On
-a pull request that a Roomote task opened, those replies are instead collected
-as review feedback for the owning Session, described below.
+Roomote only responds to comments that `@mention` it, including replies inside
+a review thread it opened, so people can discuss a finding among themselves
+without summoning it. On a pull request that a Roomote task opened, replies in
+its review threads are collected as review feedback for the owning Session,
+described below.
 
 A pull request that a Roomote task opened already belongs to the Session that
 started the work, for example the Slack thread where the task was requested.

--- a/packages/communication/src/__tests__/fast-session-footer-context.test.ts
+++ b/packages/communication/src/__tests__/fast-session-footer-context.test.ts
@@ -4,12 +4,10 @@ const {
   getSessionForFastConversationMock,
   selectWhereMock,
   resolveThreadReplyFooterContextMock,
-  resolveThreadReplyLivePreviewUrlMock,
 } = vi.hoisted(() => ({
   getSessionForFastConversationMock: vi.fn(),
   selectWhereMock: vi.fn(),
   resolveThreadReplyFooterContextMock: vi.fn(),
-  resolveThreadReplyLivePreviewUrlMock: vi.fn(),
 }));
 
 vi.mock('@roomote/db/server', () => ({
@@ -40,17 +38,13 @@ vi.mock('@roomote/db/server', () => ({
 
 vi.mock('../thread-reply-footer-context', () => ({
   resolveThreadReplyFooterContext: resolveThreadReplyFooterContextMock,
-  resolveThreadReplyLivePreviewUrl: resolveThreadReplyLivePreviewUrlMock,
 }));
 
 vi.mock('@roomote/env', () => ({
   Env: { R_APP_URL: 'https://roomote.example' },
 }));
 
-import {
-  resolveFastSessionLivePreviewUrl,
-  resolveFastSessionReplyFooterContext,
-} from '../fast-session-footer';
+import { resolveFastSessionReplyFooterContext } from '../fast-session-footer';
 
 describe('resolveFastSessionReplyFooterContext', () => {
   beforeEach(() => {
@@ -107,44 +101,5 @@ describe('resolveFastSessionReplyFooterContext', () => {
       'fast-session-1',
     );
     expect(resolveThreadReplyFooterContextMock).toHaveBeenCalledTimes(2);
-  });
-});
-
-describe('resolveFastSessionLivePreviewUrl', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    getSessionForFastConversationMock.mockResolvedValue({ id: 'session-1' });
-    selectWhereMock.mockResolvedValue([
-      { taskId: 'task-1' },
-      { taskId: 'task-2' },
-    ]);
-  });
-
-  it('returns the first linked task preview URL', async () => {
-    resolveThreadReplyLivePreviewUrlMock.mockImplementation(
-      async (taskId: string) =>
-        taskId === 'task-2' ? 'https://preview.example/app' : null,
-    );
-
-    await expect(
-      resolveFastSessionLivePreviewUrl('fast-session-1'),
-    ).resolves.toBe('https://preview.example/app');
-  });
-
-  it('returns null when no linked task exposes a preview', async () => {
-    resolveThreadReplyLivePreviewUrlMock.mockResolvedValue(null);
-
-    await expect(
-      resolveFastSessionLivePreviewUrl('fast-session-1'),
-    ).resolves.toBeNull();
-  });
-
-  it('returns null when the session is unknown', async () => {
-    getSessionForFastConversationMock.mockResolvedValue(null);
-
-    await expect(
-      resolveFastSessionLivePreviewUrl('fast-session-1'),
-    ).resolves.toBeNull();
-    expect(resolveThreadReplyLivePreviewUrlMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/communication/src/fast-session-footer.ts
+++ b/packages/communication/src/fast-session-footer.ts
@@ -16,10 +16,7 @@ import {
   type ThreadReplyLinkedPr,
 } from './chat-messages';
 import { chunkDiscordMessage } from './discord-provider';
-import {
-  resolveThreadReplyFooterContext,
-  resolveThreadReplyLivePreviewUrl,
-} from './thread-reply-footer-context';
+import { resolveThreadReplyFooterContext } from './thread-reply-footer-context';
 
 export type FastSessionFooterProvider =
   | 'slack'
@@ -85,20 +82,6 @@ async function getFastSessionLinkedTaskIds(
         .orderBy(asc(sessionTasks.attachedAt), asc(sessionTasks.taskId))
     : [];
   return linkedTasks.map(({ taskId }) => taskId);
-}
-
-/**
- * The live preview URL of the first session-linked task that exposes one, for
- * footers that skip the full linked-PR context (source-control comments).
- */
-export async function resolveFastSessionLivePreviewUrl(
-  sessionId: string,
-): Promise<string | null> {
-  const taskIds = await getFastSessionLinkedTaskIds(sessionId);
-  const urls = await Promise.all(
-    taskIds.map((taskId) => resolveThreadReplyLivePreviewUrl(taskId)),
-  );
-  return urls.find((url) => url) ?? null;
 }
 
 export async function resolveFastSessionReplyFooterContext(params: {

--- a/packages/db/src/lib/__tests__/github-branch-activity.test.ts
+++ b/packages/db/src/lib/__tests__/github-branch-activity.test.ts
@@ -21,7 +21,6 @@ import {
   findActiveGitHubBranchWork,
   findReusableGitHubPrFollowUpOwner,
   findReusableGitHubIssueTaskOwner,
-  findRoomoteOpenedPullRequestTask,
   hasRecentGitHubBranchCommit,
 } from '../github-branch-activity';
 
@@ -1951,113 +1950,5 @@ describe('hasRecentGitHubBranchCommit', () => {
         now,
       }),
     ).toBe(false);
-  });
-});
-
-describe('findRoomoteOpenedPullRequestTask', () => {
-  it('returns the task that opened the pull request even after its run finished', async () => {
-    const { user } = await createActor();
-    const run = await createPrLinkedTaskRun({
-      repoFullName: 'acme/api',
-      prNumber: 42,
-      userId: user.id,
-      payloadKind: TaskPayloadKind.StandardTask,
-      status: RunStatus.Completed,
-      createdByRoomote: true,
-    });
-
-    await expect(
-      findRoomoteOpenedPullRequestTask({
-        repoFullName: 'acme/api',
-        prNumber: 42,
-        host: 'github.com',
-      }),
-    ).resolves.toEqual({
-      runId: run.id,
-      taskId: run.taskId,
-      type: TaskPayloadKind.StandardTask,
-      status: RunStatus.Completed,
-    });
-  });
-
-  it('ignores a pull request a task merely mentioned', async () => {
-    const { user } = await createActor();
-    await createPrLinkedTaskRun({
-      repoFullName: 'acme/api',
-      prNumber: 43,
-      userId: user.id,
-      payloadKind: TaskPayloadKind.StandardTask,
-      status: RunStatus.Completed,
-      createdByRoomote: false,
-    });
-
-    await expect(
-      findRoomoteOpenedPullRequestTask({
-        repoFullName: 'acme/api',
-        prNumber: 43,
-      }),
-    ).resolves.toBeNull();
-  });
-
-  it('ignores review-pipeline and conflict-resolver linkage', async () => {
-    const { user } = await createActor();
-    for (const payloadKind of [
-      TaskPayloadKind.GithubPrReview,
-      TaskPayloadKind.GithubPrReviewSync,
-      TaskPayloadKind.GithubPrConflictResolve,
-    ]) {
-      await createPrLinkedTaskRun({
-        repoFullName: 'acme/api',
-        prNumber: 44,
-        userId: user.id,
-        payloadKind,
-        status: RunStatus.Running,
-        createdByRoomote: true,
-      });
-    }
-
-    await expect(
-      findRoomoteOpenedPullRequestTask({
-        repoFullName: 'acme/api',
-        prNumber: 44,
-      }),
-    ).resolves.toBeNull();
-  });
-
-  it('host-scopes the lookup, tolerating legacy null-host rows', async () => {
-    const { user } = await createActor();
-    await createPrLinkedTaskRun({
-      repoFullName: 'acme/api',
-      prNumber: 45,
-      userId: user.id,
-      payloadKind: TaskPayloadKind.StandardTask,
-      status: RunStatus.Completed,
-      host: 'github.example.com',
-      createdByRoomote: true,
-    });
-    const legacy = await createPrLinkedTaskRun({
-      repoFullName: 'acme/api',
-      prNumber: 46,
-      userId: user.id,
-      payloadKind: TaskPayloadKind.StandardTask,
-      status: RunStatus.Completed,
-      host: null,
-      createdByRoomote: true,
-    });
-
-    await expect(
-      findRoomoteOpenedPullRequestTask({
-        repoFullName: 'acme/api',
-        prNumber: 45,
-        host: 'github.com',
-      }),
-    ).resolves.toBeNull();
-    await expect(
-      findRoomoteOpenedPullRequestTask({
-        repoFullName: 'acme/api',
-        prNumber: 46,
-        host: 'github.com',
-      }),
-    ).resolves.toEqual(expect.objectContaining({ taskId: legacy.taskId }));
   });
 });

--- a/packages/db/src/lib/github-branch-activity.ts
+++ b/packages/db/src/lib/github-branch-activity.ts
@@ -1,14 +1,4 @@
-import {
-  and,
-  desc,
-  eq,
-  inArray,
-  isNull,
-  ne,
-  notInArray,
-  or,
-  sql,
-} from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 
 import {
   type TaskPayload,
@@ -510,68 +500,6 @@ export async function findActiveGitHubPrReviewTask({
     .limit(10);
 
   return pickActiveWork(reviewRows, 'task_pull_request');
-}
-
-export type RoomoteOpenedPullRequestTask = {
-  runId: number;
-  taskId: string;
-  type: TaskPayloadKind;
-  status: RunStatus;
-};
-
-/**
- * The newest Roomote task that opened the pull request, whether or not a run
- * is still active or resumable. Only linkage rows stamped `createdByRoomote`
- * count: a pull request merely mentioned in a task transcript is also linked
- * to that task, but Roomote did not open it. Review-pipeline and
- * conflict-resolver tasks never open pull requests and are excluded.
- *
- * Use this, not the active-run lookups above, when deciding whether a pull
- * request is Roomote-opened: those return null once the task finishes
- * without a snapshot, while the linkage is durable.
- */
-export async function findRoomoteOpenedPullRequestTask({
-  repoFullName,
-  prNumber,
-  sourceControlProvider = 'github',
-  host,
-}: {
-  repoFullName: string;
-  prNumber: number;
-  sourceControlProvider?: SourceControlProvider;
-  /** When given, only rows on this host (or legacy rows with no host) match. */
-  host?: string | null;
-}): Promise<RoomoteOpenedPullRequestTask | null> {
-  const [row] = await db
-    .select(ACTIVE_WORK_COLUMNS)
-    .from(taskRuns)
-    .innerJoin(taskPullRequests, eq(taskPullRequests.taskId, taskRuns.taskId))
-    .where(
-      and(
-        eq(taskPullRequests.createdByRoomote, true),
-        notInArray(taskRuns.payloadKind, [
-          ...ACTIVE_PR_REVIEW_TYPES,
-          TaskPayloadKind.GithubPrConflictResolve,
-        ]),
-        eq(taskPullRequests.sourceControlProvider, sourceControlProvider),
-        eq(taskPullRequests.repository, repoFullName),
-        eq(taskPullRequests.prNumber, prNumber),
-        ...(host
-          ? [or(eq(taskPullRequests.host, host), isNull(taskPullRequests.host))]
-          : []),
-      ),
-    )
-    .orderBy(desc(taskRuns.createdAt))
-    .limit(1);
-
-  return row
-    ? {
-        runId: row.runId,
-        taskId: row.taskId,
-        type: row.type,
-        status: row.status,
-      }
-    : null;
 }
 
 async function fetchRunReuseMetadata(

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -2447,8 +2447,8 @@ describe('deliverFastAgentParentEvent', () => {
       conversationId: 'pull/42',
       replyTarget: { channelId: 'pull/42', threadId: '800' },
     });
-    // The pull request gets the answer under the quoted mention, in the
-    // review thread the mention came from.
+    // The pull request gets the answer in the review thread the mention
+    // came from; the reply sits under the mention, so it is not quoted.
     expect(mocks.postSourceControlComment).toHaveBeenCalledOnce();
     const comment = mocks.postSourceControlComment.mock.calls[0]?.[0] as {
       discussion: { number: number; reviewCommentId?: string };
@@ -2457,7 +2457,7 @@ describe('deliverFastAgentParentEvent', () => {
     expect(comment.discussion).toEqual(
       expect.objectContaining({ number: 42, reviewCommentId: '800' }),
     );
-    expect(comment.body).toContain('> Can you also update the changelog?');
+    expect(comment.body).not.toContain('> Can you also update the changelog?');
     expect(comment.body).toContain('Done: the changelog now mentions the fix.');
     // The Slack thread gets the same answer with attribution to the mention.
     const slackPosts = JSON.stringify(mocks.postMessage.mock.calls);

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -1,8 +1,5 @@
 const mocks = vi.hoisted(() => ({
   createFastAgentTaskLauncher: vi.fn(),
-  resolveFastSessionLivePreviewUrl: vi.fn(
-    async (): Promise<string | null> => null,
-  ),
   repositoriesFindMany: vi.fn(),
   getInstallationOctokit: vi.fn(),
   gitlabCreateIssueNote: vi.fn(),
@@ -36,17 +33,8 @@ vi.mock('@roomote/db/server', () => ({
 }));
 
 vi.mock('@roomote/communication', () => ({
-  buildFastSessionReplyFooterText: ({
-    provider,
-    livePreviewUrl,
-  }: {
-    provider: string;
-    livePreviewUrl?: string | null;
-  }) =>
-    livePreviewUrl
-      ? `[footer:${provider}:${livePreviewUrl}]`
-      : `[footer:${provider}]`,
-  resolveFastSessionLivePreviewUrl: mocks.resolveFastSessionLivePreviewUrl,
+  buildFastSessionReplyFooterText: ({ provider }: { provider: string }) =>
+    `[footer:${provider}]`,
 }));
 
 vi.mock('@roomote/github', () => ({
@@ -380,65 +368,7 @@ describe('GitHub Fast delivery', () => {
     });
   });
 
-  it('includes the session live preview link in the comment footer when one exists', async () => {
-    mocks.resolveFastSessionLivePreviewUrl.mockResolvedValueOnce(
-      'https://preview.example/app',
-    );
-    const conversation = buildSourceControlFastConversation({
-      provider: 'github',
-      host: 'github.com',
-      repositoryFullName: 'acme/api',
-      kind: 'pull',
-      number: 42,
-    });
-    const delivery = await buildSourceControlFastDelivery(conversation);
-    const adapter = buildSourceControlFastAdapter({
-      conversation,
-      delivery: delivery!,
-      userId: 'user-1',
-      sessionId: 'fast-1',
-    });
-
-    await adapter.postReply({ message: 'On it.' });
-
-    expect(mocks.resolveFastSessionLivePreviewUrl).toHaveBeenCalledWith(
-      'fast-1',
-    );
-    expect(createComment).toHaveBeenCalledWith(
-      expect.objectContaining({
-        body: 'On it.\n\n[footer:github:https://preview.example/app]',
-      }),
-    );
-  });
-
-  it('still posts the comment when the live preview lookup fails', async () => {
-    mocks.resolveFastSessionLivePreviewUrl.mockRejectedValueOnce(
-      new Error('db down'),
-    );
-    const conversation = buildSourceControlFastConversation({
-      provider: 'github',
-      host: 'github.com',
-      repositoryFullName: 'acme/api',
-      kind: 'pull',
-      number: 42,
-    });
-    const delivery = await buildSourceControlFastDelivery(conversation);
-    const adapter = buildSourceControlFastAdapter({
-      conversation,
-      delivery: delivery!,
-      userId: 'user-1',
-      sessionId: 'fast-1',
-    });
-
-    await expect(adapter.postReply({ message: 'On it.' })).resolves.toEqual({
-      messageId: '5001',
-    });
-    expect(createComment).toHaveBeenCalledWith(
-      expect.objectContaining({ body: 'On it.\n\n[footer:github]' }),
-    );
-  });
-
-  it('edits the turn comment in place for later replies instead of posting again', async () => {
+  function mockGitHubTurnEditing() {
     const updateComment = vi.fn().mockResolvedValue({});
     mocks.getInstallationOctokit.mockResolvedValue({
       rest: {
@@ -452,6 +382,11 @@ describe('GitHub Fast delivery', () => {
       },
       request,
     });
+    return updateComment;
+  }
+
+  it('edits the turn comment in place for later replies, keeping one footer at the bottom', async () => {
+    const updateComment = mockGitHubTurnEditing();
     const conversation = buildSourceControlFastConversation({
       provider: 'github',
       host: 'github.com',
@@ -469,26 +404,59 @@ describe('GitHub Fast delivery', () => {
     });
 
     await adapter.postReply({ message: 'On it.' });
-    const second = await adapter.postReply({
-      message: 'Rebased; running checks.',
-    });
+    await adapter.postReply({ message: 'Rebased; running checks.' });
+    const last = await adapter.postReply({ message: 'Rebased and green.' });
 
     expect(createComment).toHaveBeenCalledTimes(1);
-    expect(updateComment).toHaveBeenCalledWith(
+    expect(createComment).toHaveBeenCalledWith(
       expect.objectContaining({
-        comment_id: 6001,
-        body: expect.stringContaining('On it.\n\nRebased; running checks.'),
+        body: '> @roomote please rebase this\n\nOn it.\n\n[footer:github]',
       }),
     );
-    // The turn opened with the quote and appends keep it at the top.
-    const firstBody = createComment.mock.calls[0]?.[0].body as string;
-    const editedBody = updateComment.mock.calls[0]?.[0].body as string;
-    expect(firstBody.startsWith('> @roomote please rebase this')).toBe(true);
-    expect(editedBody.startsWith('> @roomote please rebase this')).toBe(true);
-    // Footer appears once, at the bottom of the edited body.
-    const body = updateComment.mock.calls[0]?.[0].body as string;
-    expect(body.match(/footer:github/g)).toHaveLength(1);
-    expect(second).toEqual({ messageId: '6001' });
+    expect(updateComment).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        comment_id: 6001,
+        body: '> @roomote please rebase this\n\nOn it.\n\nRebased; running checks.\n\n[footer:github]',
+      }),
+    );
+    expect(updateComment).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        comment_id: 6001,
+        body: '> @roomote please rebase this\n\nOn it.\n\nRebased; running checks.\n\nRebased and green.\n\n[footer:github]',
+      }),
+    );
+    expect(last).toEqual({ messageId: '6001' });
+  });
+
+  it('does not quote the answered comment when replying inside its review thread', async () => {
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+      reviewCommentId: '800',
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    const adapter = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+      quote: '> @roomote is this loop bounded?',
+    });
+
+    await adapter.postReply({ message: 'Yes, it stops after three tries.' });
+
+    expect(request).toHaveBeenCalledWith(
+      'POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies',
+      expect.objectContaining({
+        comment_id: 800,
+        body: 'Yes, it stops after three tries.\n\n[footer:github]',
+      }),
+    );
   });
 
   it('replaces a resumed turn comment by id and keeps appending into it', async () => {
@@ -535,9 +503,7 @@ describe('GitHub Fast delivery', () => {
       2,
       expect.objectContaining({
         comment_id: 7001,
-        body: expect.stringContaining(
-          'Recovered; here is the result.\n\nAnd one more detail.',
-        ),
+        body: 'Recovered; here is the result.\n\nAnd one more detail.\n\n[footer:github]',
       }),
     );
   });

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -5,10 +5,7 @@ import {
   type LaunchFastAgentTask,
 } from '@roomote/cloud-agents/server';
 import { and, db, eq, repositories } from '@roomote/db/server';
-import {
-  buildFastSessionReplyFooterText,
-  resolveFastSessionLivePreviewUrl,
-} from '@roomote/communication';
+import { buildFastSessionReplyFooterText } from '@roomote/communication';
 import {
   ALL_REPOSITORIES,
   buildFastAgentChildTaskMetadata,
@@ -858,18 +855,26 @@ async function buildAdoFastDelivery(
 /**
  * The reply surface a Session uses in a discussion: replies post as comments
  * with the Session footer, and tasks launch against the discussion's target.
+ *
+ * A turn owns one comment: the first reply opens it and later replies append
+ * to it by editing in place, so a turn never stacks comments on the
+ * discussion. The footer is rendered once, at the bottom, on every edit.
  */
 export function buildSourceControlFastAdapter(params: {
   conversation: FastAgentSourceControlConversation;
   delivery: SourceControlFastDelivery;
   userId: string;
   sessionId: string;
-  /** Blockquote of the message this turn answers; opens the turn's comment. */
   /**
    * The Session's home conversation when the discussion is not its own (see
    * createFastAgentSourceControlTaskLauncher). Delegated children attach there.
    */
   parentConversation?: FastAgentConversation;
+  /**
+   * Blockquote of the message this turn answers; opens the turn's comment on
+   * the discussion's main thread. Inside a review thread the reply already
+   * sits under the comment it answers, so the quote is dropped there.
+   */
   quote?: string | null;
   onReplyPosted?: () => void;
 }): {
@@ -881,8 +886,16 @@ export function buildSourceControlFastAdapter(params: {
   ) => Promise<{ messageId: string }>;
 } {
   const discussion = parseSourceControlFastConversation(params.conversation);
+  const footer = discussion
+    ? buildFastSessionReplyFooterText({
+        provider: discussion.provider,
+        sessionId: params.sessionId,
+      })
+    : '';
+  const quote = discussion?.reviewCommentId ? null : params.quote;
   let turnComment: SourceControlPostedComment | null = null;
   let turnBody = '';
+  const renderBody = () => `${turnBody}\n\n${footer}`;
   return {
     launchTask: createFastAgentSourceControlTaskLauncher({
       userId: params.userId,
@@ -898,31 +911,19 @@ export function buildSourceControlFastAdapter(params: {
           'The discussion for this Session could not be resolved.',
         );
       }
-      const footer = buildFastSessionReplyFooterText({
-        provider: discussion.provider,
-        sessionId: params.sessionId,
-        // The preview link is a nicety; its lookup never blocks the comment.
-        livePreviewUrl: await resolveFastSessionLivePreviewUrl(
-          params.sessionId,
-        ).catch(() => null),
-      });
-      // One comment per turn: the first reply opens it, later replies append
-      // by editing it in place, so a turn never stacks comments on the
-      // discussion.
       if (turnComment?.update) {
         turnBody = `${turnBody}\n\n${message}`;
-        await turnComment.update(`${turnBody}\n\n${footer}`);
+        await turnComment.update(renderBody());
         params.onReplyPosted?.();
         return { messageId: turnComment.messageId };
       }
-      turnBody = params.quote ? `${params.quote}\n\n${message}` : message;
-      const posted = await params.delivery.postComment({
+      turnBody = quote ? `${quote}\n\n${message}` : message;
+      turnComment = await params.delivery.postComment({
         discussion,
-        body: `${turnBody}\n\n${footer}`,
+        body: renderBody(),
       });
-      turnComment = posted;
       params.onReplyPosted?.();
-      return { messageId: posted.messageId };
+      return { messageId: turnComment.messageId };
     },
     ...(params.delivery.updateCommentById && discussion
       ? {
@@ -930,28 +931,15 @@ export function buildSourceControlFastAdapter(params: {
           // editor from it, replace the comment's body, and adopt it as the
           // turn's comment so later replies keep appending in place.
           replaceReply: async ({ messageId }, { message }) => {
-            const footer = buildFastSessionReplyFooterText({
-              provider: discussion.provider,
-              sessionId: params.sessionId,
-              livePreviewUrl: await resolveFastSessionLivePreviewUrl(
-                params.sessionId,
-              ).catch(() => null),
-            });
-            await params.delivery.updateCommentById!({
-              discussion,
-              messageId,
-              body: `${message}\n\n${footer}`,
-            });
+            const update = (nextBody: string) =>
+              params.delivery.updateCommentById!({
+                discussion,
+                messageId,
+                body: nextBody,
+              });
             turnBody = message;
-            turnComment = {
-              messageId,
-              update: (nextBody: string) =>
-                params.delivery.updateCommentById!({
-                  discussion,
-                  messageId,
-                  body: nextBody,
-                }),
-            };
+            await update(renderBody());
+            turnComment = { messageId, update };
             params.onReplyPosted?.();
             return { messageId };
           },


### PR DESCRIPTION
## Summary

Replying inside a review thread Roomote opened produced a confusing bot comment: it triggered without an @mention, quoted the reply directly above it, and closed with a "Working on a live preview" footer that made no sense on a pull request.

- **Only @mentions trigger Roomote on a pull request.** The implicit review-thread trigger (#2161) is removed, so people can discuss a finding in a thread without summoning Roomote. The `findRoomoteOpenedPullRequestTask` helper that only existed for that gate is deleted. Replies on Roomote-opened pull requests still flow through the review-feedback pipeline as before.
- **No blockquote inside review threads.** The reply already sits under the comment it answers, so the quote-reply block is dropped there. Conversation-tab replies keep it.
- **Plain footer on source-control comments.** The live-preview lookup is gone; the footer is always "Reply with @-mention or use the web app", rendered once at the bottom of the turn's comment on every edit.

Docs updated to say only @mentions count.

## Test plan

- [x] `handlePrComment` tests: a review-thread reply without an @mention returns `no_mention` with no fetch, reaction, or Session turn
- [x] `source-control-fast-delivery` tests: single footer across edits, no quote when threaded, resumed-turn replacement
- [x] `fast-session-footer-context` and `github-branch-activity` tests after removing the helpers
- [x] `pnpm lint`, `pnpm check-types:fast`, `pnpm knip`