### PR TITLE
[Fix] One Roomote comment per human message in a review thread

### DIFF
--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -1653,6 +1653,7 @@ async function createSourceControlFastAgentParentTurn(params: {
         params.event.type === 'human_follow_up'
           ? buildSourceControlReplyQuote({ text: params.event.question })
           : null,
+      continuesThreadComment: params.event.type !== 'human_follow_up',
       onReplyPosted: params.onReplyPosted,
     }),
   };

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -601,6 +601,50 @@ describe('GitHub Fast delivery', () => {
     );
   });
 
+  it('rethrows an indeterminate failure on the remembered thread comment instead of posting twice', async () => {
+    const updateReviewComment = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Bad Gateway'), { status: 502 }),
+      );
+    mocks.getInstallationOctokit.mockResolvedValue({
+      rest: {
+        issues: { createComment },
+        pulls: { get: pullsGet, updateReviewComment },
+      },
+      request,
+    });
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+      reviewCommentId: '800',
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    await buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+    }).postReply({ message: 'Rebasing now.' });
+
+    const taskTurn = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+      continuesThreadComment: true,
+    });
+    await expect(
+      taskTurn.postReply({ message: 'Rebased and pushed.' }),
+    ).rejects.toThrow('Bad Gateway');
+
+    // The edit may have landed; no second comment is posted.
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
   it('opens a new comment for the next human message in the thread', async () => {
     const updateReviewComment = vi.fn().mockResolvedValue({});
     mocks.getInstallationOctokit.mockResolvedValue({

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -442,7 +442,7 @@ describe('GitHub Fast delivery', () => {
     expect(last).toEqual({ messageId: '6001' });
   });
 
-  it('posts a bare reply inside a review thread: no quote and no footer', async () => {
+  it('does not quote the answered comment when replying inside its review thread', async () => {
     const conversation = buildSourceControlFastConversation({
       provider: 'github',
       host: 'github.com',
@@ -466,7 +466,7 @@ describe('GitHub Fast delivery', () => {
       'POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies',
       expect.objectContaining({
         comment_id: 800,
-        body: 'Yes, it stops after three tries.',
+        body: 'Yes, it stops after three tries.\n\n[footer:github]',
       }),
     );
   });
@@ -516,7 +516,7 @@ describe('GitHub Fast delivery', () => {
     expect(updateReviewComment).toHaveBeenCalledWith(
       expect.objectContaining({
         comment_id: 5002,
-        body: 'Rebasing now.\n\nRebased and pushed.',
+        body: 'Rebasing now.\n\nRebased and pushed.\n\n[footer:github]',
       }),
     );
     expect(createComment).not.toHaveBeenCalled();

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -1,4 +1,5 @@
 const mocks = vi.hoisted(() => ({
+  redisStore: new Map<string, string>(),
   createFastAgentTaskLauncher: vi.fn(),
   repositoriesFindMany: vi.fn(),
   getInstallationOctokit: vi.fn(),
@@ -30,6 +31,16 @@ vi.mock('@roomote/db/server', () => ({
   db: { query: { repositories: { findMany: mocks.repositoriesFindMany } } },
   eq: vi.fn((left: unknown, right: unknown) => [left, right]),
   repositories: {},
+}));
+
+vi.mock('@roomote/redis', () => ({
+  getRedis: () => ({
+    get: async (key: string) => mocks.redisStore.get(key) ?? null,
+    set: async (key: string, value: string) => {
+      mocks.redisStore.set(key, value);
+      return 'OK';
+    },
+  }),
 }));
 
 vi.mock('@roomote/communication', () => ({
@@ -296,6 +307,7 @@ describe('GitHub Fast delivery', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.redisStore.clear();
     createComment.mockResolvedValue({ data: { id: 5001 } });
     request.mockResolvedValue({ data: { id: 5002 } });
     pullsGet.mockResolvedValue({
@@ -457,6 +469,123 @@ describe('GitHub Fast delivery', () => {
         body: 'Yes, it stops after three tries.',
       }),
     );
+  });
+
+  it('extends the last human comment in a review thread when a delegated task reports back', async () => {
+    const updateReviewComment = vi.fn().mockResolvedValue({});
+    mocks.getInstallationOctokit.mockResolvedValue({
+      rest: {
+        issues: { createComment },
+        pulls: { get: pullsGet, updateReviewComment },
+      },
+      request,
+    });
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+      reviewCommentId: '800',
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+
+    // The human turn opens the thread's comment.
+    const humanTurn = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+    });
+    await humanTurn.postReply({ message: 'Rebasing now.' });
+
+    // A later platform-event turn (fresh adapter, no in-memory state)
+    // appends to that comment instead of posting a new one.
+    const taskTurn = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+      continuesThreadComment: true,
+    });
+    await expect(
+      taskTurn.postReply({ message: 'Rebased and pushed.' }),
+    ).resolves.toEqual({ messageId: '5002' });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(updateReviewComment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        comment_id: 5002,
+        body: 'Rebasing now.\n\nRebased and pushed.',
+      }),
+    );
+    expect(createComment).not.toHaveBeenCalled();
+  });
+
+  it('opens a new comment for the next human message in the thread', async () => {
+    const updateReviewComment = vi.fn().mockResolvedValue({});
+    mocks.getInstallationOctokit.mockResolvedValue({
+      rest: {
+        issues: { createComment },
+        pulls: { get: pullsGet, updateReviewComment },
+      },
+      request,
+    });
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+      reviewCommentId: '800',
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    const build = (continuesThreadComment: boolean) =>
+      buildSourceControlFastAdapter({
+        conversation,
+        delivery: delivery!,
+        userId: 'user-1',
+        sessionId: 'fast-1',
+        continuesThreadComment,
+      });
+
+    await build(false).postReply({ message: 'First answer.' });
+    await build(false).postReply({ message: 'Second answer.' });
+
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(updateReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a new comment when the thread has no remembered comment', async () => {
+    const updateReviewComment = vi.fn().mockResolvedValue({});
+    mocks.getInstallationOctokit.mockResolvedValue({
+      rest: {
+        issues: { createComment },
+        pulls: { get: pullsGet, updateReviewComment },
+      },
+      request,
+    });
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+      reviewCommentId: '801',
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    const adapter = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+      continuesThreadComment: true,
+    });
+
+    await adapter.postReply({ message: 'Task finished.' });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(updateReviewComment).not.toHaveBeenCalled();
   });
 
   it('replaces a resumed turn comment by id and keeps appending into it', async () => {

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -430,7 +430,7 @@ describe('GitHub Fast delivery', () => {
     expect(last).toEqual({ messageId: '6001' });
   });
 
-  it('does not quote the answered comment when replying inside its review thread', async () => {
+  it('posts a bare reply inside a review thread: no quote and no footer', async () => {
     const conversation = buildSourceControlFastConversation({
       provider: 'github',
       host: 'github.com',
@@ -454,7 +454,7 @@ describe('GitHub Fast delivery', () => {
       'POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies',
       expect.objectContaining({
         comment_id: 800,
-        body: 'Yes, it stops after three tries.\n\n[footer:github]',
+        body: 'Yes, it stops after three tries.',
       }),
     );
   });

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.test.ts
@@ -522,6 +522,85 @@ describe('GitHub Fast delivery', () => {
     expect(createComment).not.toHaveBeenCalled();
   });
 
+  it('posts a new comment when the remembered thread comment can no longer be edited', async () => {
+    const updateReviewComment = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Not Found'), { status: 404 }),
+      );
+    mocks.getInstallationOctokit.mockResolvedValue({
+      rest: {
+        issues: { createComment },
+        pulls: { get: pullsGet, updateReviewComment },
+      },
+      request,
+    });
+    const conversation = buildSourceControlFastConversation({
+      provider: 'github',
+      host: 'github.com',
+      repositoryFullName: 'acme/api',
+      kind: 'pull',
+      number: 42,
+      reviewCommentId: '800',
+    });
+    const delivery = await buildSourceControlFastDelivery(conversation);
+    await buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+    }).postReply({ message: 'Rebasing now.' });
+    request.mockResolvedValue({ data: { id: 5003 } });
+
+    const taskTurn = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+      continuesThreadComment: true,
+    });
+    await expect(
+      taskTurn.postReply({ message: 'Rebased and pushed.' }),
+    ).resolves.toEqual({ messageId: '5003' });
+    await taskTurn.postReply({ message: 'Checks are green.' });
+
+    // The stale comment was tried once, then this turn posted its own reply
+    // and kept editing that one.
+    expect(updateReviewComment).toHaveBeenCalledTimes(2);
+    expect(updateReviewComment).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ comment_id: 5002 }),
+    );
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request).toHaveBeenLastCalledWith(
+      'POST /repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies',
+      expect.objectContaining({
+        body: 'Rebased and pushed.\n\n[footer:github]',
+      }),
+    );
+    expect(updateReviewComment).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        comment_id: 5003,
+        body: 'Rebased and pushed.\n\nChecks are green.\n\n[footer:github]',
+      }),
+    );
+
+    // The record now points at the new comment, so the next task turn
+    // adopts it rather than the deleted one.
+    const nextTurn = buildSourceControlFastAdapter({
+      conversation,
+      delivery: delivery!,
+      userId: 'user-1',
+      sessionId: 'fast-1',
+      continuesThreadComment: true,
+    });
+    await nextTurn.postReply({ message: 'Merged.' });
+    expect(updateReviewComment).toHaveBeenLastCalledWith(
+      expect.objectContaining({ comment_id: 5003 }),
+    );
+  });
+
   it('opens a new comment for the next human message in the thread', async () => {
     const updateReviewComment = vi.fn().mockResolvedValue({});
     mocks.getInstallationOctokit.mockResolvedValue({

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -9,12 +9,18 @@ import { buildFastSessionReplyFooterText } from '@roomote/communication';
 import {
   ALL_REPOSITORIES,
   buildFastAgentChildTaskMetadata,
+  formatErrorForLog,
   linkedWorkItemProviderSchema,
   TaskPayloadKind,
   type FastAgentConversation,
   type FastAgentSourceControlConversation,
   type FastAgentSourceControlSurface,
 } from '@roomote/types';
+
+import {
+  getSourceControlThreadCommentRecord,
+  setSourceControlThreadCommentRecord,
+} from './source-control-thread-comment-state';
 
 export type SourceControlDiscussionKind = 'pull' | 'issues';
 
@@ -861,7 +867,10 @@ async function buildAdoFastDelivery(
  * discussion. On the discussion's main thread the footer is rendered once, at
  * the bottom, on every edit. Inside a review thread there is no footer: the
  * thread is a conversation about one finding, and the Session link belongs
- * on the top-level comment, not on every reply.
+ * on the top-level comment, not on every reply. A review thread also holds
+ * one Roomote comment per human message: a turn that reports on delegated
+ * work (`continuesThreadComment`) extends the comment the last human turn
+ * opened there instead of adding another.
  */
 export function buildSourceControlFastAdapter(params: {
   conversation: FastAgentSourceControlConversation;
@@ -879,6 +888,11 @@ export function buildSourceControlFastAdapter(params: {
    * sits under the comment it answers, so the quote is dropped there.
    */
   quote?: string | null;
+  /**
+   * True for a turn no human wrote (a delegated task reporting back). In a
+   * review thread it appends to the comment the last human turn opened.
+   */
+  continuesThreadComment?: boolean;
   onReplyPosted?: () => void;
 }): {
   launchTask: LaunchFastAgentTask;
@@ -889,7 +903,8 @@ export function buildSourceControlFastAdapter(params: {
   ) => Promise<{ messageId: string }>;
 } {
   const discussion = parseSourceControlFastConversation(params.conversation);
-  const threaded = Boolean(discussion?.reviewCommentId);
+  const threadId = params.conversation.replyTarget.threadId;
+  const threaded = Boolean(discussion?.reviewCommentId && threadId);
   const footer =
     discussion && !threaded
       ? buildFastSessionReplyFooterText({
@@ -901,6 +916,59 @@ export function buildSourceControlFastAdapter(params: {
   let turnComment: SourceControlPostedComment | null = null;
   let turnBody = '';
   const renderBody = () => (footer ? `${turnBody}\n\n${footer}` : turnBody);
+  const editorFor = (messageId: string): SourceControlPostedComment => ({
+    messageId,
+    ...(params.delivery.updateCommentById && discussion
+      ? {
+          update: (nextBody: string) =>
+            params.delivery.updateCommentById!({
+              discussion,
+              messageId,
+              body: nextBody,
+            }),
+        }
+      : {}),
+  });
+  // The thread's comment record is a best-effort nicety: losing it costs one
+  // extra comment, never the reply.
+  const rememberThreadComment = async () => {
+    if (!threaded || !threadId || !turnComment) {
+      return;
+    }
+    await setSourceControlThreadCommentRecord(params.sessionId, threadId, {
+      messageId: turnComment.messageId,
+      body: turnBody,
+    }).catch((error) => {
+      console.warn(
+        `[Fast Agent] Failed to remember the review thread comment: ${formatErrorForLog(error)}`,
+      );
+    });
+  };
+  const adoptThreadComment = async (): Promise<boolean> => {
+    if (
+      !threaded ||
+      !threadId ||
+      !params.continuesThreadComment ||
+      !params.delivery.updateCommentById
+    ) {
+      return false;
+    }
+    const record = await getSourceControlThreadCommentRecord(
+      params.sessionId,
+      threadId,
+    ).catch((error) => {
+      console.warn(
+        `[Fast Agent] Failed to look up the review thread comment: ${formatErrorForLog(error)}`,
+      );
+      return null;
+    });
+    if (!record) {
+      return false;
+    }
+    turnComment = editorFor(record.messageId);
+    turnBody = record.body;
+    return true;
+  };
   return {
     launchTask: createFastAgentSourceControlTaskLauncher({
       userId: params.userId,
@@ -916,9 +984,13 @@ export function buildSourceControlFastAdapter(params: {
           'The discussion for this Session could not be resolved.',
         );
       }
+      if (!turnComment) {
+        await adoptThreadComment();
+      }
       if (turnComment?.update) {
         turnBody = `${turnBody}\n\n${message}`;
         await turnComment.update(renderBody());
+        await rememberThreadComment();
         params.onReplyPosted?.();
         return { messageId: turnComment.messageId };
       }
@@ -927,6 +999,7 @@ export function buildSourceControlFastAdapter(params: {
         discussion,
         body: renderBody(),
       });
+      await rememberThreadComment();
       params.onReplyPosted?.();
       return { messageId: turnComment.messageId };
     },
@@ -936,15 +1009,10 @@ export function buildSourceControlFastAdapter(params: {
           // editor from it, replace the comment's body, and adopt it as the
           // turn's comment so later replies keep appending in place.
           replaceReply: async ({ messageId }, { message }) => {
-            const update = (nextBody: string) =>
-              params.delivery.updateCommentById!({
-                discussion,
-                messageId,
-                body: nextBody,
-              });
+            turnComment = editorFor(messageId);
             turnBody = message;
-            await update(renderBody());
-            turnComment = { messageId, update };
+            await turnComment.update!(renderBody());
+            await rememberThreadComment();
             params.onReplyPosted?.();
             return { messageId };
           },

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -864,13 +864,10 @@ async function buildAdoFastDelivery(
  *
  * A turn owns one comment: the first reply opens it and later replies append
  * to it by editing in place, so a turn never stacks comments on the
- * discussion. On the discussion's main thread the footer is rendered once, at
- * the bottom, on every edit. Inside a review thread there is no footer: the
- * thread is a conversation about one finding, and the Session link belongs
- * on the top-level comment, not on every reply. A review thread also holds
- * one Roomote comment per human message: a turn that reports on delegated
- * work (`continuesThreadComment`) extends the comment the last human turn
- * opened there instead of adding another.
+ * discussion. The footer is rendered once, at the bottom, on every edit. A
+ * review thread holds one Roomote comment per human message: a turn that
+ * reports on delegated work (`continuesThreadComment`) extends the comment
+ * the last human turn opened there instead of adding another.
  */
 export function buildSourceControlFastAdapter(params: {
   conversation: FastAgentSourceControlConversation;
@@ -905,17 +902,16 @@ export function buildSourceControlFastAdapter(params: {
   const discussion = parseSourceControlFastConversation(params.conversation);
   const threadId = params.conversation.replyTarget.threadId;
   const threaded = Boolean(discussion?.reviewCommentId && threadId);
-  const footer =
-    discussion && !threaded
-      ? buildFastSessionReplyFooterText({
-          provider: discussion.provider,
-          sessionId: params.sessionId,
-        })
-      : null;
+  const footer = discussion
+    ? buildFastSessionReplyFooterText({
+        provider: discussion.provider,
+        sessionId: params.sessionId,
+      })
+    : '';
   const quote = threaded ? null : params.quote;
   let turnComment: SourceControlPostedComment | null = null;
   let turnBody = '';
-  const renderBody = () => (footer ? `${turnBody}\n\n${footer}` : turnBody);
+  const renderBody = () => `${turnBody}\n\n${footer}`;
   const editorFor = (messageId: string): SourceControlPostedComment => ({
     messageId,
     ...(params.delivery.updateCommentById && discussion

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -911,6 +911,9 @@ export function buildSourceControlFastAdapter(params: {
   const quote = threaded ? null : params.quote;
   let turnComment: SourceControlPostedComment | null = null;
   let turnBody = '';
+  // True while the turn is editing a comment it adopted from the thread's
+  // record rather than one it posted itself.
+  let adoptedThreadComment = false;
   const renderBody = () => `${turnBody}\n\n${footer}`;
   const editorFor = (messageId: string): SourceControlPostedComment => ({
     messageId,
@@ -963,7 +966,22 @@ export function buildSourceControlFastAdapter(params: {
     }
     turnComment = editorFor(record.messageId);
     turnBody = record.body;
+    adoptedThreadComment = true;
     return true;
+  };
+  const postTurnComment = async (
+    discussion: SourceControlFastDiscussion,
+    message: string,
+  ) => {
+    turnBody = quote ? `${quote}\n\n${message}` : message;
+    turnComment = await params.delivery.postComment({
+      discussion,
+      body: renderBody(),
+    });
+    adoptedThreadComment = false;
+    await rememberThreadComment();
+    params.onReplyPosted?.();
+    return { messageId: turnComment.messageId };
   };
   return {
     launchTask: createFastAgentSourceControlTaskLauncher({
@@ -984,20 +1002,30 @@ export function buildSourceControlFastAdapter(params: {
         await adoptThreadComment();
       }
       if (turnComment?.update) {
+        const previousBody = turnBody;
         turnBody = `${turnBody}\n\n${message}`;
-        await turnComment.update(renderBody());
+        try {
+          await turnComment.update(renderBody());
+        } catch (error) {
+          // The remembered comment can be gone (deleted by its author or a
+          // maintainer) or otherwise uneditable. Treat that as a miss on the
+          // thread record and post this turn's own comment, which replaces
+          // the stale record so later turns stop adopting it.
+          if (!adoptedThreadComment) {
+            throw error;
+          }
+          console.warn(
+            `[Fast Agent] The remembered review thread comment could not be updated; posting a new comment: ${formatErrorForLog(error)}`,
+          );
+          turnBody = previousBody;
+          turnComment = null;
+          return postTurnComment(discussion, message);
+        }
         await rememberThreadComment();
         params.onReplyPosted?.();
         return { messageId: turnComment.messageId };
       }
-      turnBody = quote ? `${quote}\n\n${message}` : message;
-      turnComment = await params.delivery.postComment({
-        discussion,
-        body: renderBody(),
-      });
-      await rememberThreadComment();
-      params.onReplyPosted?.();
-      return { messageId: turnComment.messageId };
+      return postTurnComment(discussion, message);
     },
     ...(params.delivery.updateCommentById && discussion
       ? {
@@ -1006,6 +1034,7 @@ export function buildSourceControlFastAdapter(params: {
           // turn's comment so later replies keep appending in place.
           replaceReply: async ({ messageId }, { message }) => {
             turnComment = editorFor(messageId);
+            adoptedThreadComment = false;
             turnBody = message;
             await turnComment.update!(renderBody());
             await rememberThreadComment();

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -858,7 +858,10 @@ async function buildAdoFastDelivery(
  *
  * A turn owns one comment: the first reply opens it and later replies append
  * to it by editing in place, so a turn never stacks comments on the
- * discussion. The footer is rendered once, at the bottom, on every edit.
+ * discussion. On the discussion's main thread the footer is rendered once, at
+ * the bottom, on every edit. Inside a review thread there is no footer: the
+ * thread is a conversation about one finding, and the Session link belongs
+ * on the top-level comment, not on every reply.
  */
 export function buildSourceControlFastAdapter(params: {
   conversation: FastAgentSourceControlConversation;
@@ -886,16 +889,18 @@ export function buildSourceControlFastAdapter(params: {
   ) => Promise<{ messageId: string }>;
 } {
   const discussion = parseSourceControlFastConversation(params.conversation);
-  const footer = discussion
-    ? buildFastSessionReplyFooterText({
-        provider: discussion.provider,
-        sessionId: params.sessionId,
-      })
-    : '';
-  const quote = discussion?.reviewCommentId ? null : params.quote;
+  const threaded = Boolean(discussion?.reviewCommentId);
+  const footer =
+    discussion && !threaded
+      ? buildFastSessionReplyFooterText({
+          provider: discussion.provider,
+          sessionId: params.sessionId,
+        })
+      : null;
+  const quote = threaded ? null : params.quote;
   let turnComment: SourceControlPostedComment | null = null;
   let turnBody = '';
-  const renderBody = () => `${turnBody}\n\n${footer}`;
+  const renderBody = () => (footer ? `${turnBody}\n\n${footer}` : turnBody);
   return {
     launchTask: createFastAgentSourceControlTaskLauncher({
       userId: params.userId,

--- a/packages/sdk/src/server/lib/source-control-fast-delivery.ts
+++ b/packages/sdk/src/server/lib/source-control-fast-delivery.ts
@@ -859,6 +859,21 @@ async function buildAdoFastDelivery(
 }
 
 /**
+ * True when a provider rejected a comment edit because the comment is gone.
+ * Every provider client (Octokit's RequestError and the GitLab, Bitbucket,
+ * Gitea, and Azure DevOps API errors) carries the HTTP status on the error.
+ * Anything else (a timeout, a 5xx) is indeterminate: the edit may have
+ * landed, so it must not be answered with a second comment.
+ */
+function isCommentGoneError(error: unknown): boolean {
+  const status =
+    error && typeof error === 'object' && 'status' in error
+      ? (error as { status?: unknown }).status
+      : undefined;
+  return status === 404 || status === 410;
+}
+
+/**
  * The reply surface a Session uses in a discussion: replies post as comments
  * with the Session footer, and tasks launch against the discussion's target.
  *
@@ -1008,10 +1023,11 @@ export function buildSourceControlFastAdapter(params: {
           await turnComment.update(renderBody());
         } catch (error) {
           // The remembered comment can be gone (deleted by its author or a
-          // maintainer) or otherwise uneditable. Treat that as a miss on the
-          // thread record and post this turn's own comment, which replaces
-          // the stale record so later turns stop adopting it.
-          if (!adoptedThreadComment) {
+          // maintainer). Treat that as a miss on the thread record and post
+          // this turn's own comment, which replaces the stale record so
+          // later turns stop adopting it. Any other failure rethrows so the
+          // normal retry path keeps one comment per human turn.
+          if (!adoptedThreadComment || !isCommentGoneError(error)) {
             throw error;
           }
           console.warn(

--- a/packages/sdk/src/server/lib/source-control-thread-comment-state.ts
+++ b/packages/sdk/src/server/lib/source-control-thread-comment-state.ts
@@ -1,0 +1,50 @@
+import { getRedis } from '@roomote/redis';
+
+const THREAD_COMMENT_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+/**
+ * The comment a Session last opened inside a review thread, so later turns
+ * that report on the same thread (a delegated task finishing, a pull request
+ * opening) extend that comment instead of stacking new ones. The body rides
+ * along because providers replace a comment's whole text on edit.
+ */
+type SourceControlThreadCommentRecord = {
+  messageId: string;
+  body: string;
+};
+
+function getThreadCommentKey(sessionId: string, threadId: string): string {
+  return `source_control:thread_comment:${sessionId}:${threadId}`;
+}
+
+export async function getSourceControlThreadCommentRecord(
+  sessionId: string,
+  threadId: string,
+): Promise<SourceControlThreadCommentRecord | null> {
+  const raw = await getRedis().get(getThreadCommentKey(sessionId, threadId));
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<SourceControlThreadCommentRecord>;
+    return typeof parsed.messageId === 'string' &&
+      typeof parsed.body === 'string'
+      ? { messageId: parsed.messageId, body: parsed.body }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setSourceControlThreadCommentRecord(
+  sessionId: string,
+  threadId: string,
+  record: SourceControlThreadCommentRecord,
+): Promise<void> {
+  await getRedis().set(
+    getThreadCommentKey(sessionId, threadId),
+    JSON.stringify(record),
+    'EX',
+    THREAD_COMMENT_TTL_SECONDS,
+  );
+}


### PR DESCRIPTION
## Summary

Follow-up to #2229. A review thread was collecting a new Roomote comment for every turn: the human's mention, then one more each time a delegated task reported back, each with its own footer.

- **One comment per human message in a review thread.** Turns that no human wrote (a delegated task finishing, a pull request opening) now append to the comment the last human turn opened in that thread instead of posting another. The thread's current comment id and body are remembered in Redis per Session and thread for 30 days; if nothing is remembered, the turn falls back to a new comment.
- **No blockquote inside review threads.** The reply already sits under the comment it answers.
- The footer stays, rendered once at the bottom of the comment as `<sub>` text (#2238), on top-level comments and thread replies alike.

## Test plan

- [x] `source-control-fast-delivery` tests: platform-event turn extends the remembered thread comment; a new human message opens a new comment; missing record falls back to a new comment; threaded reply has no quote and one footer
- [x] `fast-agent-parent-event` tests
- [x] `pnpm lint`, `pnpm check-types:fast`, `pnpm knip`