### PR TITLE
[Fix] Enable Azure sandbox idle suspension by default

### DIFF
--- a/apps/docs/providers/compute/azure.mdx
+++ b/apps/docs/providers/compute/azure.mdx
@@ -85,6 +85,26 @@ memory-preserving suspend/resume, and sandboxes bill storage-only while
 suspended. Preview port URLs do not survive a snapshot restore; Roomote
 re-adds ports after resume.
 
+## Idle suspension and cost control
+
+Roomote enables Azure's memory-preserving auto-suspend policy for new
+sandboxes and refreshes it when restoring snapshots or resuming standby.
+The idle interval follows the task's sandbox timeout, normally five hours.
+This gives Azure a fallback when Roomote's cleanup service is offline or a
+development database has been reset. CPU and memory charges stop while the
+sandbox is suspended.
+
+Azure measures idle time from incoming traffic, API code execution, shell
+sessions, and file operations. This is an idle fallback, not a hard runtime
+or spending cap: continued activity can keep a sandbox running. Roomote's
+normal task sleep and timeout handling still applies.
+
+The separate auto-delete policy retains stopped task sandboxes for at least
+30 days. Its timer starts after suspension; it cannot stop a running sandbox.
+Upgrading refreshes lifecycle settings as sandboxes are reused. Existing
+orphaned sandboxes that Roomote no longer tracks need to be inspected and
+suspended separately in Azure.
+
 ## Egress TLS inspection
 
 The ACA egress proxy can TLS-inspect (MITM) outbound traffic. Roomote defaults

