### PR TITLE
[Fix] Fast retries a rejected inference request once and shows the provider error

### DIFF
--- a/.changeset/fast-rejection-retry.md
+++ b/.changeset/fast-rejection-retry.md
@@ -1,0 +1,5 @@
+---
+'@roomote/web': patch
+---
+
+Fast turns retry a provider rejection once automatically instead of asking the user to try again. When the inference provider rejects a request outright (a 4xx such as a model refusing replayed tool-call history), the turn is re-run once from a fresh session: in process when no tool has run yet, and as a durable park that resumes from the recorded transcript when tools already ran. When the closeout is still needed, it now includes the model and the provider's status and message, so "the inference provider returned an error" says which provider and what it said.

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -4929,6 +4929,217 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
       }
     });
 
+    it('retries a rejected request once from a fresh session before any tool ran', async () => {
+      vi.useFakeTimers();
+      try {
+        mocks.generateText
+          .mockRejectedValueOnce(
+            new Error('BadRequestError: Invalid tool call history'),
+          )
+          .mockImplementationOnce(async (_params, _session, options) => {
+            await options.onSessionReady('opencode-session-2');
+            await invokeTool(nativeToolNames.sendChatReply, {
+              purpose: 'closeout',
+              message: 'Recovered on a fresh session.',
+            });
+            return '';
+          });
+        const postReply = vi.fn().mockResolvedValue(undefined);
+
+        const result = answerFastAgentQuestion({
+          ...baseParams,
+          adapter: callbacks({ postReply }),
+        });
+        result.catch(() => undefined);
+        await vi.runAllTimersAsync();
+        vi.useRealTimers();
+        await expect(result).resolves.toBe('Recovered on a fresh session.');
+
+        expect(mocks.generateText).toHaveBeenCalledTimes(2);
+        // A quick fresh-session retry stays inside the silent recovery
+        // window: the retry marker is persisted for the reconciler, but
+        // the thread only ever sees the answer.
+        const retryWrites = mocks.upsertMessage.mock.calls
+          .map(([input]) => input.message)
+          .filter((message) => message.eventId === '100.2:retry-notice:0');
+        expect(retryWrites.at(-1)?.metadata).toMatchObject({
+          inferenceRetryNotice: true,
+        });
+        expect(retryWrites.at(0)?.contentBlocks).toEqual([
+          {
+            type: 'text',
+            text: 'The inference provider rejected the request. Retrying once from a fresh session…',
+          },
+        ]);
+        expect(postReply).toHaveBeenCalledTimes(1);
+        expect(postReply).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            purpose: 'closeout',
+            message: 'Recovered on a fresh session.',
+          }),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('gives up after one fresh-session retry and shows the provider error', async () => {
+      vi.useFakeTimers();
+      try {
+        const rejection = Object.assign(
+          new Error('BadRequestError: Invalid tool call history'),
+          {
+            data: { statusCode: 400, message: 'Invalid tool call history' },
+          },
+        );
+        mocks.generateText
+          .mockImplementationOnce(async (_params, _session, options) => {
+            options.onModelResolved?.('openrouter/google/gemini-3.8-flash');
+            throw rejection;
+          })
+          .mockRejectedValueOnce(rejection);
+        const postReply = vi.fn().mockResolvedValue(undefined);
+
+        const result = answerFastAgentQuestion({
+          ...baseParams,
+          adapter: callbacks({ postReply }),
+        });
+        result.catch(() => undefined);
+        await vi.runAllTimersAsync();
+        vi.useRealTimers();
+        await result.catch(() => undefined);
+
+        expect(mocks.generateText).toHaveBeenCalledTimes(2);
+        expect(postReply).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            purpose: 'closeout',
+            message:
+              'Could not complete the request because the inference provider returned an error. Please try again in a moment.\n\nProvider error (openrouter/google/gemini-3.8-flash): HTTP 400: Invalid tool call history',
+          }),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not retry a rejection after tool use without a durable row', async () => {
+      mocks.generateText.mockImplementationOnce(
+        async (_params, _session, options) => {
+          options.onModelResolved?.('openrouter/google/gemini-3.8-flash');
+          await options.onSessionReady('opencode-session-1');
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'progress',
+            message: 'Checking the code now.',
+          });
+          throw Object.assign(new Error('BadRequestError: Invalid request'), {
+            data: { statusCode: 400, message: 'Invalid request' },
+          });
+        },
+      );
+      const postReply = vi.fn().mockResolvedValue(undefined);
+
+      await answerFastAgentQuestion({
+        ...baseParams,
+        adapter: callbacks({ postReply }),
+      }).catch(() => undefined);
+
+      // Continuing the rejected session would fail the same way and a cold
+      // rebuild could repeat the tool's side effects, so the turn closes out.
+      expect(mocks.generateText).toHaveBeenCalledTimes(1);
+      expect(postReply).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          purpose: 'closeout',
+          message: expect.stringContaining(
+            'Provider error (openrouter/google/gemini-3.8-flash): HTTP 400: Invalid request',
+          ),
+        }),
+      );
+    });
+
+    it('parks a rejection after tool use so the resumed run starts from the recorded transcript', async () => {
+      vi.useFakeTimers();
+      const before = Date.now();
+      mocks.getUnifiedSession.mockResolvedValue({ id: 'session-1' });
+      mocks.generateText.mockImplementationOnce(
+        async (_params, _session, options) => {
+          await options.onSessionReady('opencode-session-1');
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'progress',
+            message: 'Checking the code now.',
+          });
+          throw new Error('BadRequestError: Invalid tool call history');
+        },
+      );
+      const requestDurableRetry = vi.fn().mockResolvedValue(undefined);
+      const postReply = vi.fn().mockResolvedValue(undefined);
+
+      const result = answerFastAgentQuestion({
+        ...baseParams,
+        adapter: callbacks({ postReply, requestDurableRetry }),
+        durableAdmission,
+      });
+      result.catch(() => undefined);
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
+      await expect(result).rejects.toBeInstanceOf(
+        FastAgentDurableRetryScheduledError,
+      );
+
+      expect(mocks.generateText).toHaveBeenCalledTimes(1);
+      expect(mocks.scheduleDurableRetry).toHaveBeenCalledOnce();
+      const [rowId, schedule] = mocks.scheduleDurableRetry.mock.calls[0]!;
+      expect(rowId).toBe('durable-row-1');
+      expect(schedule.reason).toContain('provider_error');
+      expect(schedule.retryAt.getTime()).toBeGreaterThan(before);
+      expect(requestDurableRetry).toHaveBeenCalledWith(schedule.retryAt);
+      expect(postReply).not.toHaveBeenCalledWith(
+        expect.objectContaining({ purpose: 'closeout' }),
+      );
+      // The rejected native session is forgotten before the park, so the
+      // resumed run rebuilds from the transcript instead of reattaching.
+      expect(mocks.setOpenCodeSession).toHaveBeenLastCalledWith({
+        sessionId: expect.any(String),
+        openCodeSessionId: null,
+      });
+      expect(mocks.invalidateSession).toHaveBeenCalled();
+    });
+
+    it('does not grant a resumed retry a second fresh session', async () => {
+      mocks.generateText.mockImplementationOnce(
+        async (_params, _session, options) => {
+          options.onModelResolved?.('openrouter/google/gemini-3.8-flash');
+          await options.onSessionReady('opencode-session-1');
+          await invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'progress',
+            message: 'Checking the code now.',
+          });
+          throw Object.assign(new Error('BadRequestError: Invalid request'), {
+            data: { statusCode: 400, message: 'Invalid request' },
+          });
+        },
+      );
+      const requestDurableRetry = vi.fn().mockResolvedValue(undefined);
+      const postReply = vi.fn().mockResolvedValue(undefined);
+
+      await answerFastAgentQuestion({
+        ...baseParams,
+        adapter: callbacks({ postReply, requestDurableRetry }),
+        durableAdmission: { eventId: 'durable-row-1', inferenceRetries: 1 },
+        resumedAfterInferenceRetry: true,
+      }).catch(() => undefined);
+
+      expect(mocks.generateText).toHaveBeenCalledTimes(1);
+      expect(mocks.scheduleDurableRetry).not.toHaveBeenCalled();
+      expect(postReply).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          purpose: 'closeout',
+          message: expect.stringContaining(
+            'Provider error (openrouter/google/gemini-3.8-flash): HTTP 400: Invalid request',
+          ),
+        }),
+      );
+    });
+
     it('rides out the first short retry in place and parks from the second', async () => {
       vi.useFakeTimers();
       const before = Date.now();

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-conversation-repository.ts
@@ -786,9 +786,10 @@ export interface FastAgentConversationRepository {
     conversationId: string;
     message: FastAgentMessageWrite;
   }): Promise<FastAgentMessageUpsertResult>;
+  /** `null` forgets the native session so the next turn rebuilds it. */
   setOpenCodeSession(input: {
     conversationId: string;
-    openCodeSessionId: string;
+    openCodeSessionId: string | null;
   }): Promise<void>;
 }
 

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import type { ModelMessage } from 'ai';
+import { redactSecrets } from '@roomote/communication/redact-secrets';
 import {
   ACP_ENVELOPE_EVENT_TYPES,
   ACP_UI_TOOL_OUTPUT_MAX_CHARS,
@@ -671,10 +672,23 @@ type FastAgentInferenceRetryNotice = {
   attemptNumber: number;
   maxAttempts?: number;
   delayMs?: number;
+  /** The one fresh-start retry granted to a rejected request. */
+  freshSession?: boolean;
 };
 
 type FastAgentInferenceRetryOptions = {
   canRetry?: (error: unknown, failure: FastAgentInferenceFailure) => boolean;
+  /**
+   * A provider rejection (a non-retryable `provider_error`, typically a 4xx
+   * on the request as sent) is not worth repeating as-is, but the same
+   * request from a fresh session usually succeeds: a human "try again" is
+   * exactly that. Return true to grant one such retry per turn; the caller
+   * must then rebuild rather than continue the rejected session.
+   */
+  retryRejection?: (
+    error: unknown,
+    failure: FastAgentInferenceFailure,
+  ) => boolean;
   prepareRetry?: () => Promise<void> | void;
   /**
    * Offered the pending backoff after its notice is recorded and before the
@@ -740,6 +754,9 @@ export function findFastAgentDurableRetryScheduledError(
 }
 
 class FastAgentInferenceError extends Error {
+  /** Provider status and message, redacted and bounded, for the closeout. */
+  public readonly detail: string | undefined;
+
   constructor(
     public readonly failure: FastAgentInferenceFailure,
     cause: unknown,
@@ -749,7 +766,88 @@ class FastAgentInferenceError extends Error {
       { cause },
     );
     this.name = 'FastAgentInferenceError';
+    this.detail = describeInferenceErrorForUser(cause);
   }
+}
+
+const FAST_AGENT_INFERENCE_DETAIL_MAX_CHARS = 200;
+
+/**
+ * The provider's own status and message, as OpenCode surfaces them
+ * (`{name, data: {statusCode, message, responseBody}}`, possibly wrapped in
+ * a prompt error's `providerError` or an Error `cause`). Secrets are
+ * redacted and the text is bounded so it can be shown in the thread; a
+ * closeout that only says "the provider returned an error" leaves the
+ * reader guessing which provider and why.
+ */
+function describeInferenceErrorForUser(error: unknown): string | undefined {
+  let statusCode: number | undefined;
+  let message: string | undefined;
+  const pending: Array<{ value: unknown; depth: number }> = [
+    { value: error, depth: 0 },
+  ];
+  const seen = new Set<object>();
+  while (pending.length > 0) {
+    const current = pending.shift();
+    if (!current || current.depth > 4) continue;
+    const { value, depth } = current;
+    if (typeof value === 'string') {
+      if (value.trim().startsWith('{')) {
+        try {
+          pending.push({ value: JSON.parse(value), depth: depth + 1 });
+        } catch {
+          // Plain text; nothing nested to read.
+        }
+      }
+      continue;
+    }
+    if (!value || typeof value !== 'object' || seen.has(value)) continue;
+    seen.add(value);
+    const record = value as Record<string, unknown>;
+    if (statusCode === undefined) {
+      const candidate = record.statusCode ?? record.status;
+      if (typeof candidate === 'number' && candidate >= 100) {
+        statusCode = candidate;
+      }
+    }
+    // Prefer the innermost provider message over the wrapper's own text.
+    const data = record.data;
+    const dataMessage =
+      data && typeof data === 'object'
+        ? (data as Record<string, unknown>).message
+        : undefined;
+    if (typeof dataMessage === 'string' && dataMessage.trim()) {
+      message = dataMessage;
+    } else if (
+      message === undefined &&
+      typeof record.message === 'string' &&
+      record.message.trim() &&
+      !(value instanceof Error)
+    ) {
+      message = record.message;
+    }
+    for (const key of [
+      'providerError',
+      'cause',
+      'data',
+      'error',
+      'responseBody',
+    ]) {
+      if (key in record) pending.push({ value: record[key], depth: depth + 1 });
+    }
+  }
+  if (message === undefined && error instanceof Error) {
+    message = error.message;
+  }
+  const parts = [
+    statusCode === undefined ? undefined : `HTTP ${statusCode}`,
+    message?.replace(/\s+/gu, ' ').trim() || undefined,
+  ].filter((part): part is string => Boolean(part));
+  if (parts.length === 0) return undefined;
+  const text = redactSecrets(parts.join(': '));
+  return text.length <= FAST_AGENT_INFERENCE_DETAIL_MAX_CHARS
+    ? text
+    : `${text.slice(0, FAST_AGENT_INFERENCE_DETAIL_MAX_CHARS - 1)}…`;
 }
 
 function resolveFastAgentInferenceMaxRetries(
@@ -792,6 +890,9 @@ function resolveFastAgentInferenceRetryDelayMs(
 function formatFastAgentInferenceRetryNotice(
   notice: FastAgentInferenceRetryNotice,
 ): string {
+  if (notice.freshSession) {
+    return 'The inference provider rejected the request. Retrying once from a fresh session…';
+  }
   const headline =
     notice.failure.reason === 'rate_limited'
       ? 'The inference provider is rate limiting requests.'
@@ -810,6 +911,20 @@ function formatFastAgentInferenceRetryNotice(
 }
 
 function formatFastAgentInferenceFailure(
+  failure: FastAgentInferenceFailure,
+  retried: boolean,
+  context: { detail?: string; model?: string } = {},
+): string {
+  const summary = formatFastAgentInferenceFailureSummary(failure, retried);
+  // The specific reasons already say what happened. The generic rejection
+  // is the one that leaves the reader guessing, so it carries the provider's
+  // own status and message, and the model that produced them.
+  if (failure.reason !== 'provider_error' || !context.detail) return summary;
+  const source = context.model ? ` (${context.model})` : '';
+  return `${summary}\n\nProvider error${source}: ${context.detail}`;
+}
+
+function formatFastAgentInferenceFailureSummary(
   failure: FastAgentInferenceFailure,
   retried: boolean,
 ): string {
@@ -871,6 +986,7 @@ async function runFastAgentInferenceWithRetries<T>(
   options: FastAgentInferenceRetryOptions = {},
 ): Promise<T> {
   let totalRetryCount = 0;
+  let rejectionRetryUsed = false;
   for (let retryNumber = 0; ; retryNumber += 1) {
     try {
       options.signal?.throwIfAborted();
@@ -898,14 +1014,20 @@ async function runFastAgentInferenceWithRetries<T>(
         retryNumber = 0;
       }
       const maxRetries = resolveFastAgentInferenceMaxRetries(failure);
+      const rejectionRetry =
+        !failure.retryable &&
+        failure.reason === 'provider_error' &&
+        !rejectionRetryUsed &&
+        options.retryRejection?.(error, failure) === true;
       if (
-        !failure.retryable ||
+        (!failure.retryable && !rejectionRetry) ||
         options.canRetry?.(error, failure) === false ||
         retryNumber >= maxRetries ||
         totalRetryCount >= FAST_AGENT_MAX_INFERENCE_RETRIES_PER_TURN
       ) {
         throw new FastAgentInferenceError(failure, error);
       }
+      if (rejectionRetry) rejectionRetryUsed = true;
 
       totalRetryCount += 1;
       const attemptNumber = retryNumber + 1;
@@ -920,6 +1042,7 @@ async function runFastAgentInferenceWithRetries<T>(
           attemptNumber,
           maxAttempts: maxRetries,
           delayMs,
+          ...(rejectionRetry ? { freshSession: true } : {}),
         });
       } catch (noticeError) {
         console.warn(
@@ -934,6 +1057,7 @@ async function runFastAgentInferenceWithRetries<T>(
         maxAttempts: maxRetries,
         delayMs,
         inProcessAttempt: attemptNumber,
+        ...(rejectionRetry ? { freshSession: true } : {}),
       });
       if (parkedUntil) {
         throw new FastAgentDurableRetryScheduledError(parkedUntil);
@@ -1557,6 +1681,8 @@ export async function answerFastAgentQuestion({
   let canonicalConversationId: string | null = null;
   let durableOpenCodeSessionId: string | null = null;
   let lastVisibleMessage = '';
+  /** Last model OpenCode resolved for this turn, for the failure closeout. */
+  let lastResolvedInferenceModel: string | undefined;
   let currentInstructionVersion = 0;
   const assistantInstructionVersions = new Map<string, number>();
   const closedInstructionVersions = new Set<number>();
@@ -1682,24 +1808,37 @@ export async function answerFastAgentQuestion({
    * (row superseded or withdrawn, write failed) also falls back to the
    * in-process wait, so durability here is best effort like admission.
    */
+  /** Whether a pending retry could leave the process as a durable park. */
+  const canParkDurableRetry = () =>
+    Boolean(
+      durableAdmission &&
+      durableTurnReplayable &&
+      adapter.requestDurableRetry &&
+      !Env.R_FAST_DURABLE_RETRY_DISABLED &&
+      !signal?.aborted &&
+      !isInstructionClosed() &&
+      durableRetriesConsumed < FAST_AGENT_DURABLE_RETRY_MAX_PARKS,
+    );
   const deferInferenceRetry = async (
     notice: FastAgentInferenceRetryNotice & { inProcessAttempt: number },
   ): Promise<Date | null> => {
+    // The explicit checks repeat part of canParkDurableRetry so the
+    // admission row and the wakeup hook are narrowed for the calls below.
     if (
       !durableAdmission ||
-      !durableTurnReplayable ||
       !adapter.requestDurableRetry ||
-      Env.R_FAST_DURABLE_RETRY_DISABLED ||
-      notice.delayMs === undefined ||
-      signal?.aborted ||
-      isInstructionClosed()
+      !canParkDurableRetry() ||
+      notice.delayMs === undefined
     ) {
       return null;
     }
     // A one-off blip is cheapest to ride out where it happened: the first
     // in-process retry stays in place unless its wait is already long.
-    // From the second attempt on, the wait leaves the process.
+    // From the second attempt on, the wait leaves the process. A rejection
+    // always parks: the point of its one retry is a fresh session built
+    // from the recorded transcript, which only the resumed run provides.
     if (
+      !notice.freshSession &&
       notice.inProcessAttempt < 2 &&
       notice.delayMs < FAST_AGENT_DURABLE_RETRY_IMMEDIATE_PARK_WAIT_MS
     ) {
@@ -1727,6 +1866,25 @@ export async function answerFastAgentQuestion({
     }
     const retryAt = new Date(now + parkDelayMs);
     const inferenceRetries = durableRetriesConsumed + 1;
+    if (notice.freshSession && canonicalConversationId) {
+      // The provider rejected this session's native history, so the resumed
+      // run must not reattach to it. Forget the durable OpenCode session
+      // first: the resume then rebuilds from the recorded transcript, which
+      // is what a human "try again" gets.
+      try {
+        await setFastAgentOpenCodeSession({
+          sessionId: canonicalConversationId,
+          openCodeSessionId: null,
+        });
+      } catch (error) {
+        console.warn(
+          `[Fast Agent] Failed to forget the rejected OpenCode session before parking: ${formatErrorForLog(error)}`,
+        );
+        return null;
+      }
+      durableOpenCodeSessionId = null;
+      fastAgentOpenCodeSessionManager.invalidate(canonicalConversationId);
+    }
     const scheduled = await scheduleFastAgentDurableTurnRetry(
       durableAdmission.eventId,
       {
@@ -4494,6 +4652,7 @@ export async function answerFastAgentQuestion({
                       tools: FAST_AGENT_SESSION_TOOL_FILTER,
                       onModelResolved: (model) => {
                         resolvedInferenceModel = model;
+                        lastResolvedInferenceModel = model;
                         diagnostics.recordModelResolved(model);
                       },
                       onMessageCompleted: (message) => {
@@ -4691,6 +4850,20 @@ export async function answerFastAgentQuestion({
                 (!nativeToolInvoked || openCodeSession.id !== undefined) &&
                 !isNonTaskOpenCodePromptTimeoutError(error) &&
                 !isNonTaskOpenCodeSessionValidationError(error),
+              // A rejected request is retried once from a fresh start, the
+              // way a human "try again" would run it: before tools ran, an
+              // in-process rebuild from visible history; after tools ran, a
+              // durable park so the resumed run replays from the recorded
+              // transcript instead of the rejected native history.
+              // A run that is itself the resumed retry gets no second one:
+              // a rejection that survives a fresh session is terminal.
+              retryRejection: (error) =>
+                !signal?.aborted &&
+                !isInstructionClosed() &&
+                !resumedAfterInferenceRetry &&
+                !isNonTaskOpenCodePromptTimeoutError(error) &&
+                !isNonTaskOpenCodeSessionValidationError(error) &&
+                (!nativeToolInvoked || canParkDurableRetry()),
               // Grant a fresh bounded budget only when the failed attempt
               // advanced the turn and the next retry continues the same
               // OpenCode session. Cold rebuilds replay from scratch, so
@@ -4963,6 +5136,7 @@ export async function answerFastAgentQuestion({
         ? formatFastAgentInferenceFailure(
             error.failure,
             inferenceRetryAttempted,
+            { detail: error.detail, model: lastResolvedInferenceModel },
           )
         : 'I hit an error while handling that request. Please try again in a moment.';
     // The error closeout is recorded like any other closeout: its intent

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -1866,25 +1866,6 @@ export async function answerFastAgentQuestion({
     }
     const retryAt = new Date(now + parkDelayMs);
     const inferenceRetries = durableRetriesConsumed + 1;
-    if (notice.freshSession && canonicalConversationId) {
-      // The provider rejected this session's native history, so the resumed
-      // run must not reattach to it. Forget the durable OpenCode session
-      // first: the resume then rebuilds from the recorded transcript, which
-      // is what a human "try again" gets.
-      try {
-        await setFastAgentOpenCodeSession({
-          sessionId: canonicalConversationId,
-          openCodeSessionId: null,
-        });
-      } catch (error) {
-        console.warn(
-          `[Fast Agent] Failed to forget the rejected OpenCode session before parking: ${formatErrorForLog(error)}`,
-        );
-        return null;
-      }
-      durableOpenCodeSessionId = null;
-      fastAgentOpenCodeSessionManager.invalidate(canonicalConversationId);
-    }
     const scheduled = await scheduleFastAgentDurableTurnRetry(
       durableAdmission.eventId,
       {
@@ -1902,6 +1883,29 @@ export async function answerFastAgentQuestion({
     durableTurnReplayable = false;
     durableTurnDeferred = true;
     durableRetriesConsumed = inferenceRetries;
+    if (notice.freshSession && canonicalConversationId) {
+      // The provider rejected this session's native history, so the resumed
+      // run must not reattach to it. Forget the durable OpenCode session so
+      // the resume rebuilds from the recorded transcript, which is what a
+      // human "try again" gets. This runs only once the park is committed:
+      // dropping the live session before that would send a failed schedule
+      // down the in-process cold-rebuild path and could repeat the tool
+      // side effects the durable guard exists to prevent. If forgetting
+      // fails, the resumed run reattaches, meets the same rejection, and
+      // closes out honestly, since a resumed run gets no second retry.
+      try {
+        await setFastAgentOpenCodeSession({
+          sessionId: canonicalConversationId,
+          openCodeSessionId: null,
+        });
+        durableOpenCodeSessionId = null;
+        fastAgentOpenCodeSessionManager.invalidate(canonicalConversationId);
+      } catch (error) {
+        console.warn(
+          `[Fast Agent] Failed to forget the rejected OpenCode session for the parked retry: ${formatErrorForLog(error)}`,
+        );
+      }
+    }
     await adapter.requestDurableRetry(retryAt).catch((error) => {
       console.warn(
         `[Fast Agent] Failed to queue the durable inference retry wakeup: ${formatErrorForLog(error)}`,

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-session.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-session.ts
@@ -161,7 +161,7 @@ export async function setFastAgentOpenCodeSession({
   openCodeSessionId,
 }: {
   sessionId: string;
-  openCodeSessionId: string;
+  openCodeSessionId: string | null;
 }): Promise<void> {
   await fastAgentConversationRepository.setOpenCodeSession({
     conversationId: sessionId,


### PR DESCRIPTION
## Summary

Three Fast sessions today closed out with "Could not complete the request because the inference provider returned an error. Please try again in a moment." In each case the provider had rejected the request outright (a non-retryable 4xx), and when a person replied "try again" a fresh turn succeeded. The fix does that retry automatically and, when a closeout is still needed, says what the provider actually returned.

## Behavior

- **One automatic fresh-session retry for a provider rejection.** A non-retryable `provider_error` (typically a 4xx on the request as sent) gets exactly one retry per turn, run the way a human "try again" would run it:
  - before any tool has run, an in-process rebuild from visible history;
  - after tools ran, a durable park. The park first forgets the conversation's stored OpenCode session so the resumed run rebuilds from the recorded transcript instead of reattaching to the session whose native history the provider rejected. A run that is itself the resumed retry gets no second one.
  - Credential, credit, model-availability, and content-filter failures are unchanged.
- **The retry notice names what is happening:** "The inference provider rejected the request. Retrying once from a fresh session…". Like every retry notice it stays inside the silent recovery window, so a quick recovery shows only the answer.
- **The generic closeout carries the provider's own error.** The model, HTTP status, and provider message are appended, redacted and bounded to 200 characters, for example:

  > Could not complete the request because the inference provider returned an error. Please try again in a moment.
  >
  > Provider error (openrouter/google/gemini-3.8-flash): HTTP 400: Invalid tool call history

  Reason-specific closeouts (rate limit, timeout, unreachable, credentials, content filter) already say what happened and are unchanged.

## Notes

- `setFastAgentOpenCodeSession` now accepts `null` to forget the stored native session; the column was already nullable.
- The durable park guard is factored into `canParkDurableRetry()` and reused to decide whether a post-tool rejection may retry at all.

## Tests

New service tests: fresh-session retry before tools (recovers, only the answer is posted), rejection retried once then closed out with the provider detail, no retry after tool use without a durable row, park after tool use with the stored OpenCode session forgotten, and no second fresh session for a resumed run. Full service, diagnostics, and provider-usage suites pass apart from the pre-existing macOS-only storage-exhaustion test. oxfmt, oxlint, and `tsc --noEmit` on cloud-agents are clean.
