### PR TITLE
[Fix] Refresh inference cost when task info opens

### DIFF
--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.client.test.tsx
@@ -1,11 +1,48 @@
-import type { ReactNode } from 'react';
-import { render, screen } from '@testing-library/react';
+import type { ReactElement, ReactNode } from 'react';
+import {
+  act,
+  render as renderComponent,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { TaskPayloadKind } from '@roomote/types';
 
-const { useSandboxMessagesMock, useTaskSummaryMock } = vi.hoisted(() => ({
-  useSandboxMessagesMock: vi.fn(),
-  useTaskSummaryMock: vi.fn(),
+const { useSandboxMessagesMock, useTaskSummaryMock, fetchSessionMock } =
+  vi.hoisted(() => ({
+    useSandboxMessagesMock: vi.fn(),
+    useTaskSummaryMock: vi.fn(),
+    fetchSessionMock: vi.fn(),
+  }));
+
+const sessionQueryKey = ['sandboxSession', 'byTaskId', { taskId: 'task-1' }];
+
+vi.mock('@/trpc/client', () => ({
+  useTRPC: () => ({
+    sandboxSession: {
+      byTaskId: {
+        queryOptions: (_input: unknown, options: object) => ({
+          queryKey: sessionQueryKey,
+          queryFn: fetchSessionMock,
+          ...options,
+        }),
+      },
+    },
+  }),
 }));
+
+function render(
+  ui: ReactElement,
+  client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 30_000 } },
+  }),
+) {
+  return renderComponent(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  });
+}
 
 vi.mock('../hooks', () => ({
   useSandboxMessages: useSandboxMessagesMock,
@@ -80,6 +117,7 @@ const baseTaskRun = {
 describe('TaskInfoPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchSessionMock.mockResolvedValue(null);
     useSandboxMessagesMock.mockReturnValue({
       messages: [],
       protocol: 'roomote_runtime',
@@ -301,6 +339,63 @@ describe('TaskInfoPanel', () => {
 
     expect(screen.getByText('Inference Cost')).toBeInTheDocument();
     expect(screen.getByText('0.02')).toBeInTheDocument();
+  });
+
+  it('refreshes a fresh cached zero on opening and catches up with later usage writes', async () => {
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 30_000 } },
+    });
+    const sessionWithCost = (costMicroUsd: number) => ({
+      task: { ...baseTask, inferenceUsage: { eventCount: 2, costMicroUsd } },
+    });
+    client.setQueryData(sessionQueryKey, sessionWithCost(0));
+    fetchSessionMock.mockResolvedValue(sessionWithCost(1_250_000));
+    const panel = (active: boolean) => (
+      <TaskInfoPanel
+        active={active}
+        task={baseTask as never}
+        taskRun={baseTaskRun as never}
+        harness="opencode-server"
+        onClose={vi.fn()}
+      />
+    );
+    const { rerender, unmount } = render(panel(false), client);
+    expect(fetchSessionMock).not.toHaveBeenCalled();
+
+    rerender(panel(true));
+    await waitFor(() => expect(screen.getByText('1.25')).toBeInTheDocument());
+    expect(client.getQueryData(sessionQueryKey)).toEqual(
+      sessionWithCost(1_250_000),
+    );
+
+    vi.useFakeTimers();
+    try {
+      fetchSessionMock.mockResolvedValue(sessionWithCost(1_500_000));
+      // Reopening installs the polling timer under the fake clock.
+      rerender(panel(false));
+      rerender(panel(true));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_100);
+      });
+      expect(screen.getByText('1.50')).toBeInTheDocument();
+
+      fetchSessionMock.mockResolvedValue(sessionWithCost(1_750_000));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_100);
+      });
+      expect(screen.getByText('1.75')).toBeInTheDocument();
+
+      rerender(panel(false));
+      fetchSessionMock.mockClear();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+      expect(fetchSessionMock).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+      client.clear();
+      vi.useRealTimers();
+    }
   });
 
   it('shows zero inference cost before usage is recorded', () => {

--- a/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/sidebar-panels/TaskInfoPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 import { Streamdown } from 'streamdown';
 
@@ -23,6 +24,7 @@ import { getTaskRunDisplayError } from '@/lib/task-run-errors';
 import { formatInferenceCost } from '@/lib/formatters';
 import { getUserDisplayName } from '@/lib/user-display-name';
 import { cn } from '@/lib/utils';
+import { useTRPC } from '@/trpc/client';
 
 import {
   BrandIcon,
@@ -226,6 +228,21 @@ export function TaskInfoPanel({
   harness,
   onClose,
 }: TaskInfoPanelProps) {
+  const trpc = useTRPC();
+  // Live usage events only carry context tokens. Refresh persisted cost when
+  // Info opens, even if the workspace's cached session is still fresh, and
+  // keep catching up with asynchronous usage writes while the panel is open.
+  const { data: session } = useQuery(
+    trpc.sandboxSession.byTaskId.queryOptions(
+      { taskId: task.id },
+      {
+        enabled: active,
+        staleTime: 0,
+        refetchOnMount: 'always',
+        refetchInterval: active ? 10_000 : false,
+      },
+    ),
+  );
   const { messages } = useSandboxMessages();
   const {
     enabled: summaryEnabled,
@@ -271,7 +288,7 @@ export function TaskInfoPanel({
         .join(' • ')
     : null;
   const inferenceCostLabel = formatInferenceCost(
-    task.inferenceUsage?.costMicroUsd,
+    (session?.task ?? task).inferenceUsage?.costMicroUsd,
   );
   const showRuntimeRow = false;
   const participants = useMemo(


### PR DESCRIPTION
## What changed

Opening Task Info could show a cached inference cost of zero until the page was refreshed. The workspace stops polling once the task is interactive, and live usage events update context tokens without refreshing persisted cost.

Refresh the shared session query whenever Task Info opens, even when its cache is still fresh, and every 10 seconds while the panel remains open. Display the refreshed cost and stop panel polling when it closes. Cost can briefly lag asynchronous usage persistence.

## How it was tested

- 33 focused client tests passed across TaskInfoPanel and useTaskSession, including a regression covering cached zero, later usage writes, and stopping polling when closed.
- Web TypeScript check passed.
- Full pre-push suite passed: monorepo Oxlint, residual ESLint, fast type checks, and Knip.
- Changed-file formatting and git diff checks passed.
- No browser or full-repository test suite was run. The client tests passed without a local .env.test file.

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is small and scoped to one change
- [x] Lint and type checks pass locally as described above
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [ ] If this change should appear in the changelog, I ran pnpm changeset