--- a/packages/compute-providers/src/__tests__/azure.contract.test.ts
+++ b/packages/compute-providers/src/__tests__/azure.contract.test.ts
@@ -111,6 +111,7 @@ function createFetchMock(options: {
 
 function createClient(
   fetchImpl: typeof fetch,
+  overrides: Partial<AzureConfig> = {},
 ): ReturnType<typeof createComputeProviderClient> {
   const config: AzureConfig = {
     subscriptionId: 'sub-1',
@@ -121,6 +122,7 @@ function createClient(
     timeoutMs: 3_600_000,
     tokenProvider: { getToken: async () => 'test-token' },
     fetchImpl,
+    ...overrides,
   };
   return createComputeProviderClient({ provider: 'azure', config });
 }
@@ -152,7 +154,7 @@ describe('azure adapter contract', () => {
       sourcesRef: { diskImage: { id: 'disk-image-1' } },
       resources: { cpu: '1000m', memory: '2048Mi' },
       lifecycle: {
-        autoSuspendPolicy: { enabled: false, interval: 0, mode: 'Memory' },
+        autoSuspendPolicy: { enabled: true, interval: 3600, mode: 'Memory' },
         // Backstop floors to 30d (suspension-anchored TTL); the 3600s
         // task timeout stays Roomote-side.
         autoDeletePolicy: { enabled: true, deleteIntervalInSeconds: 2592000 },
@@ -169,6 +171,72 @@ describe('azure adapter contract', () => {
       // standby sandboxes on any inbound traffic.
       activationMode: 'Manual',
     });
+  });
+
+  it.each([
+    { config: { timeoutMs: undefined }, seconds: 18_000 },
+    { config: { timeoutMs: 3_600_001 }, seconds: 3601 },
+    { config: { autoSuspendSeconds: 900 }, seconds: 900 },
+    { config: { autoSuspendSeconds: 0 }, seconds: 0 },
+  ])('sets the idle fallback for $config', async ({ config, seconds }) => {
+    const { fetchImpl, requests } = createFetchMock({});
+    await createClient(fetchImpl, config).createInstance({});
+    expect(requests.find((r) => r.method === 'PUT')?.body).toMatchObject({
+      lifecycle: {
+        autoSuspendPolicy: {
+          enabled: seconds > 0,
+          interval: seconds,
+          mode: 'Memory',
+        },
+      },
+    });
+  });
+
+  it.each([
+    { timeoutMs: 0 },
+    { timeoutMs: Number.NaN },
+    { timeoutMs: Number.POSITIVE_INFINITY },
+    { autoSuspendSeconds: -1 },
+    { autoSuspendSeconds: 0.5 },
+  ])(
+    'rejects invalid lifecycle settings before creation: %j',
+    async (config) => {
+      const { fetchImpl, requests } = createFetchMock({});
+      await expect(
+        createClient(fetchImpl, config).createInstance({}),
+      ).rejects.toThrow('Azure requires a positive timeout');
+      expect(requests).toHaveLength(0);
+    },
+  );
+
+  it('refreshes the idle fallback when reusing an idempotent launch', async () => {
+    const { fetchImpl, requests } = createFetchMock({
+      onRequest: (request) =>
+        request.method === 'GET' && request.url.includes('/sandboxes?')
+          ? jsonResponse([
+              {
+                id: SANDBOX_ID,
+                state: 'Running',
+                labels: { 'roomote-idempotency-key': 'launch-1' },
+                lifecycle: { autoSuspendPolicy: { enabled: false } },
+              },
+            ])
+          : undefined,
+    });
+    await createClient(fetchImpl).createInstance({
+      idempotencyKey: 'launch-1',
+      ports: [3000],
+    });
+    expect(requests.some((r) => r.method === 'PUT')).toBe(false);
+    const lifecycleIndex = requests.findIndex((r) =>
+      r.url.includes('/lifecycle'),
+    );
+    expect(requests[lifecycleIndex]?.body).toMatchObject({
+      autoSuspendPolicy: { enabled: true, interval: 3600, mode: 'Memory' },
+    });
+    expect(
+      requests.findIndex((r) => r.url.includes('/ports/add')),
+    ).toBeGreaterThan(lifecycleIndex);
   });
 
   it('does not round small tier cpus up to whole cores', async () => {
@@ -617,7 +685,65 @@ describe('azure adapter contract', () => {
     expect(put?.body).toMatchObject({
       sourcesRef: { snapshot: { id: 'snap-1' } },
     });
+    expect(put?.body).not.toHaveProperty('lifecycle');
+    const lifecycleIndex = requests.findIndex((r) =>
+      r.url.includes('/lifecycle'),
+    );
+    expect(requests[lifecycleIndex]?.body).toMatchObject({
+      autoSuspendPolicy: { enabled: true, interval: 3600, mode: 'Memory' },
+    });
+    expect(
+      requests.findIndex((r) => r.url.includes('/ports/add')),
+    ).toBeGreaterThan(lifecycleIndex);
     expect(requests.some((r) => r.url.includes('/ports/add'))).toBe(true);
+  });
+
+  it('refreshes lifecycle after a legacy unlabeled snapshot restore', async () => {
+    const { fetchImpl, requests } = createFetchMock({
+      onRequest: (request) =>
+        request.method === 'PUT' &&
+        request.url.includes('/sandboxes?') &&
+        (request.body as { labels?: unknown })?.labels
+          ? jsonResponse(
+              { title: 'InvalidRequest', detail: 'Labels not supported' },
+              400,
+            )
+          : undefined,
+    });
+    await createClient(fetchImpl).resumeFromSnapshot({
+      sourceSnapshotId: 'snap-1',
+      tags: { app_environment: 'development' },
+    });
+    expect(requests.filter((r) => r.method === 'PUT')).toHaveLength(2);
+    expect(
+      requests.find((r) => r.url.includes('/lifecycle'))?.body,
+    ).toMatchObject({
+      autoSuspendPolicy: { enabled: true, interval: 3600 },
+    });
+  });
+
+  it('cleans up a restored clone if lifecycle installation fails without retrying the restore', async () => {
+    const { fetchImpl, requests } = createFetchMock({
+      onRequest: (request) =>
+        request.url.includes('/lifecycle')
+          ? jsonResponse(
+              { title: 'InvalidPolicy', detail: 'Policy rejected' },
+              400,
+            )
+          : undefined,
+    });
+    await expect(
+      createClient(fetchImpl).resumeFromSnapshot({
+        sourceSnapshotId: 'snap-1',
+        tags: { app_environment: 'development' },
+        ports: [3000],
+      }),
+    ).rejects.toThrow('Policy rejected');
+    expect(requests.filter((r) => r.method === 'PUT')).toHaveLength(1);
+    expect(
+      requests.some((r) => r.method === 'DELETE' && r.url.includes(SANDBOX_ID)),
+    ).toBe(true);
+    expect(requests.some((r) => r.url.includes('/ports/add'))).toBe(false);
   });
 
   it('enters standby via stop and resumes via resume', async () => {
@@ -640,9 +766,110 @@ describe('azure adapter contract', () => {
     expect(resumed?.status).toBe('running');
     expect(requests.some((r) => r.url.includes('/resume'))).toBe(true);
 
-    // No lifecycle refresh on resume: auto-delete is suspension-anchored,
-    // so each standby cycle re-anchors the TTL window by itself.
-    expect(requests.some((r) => r.url.includes('/lifecycle'))).toBe(false);
+    const lifecycleIndex = requests.findIndex((r) =>
+      r.url.includes('/lifecycle'),
+    );
+    expect(requests[lifecycleIndex]?.body).toMatchObject({
+      autoSuspendPolicy: { enabled: true, interval: 3600, mode: 'Memory' },
+      autoDeletePolicy: { enabled: true, deleteIntervalInSeconds: 2592000 },
+    });
+    expect(
+      requests.findIndex((r) => r.url.includes('/resume')),
+    ).toBeGreaterThan(lifecycleIndex);
+  });
+
+  it('does not resume a retained sandbox if lifecycle installation fails', async () => {
+    const { fetchImpl, requests } = createFetchMock({
+      states: ['Stopped'],
+      onRequest: (request) =>
+        request.url.includes('/lifecycle')
+          ? jsonResponse(
+              { title: 'InvalidPolicy', detail: 'Policy rejected' },
+              400,
+            )
+          : undefined,
+    });
+    await expect(
+      createClient(fetchImpl).resumeFromStandby?.({ resumeHandle: SANDBOX_ID }),
+    ).rejects.toThrow('Policy rejected');
+    expect(requests.some((r) => r.url.includes('/resume'))).toBe(false);
+    expect(requests.some((r) => r.method === 'DELETE')).toBe(false);
+  });
+
+  it('refreshes an already-running standby while preserving its deletion policy when no timeout is configured', async () => {
+    const autoDeletePolicy = {
+      enabled: true,
+      deleteIntervalInSeconds: 3_456_000,
+    };
+    const { fetchImpl, requests } = createFetchMock({
+      onRequest: (request) =>
+        request.method === 'GET' && request.url.includes(`${SANDBOX_ID}?`)
+          ? jsonResponse({
+              id: SANDBOX_ID,
+              state: 'Running',
+              lifecycle: {
+                autoDeletePolicy,
+                autoSuspendPolicy: { enabled: false },
+              },
+            })
+          : undefined,
+    });
+    await createClient(fetchImpl, { timeoutMs: undefined }).resumeFromStandby?.(
+      { resumeHandle: SANDBOX_ID },
+    );
+    expect(requests.find((r) => r.url.includes('/lifecycle'))?.body).toEqual({
+      autoDeletePolicy,
+      autoSuspendPolicy: { enabled: true, interval: 18_000, mode: 'Memory' },
+    });
+    expect(requests.some((r) => r.url.includes('/resume'))).toBe(false);
+  });
+
+  it('accepts a concurrent stop only after confirming the sandbox is stopped', async () => {
+    const { fetchImpl } = createFetchMock({
+      states: ['Stopped'],
+      onRequest: (request) =>
+        request.url.includes('/stop?')
+          ? jsonResponse(
+              { title: 'SandboxNotRunning', detail: 'Not running' },
+              409,
+            )
+          : undefined,
+    });
+    await expect(
+      createClient(fetchImpl).enterStandby?.({ instanceId: SANDBOX_ID }),
+    ).resolves.toMatchObject({ resumeHandle: SANDBOX_ID });
+  });
+
+  it.each(['Running', 'Failed', 'Deleting'])(
+    'does not report a successful suspension when stop conflicts and GET says %s',
+    async (state) => {
+      const { fetchImpl } = createFetchMock({
+        states: [state],
+        onRequest: (request) =>
+          request.url.includes('/stop?')
+            ? jsonResponse(
+                { title: 'SandboxNotRunning', detail: 'Not running' },
+                409,
+              )
+            : undefined,
+      });
+      await expect(
+        createClient(fetchImpl).enterStandby?.({ instanceId: SANDBOX_ID }),
+      ).rejects.toMatchObject({ status: 409, code: 'SandboxNotRunning' });
+    },
+  );
+
+  it('does not swallow unrelated stop conflicts', async () => {
+    const { fetchImpl } = createFetchMock({
+      states: ['Stopped'],
+      onRequest: (request) =>
+        request.url.includes('/stop?')
+          ? jsonResponse({ title: 'AnotherConflict', detail: 'Conflict' }, 409)
+          : undefined,
+    });
+    await expect(
+      createClient(fetchImpl).enterStandby?.({ instanceId: SANDBOX_ID }),
+    ).rejects.toMatchObject({ code: 'AnotherConflict' });
   });
 
   it('destroys an instance and reports usage', async () => {

--- a/packages/compute-providers/src/adapters/azure.ts
+++ b/packages/compute-providers/src/adapters/azure.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 
 import {
   AZURE_CAPABILITIES as AZURE_CAPABILITIES_VALUE,
+  SANDBOX_TIMEOUT_MS,
   type ComputeProvider,
 } from '@roomote/types';
 
@@ -239,6 +240,7 @@ export class AzureClient implements ComputeProviderClient {
         input.signal,
       );
       if (existing) {
+        await this.refreshLifecyclePolicy(existing, input.signal);
         const domains = await this.ensurePorts(
           existing.id,
           input.ports ?? [],
@@ -650,19 +652,27 @@ export class AzureClient implements ComputeProviderClient {
       }
     }
 
-    // Ports do NOT persist through snapshot/restore (measured) — re-add.
-    const domains = await this.ensurePorts(
-      created.id,
-      input.ports ?? [],
-      input.signal,
-    );
+    try {
+      // Restore inherits the snapshot's lifecycle; the create endpoint does
+      // not accept overrides. Refresh before handing the clone to a worker.
+      await this.refreshLifecyclePolicy(created, input.signal);
+      // Ports do NOT persist through snapshot/restore (measured) — re-add.
+      const domains = await this.ensurePorts(
+        created.id,
+        input.ports ?? [],
+        input.signal,
+      );
 
-    return {
-      instanceId: created.id,
-      status: 'running',
-      sourceSnapshotId: input.sourceSnapshotId,
-      ...(Object.keys(domains).length > 0 ? { domains } : {}),
-    };
+      return {
+        instanceId: created.id,
+        status: 'running',
+        sourceSnapshotId: input.sourceSnapshotId,
+        ...(Object.keys(domains).length > 0 ? { domains } : {}),
+      };
+    } catch (error) {
+      await this.cleanupSandboxAfterFailure(created.id);
+      throw error;
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -676,10 +686,30 @@ export class AzureClient implements ComputeProviderClient {
 
     const usageObservation = await this.readUsageObservation(input.instanceId);
 
-    await this.request('POST', `${this.sandboxPath(input.instanceId)}/stop`, {
-      signal: input.signal,
-      abortMessage: `Suspending Azure sandbox ${input.instanceId} was aborted`,
-    });
+    try {
+      await this.request('POST', `${this.sandboxPath(input.instanceId)}/stop`, {
+        signal: input.signal,
+        abortMessage: `Suspending Azure sandbox ${input.instanceId} was aborted`,
+      });
+    } catch (error) {
+      if (
+        !(error instanceof AzureDataPlaneError) ||
+        error.status !== 409 ||
+        error.code !== 'SandboxNotRunning'
+      ) {
+        throw error;
+      }
+      // A concurrent stop may already have succeeded. Confirm it rather
+      // than treating every conflict as success: preview APIs can also
+      // reject stop while GET still reports Running.
+      const current = await this.getSandbox(input.instanceId, input.signal);
+      if (
+        this.mapState(current.state) !== 'stopped' &&
+        current.state !== 'Stopping'
+      ) {
+        throw error;
+      }
+    }
     await this.waitForState(
       input.instanceId,
       ['Stopped', 'Suspended', 'Idle'],
@@ -700,6 +730,9 @@ export class AzureClient implements ComputeProviderClient {
     // No-op when already Running (double-wake race): resuming a Running
     // sandbox is rejected by the service.
     const current = await this.getSandbox(input.resumeHandle, input.signal);
+    // Retained sandboxes may predate the idle backstop. Install it before
+    // resuming so a failed policy update cannot wake an unprotected sandbox.
+    await this.refreshLifecyclePolicy(current, input.signal);
     if (current.state !== 'Running') {
       await this.request(
         'POST',
@@ -711,12 +744,6 @@ export class AzureClient implements ComputeProviderClient {
       );
       await this.waitForState(input.resumeHandle, ['Running'], input.signal);
     }
-
-    // NOTE: no lifecycle refresh here. Measured semantics (2026-07-30):
-    // auto-delete is a suspension-anchored TTL (stoppedAt + interval,
-    // laggy sweeper) and never fires on Running sandboxes, and each
-    // suspension re-anchors stoppedAt — so every Roomote standby cycle gets
-    // a fresh TTL window with no action needed from the adapter.
 
     // Ports persist through stop/resume (measured); ensure anyway so callers
     // always get domains back.
@@ -777,8 +804,6 @@ export class AzureClient implements ComputeProviderClient {
         }
       : { id: this.config.diskImage };
 
-    const autoSuspendSeconds = this.config.autoSuspendSeconds ?? 0;
-
     // ACA tiers cap BOTH memory (cores × 2Gi) and disk (cores × 20Gi) at
     // the CPU anchor (verified live: 400 InvalidResourceTier past either).
     // Scale CPU up to fit the requested memory rather than failing —
@@ -808,28 +833,7 @@ export class AzureClient implements ComputeProviderClient {
         memory: `${memoryMiB}Mi`,
         ...(diskSize ? { disk: diskSize } : {}),
       },
-      lifecycle: {
-        autoSuspendPolicy: {
-          enabled: autoSuspendSeconds > 0,
-          interval: autoSuspendSeconds,
-          mode: 'Memory',
-        },
-        // Measured (2026-07-30): auto-delete fires only on suspended
-        // sandboxes, at stoppedAt + interval. Make it a long backstop
-        // (>= standby retention) rather than the task timeout — the
-        // Roomote-side timeout is enforced by the worker/sleep-check.
-        ...(this.config.timeoutMs
-          ? {
-              autoDeletePolicy: {
-                enabled: true,
-                deleteIntervalInSeconds: Math.ceil(
-                  Math.max(this.config.timeoutMs, AUTO_DELETE_BACKSTOP_MS) /
-                    1_000,
-                ),
-              },
-            }
-          : {}),
-      },
+      lifecycle: this.buildLifecyclePolicy(),
       // Default Partial inspection: no rules configured means no TLS
       // resigning at all (clean trust stores, SSH allowed). See AzureConfig.
       egressPolicy: {
@@ -838,6 +842,53 @@ export class AzureClient implements ComputeProviderClient {
       },
       ...(options.labels ? { labels: options.labels } : {}),
     };
+  }
+
+  private buildLifecyclePolicy(): NonNullable<AzureSandbox['lifecycle']> {
+    // Auto-delete never limits running time. Use a provider-side idle
+    // backstop too, including when the controller/database is unavailable.
+    // Detached worker activity is not necessarily Azure API activity, so
+    // allow the full task timeout before automatically preserving its state.
+    const timeoutMs = this.config.timeoutMs ?? SANDBOX_TIMEOUT_MS;
+    const autoSuspendSeconds =
+      this.config.autoSuspendSeconds ?? Math.ceil(timeoutMs / 1_000);
+    if (
+      !Number.isFinite(timeoutMs) ||
+      timeoutMs <= 0 ||
+      !Number.isSafeInteger(autoSuspendSeconds) ||
+      autoSuspendSeconds < 0
+    ) {
+      throw new Error(
+        'Azure requires a positive timeout and a non-negative integer auto-suspend interval',
+      );
+    }
+    return {
+      autoSuspendPolicy: {
+        enabled: autoSuspendSeconds > 0,
+        interval: autoSuspendSeconds,
+        mode: 'Memory',
+      },
+      ...(this.config.timeoutMs
+        ? {
+            autoDeletePolicy: {
+              enabled: true,
+              deleteIntervalInSeconds: Math.ceil(
+                Math.max(timeoutMs, AUTO_DELETE_BACKSTOP_MS) / 1_000,
+              ),
+            },
+          }
+        : {}),
+    };
+  }
+
+  private async refreshLifecyclePolicy(
+    sandbox: AzureSandbox,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await this.request('POST', `${this.sandboxPath(sandbox.id)}/lifecycle`, {
+      body: { ...sandbox.lifecycle, ...this.buildLifecyclePolicy() },
+      signal,
+    });
   }
 
   /**

--- a/packages/compute-providers/src/types.ts
+++ b/packages/compute-providers/src/types.ts
@@ -376,14 +376,15 @@ export interface AzureConfig {
     clientSecret: string;
   };
   /**
-   * Maximum sandbox lifetime in milliseconds, enforced provider-side via the
-   * sandbox auto-delete lifecycle policy.
+   * Roomote task timeout in milliseconds. Also sets the default Azure idle
+   * auto-suspend interval (five hours when omitted), not a provider-enforced
+   * wall-clock lifetime. Auto-delete only starts after suspension.
    */
   timeoutMs?: number;
   /**
-   * Idle auto-suspend interval in seconds. Defaults to 0 (disabled): Roomote
-   * drives suspend/resume explicitly via standby and idle workers must not
-   * suspend underneath the controller.
+   * Idle auto-suspend interval in seconds. Defaults to timeoutMs rounded up
+   * to seconds, or five hours. This fallback preserves memory and disk when
+   * Roomote cleanup is unavailable. Set 0 only to explicitly disable it.
    */
   autoSuspendSeconds?: number;
   /**


### PR DESCRIPTION
Azure sandboxes previously defaulted to disabled automatic suspension, so idle compute could remain running when Roomote cleanup was unavailable. Enable Azure's idle suspension using the configured task timeout (five hours by default), and refresh the policy on reused, resumed, and snapshot-restored sandboxes. Explicit zero remains an opt-out; stopped-sandbox deletion retention is preserved.

Refresh policies before resuming retained sandboxes and clean up newly restored clones if initialization fails. Treat a concurrent-stop conflict as success only after confirming a stopped state. Document the idle-policy limits and the need to inspect older untracked sandboxes manually.

Validation: all 40 Azure adapter contract tests pass; package typecheck, focused lint, and documentation validation pass. Full repository pre-push checks also pass (oxlint, residual ESLint, typechecks, and knip).
