### PR TITLE
[Feat] Post suggested tasks when a delegated automation task settles

### DIFF
--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-prompt.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-prompt.test.ts
@@ -125,6 +125,25 @@ describe('buildFastAgentSystemPrompt', () => {
     expect(eventPrompt).toContain('unless the prompt names a different one');
   });
 
+  it('offers suggestions on an automation task-settled report only', () => {
+    const settlePrompt = buildFastAgentSystemPrompt({
+      availableEnvironments: [],
+      turnSource: 'platform_event',
+      platformEventKind: 'delegated_task',
+      automationReport: true,
+    });
+    const plainSettlePrompt = buildFastAgentSystemPrompt({
+      availableEnvironments: [],
+      turnSource: 'platform_event',
+      platformEventKind: 'delegated_task',
+    });
+
+    expect(settlePrompt).toContain("this closeout is that run's report");
+    expect(settlePrompt).toContain('`suggestions` array');
+    expect(settlePrompt).not.toContain('Execute the automation prompt now');
+    expect(plainSettlePrompt).not.toContain('`suggestions` array');
+  });
+
   it('omits the release identifier when no version is resolved', () => {
     const prompt = buildFastAgentSystemPrompt({ availableEnvironments: [] });
 

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-service.test.ts
@@ -7397,6 +7397,40 @@ describe('answerFastAgentQuestion native OpenCode tools', () => {
     );
   });
 
+  it('passes structured suggestions through an automation task-settled closeout', async () => {
+    const adapter = callbacks();
+    const suggestions = [
+      { title: 'Quarantine the flaky spec', brief: 'Skip it until fixed.' },
+    ];
+    mocks.generateText.mockImplementation(
+      async (_params, _session, options) => {
+        await options.onSessionReady('opencode-session-1');
+        await expect(
+          invokeTool(nativeToolNames.sendChatReply, {
+            purpose: 'closeout',
+            message: 'Two flaky specs found.',
+            suggestions,
+          }),
+        ).resolves.toMatchObject({ success: true, closed: true });
+        return '';
+      },
+    );
+
+    await answerFastAgentQuestion({
+      ...baseParams,
+      adapter,
+      turnSource: 'platform_event',
+      platformEventKind: 'delegated_task',
+      automationReport: true,
+    });
+
+    expect(adapter.postReply).toHaveBeenCalledWith({
+      purpose: 'closeout',
+      message: 'Two flaky specs found.',
+      suggestions,
+    });
+  });
+
   it('rejects structured suggestions outside automation reports', async () => {
     mocks.generateText.mockImplementation(
       async (_params, _session, options) => {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
@@ -396,18 +396,18 @@ ${
 `
     : ''
 }${
-  automationReport
-    ? `- The task settling in this event carried out a custom automation run, and this closeout is that run's report. Judge it by the automation's prompt earlier in this conversation, including whether it asked for launchable suggested tasks.
+        automationReport
+          ? `- The task settling in this event carried out a custom automation run, and this closeout is that run's report. Judge it by the automation's prompt earlier in this conversation, including whether it asked for launchable suggested tasks.
 `
-    : ''
-}${
-  platformEventKind === 'automation' || automationReport
-    ? `- When the automation asks for launchable suggested tasks and this is a Slack, Discord, Teams, or Telegram report, put each concrete follow-up in the closeout's \`suggestions\` array. Keep the report summary in \`message\`; do not render suggestion cards or launch instructions as inline prose because the delivery layer adds them.
+          : ''
+      }${
+        platformEventKind === 'automation' || automationReport
+          ? `- When the automation asks for launchable suggested tasks and this is a Slack, Discord, Teams, or Telegram report, put each concrete follow-up in the closeout's \`suggestions\` array. Keep the report summary in \`message\`; do not render suggestion cards or launch instructions as inline prose because the delivery layer adds them.
 - Each suggestion may independently set \`environmentId\` to an exact environment ID listed under All Environments, \`${ALL_REPOSITORIES}\` for all repositories, or \`${FAST_EXECUTION}\` for Fast mode. This target is independent of the automation's own execution environment. Omit \`environmentId\` only when normal workspace routing should choose at launch time; never invent an ID.
 - If launchable suggestions are unavailable on the current surface, keep follow-ups as ordinary report text and do not promise reaction-triggered launching.
 `
-    : ''
-}
+          : ''
+      }
 ${
   platformEventKind === 'setup'
     ? `- For a setup-session-started event, briefly introduce myself and explain the next unmet user need in ordinary language.

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-prompt.ts
@@ -119,6 +119,7 @@ export function buildFastAgentSystemPrompt({
   platformEventHandling = 'default',
   platformEventVisibility = 'optional',
   platformEventKind = 'delegated_task',
+  automationReport = false,
   retryTaskStartAvailable = false,
   allowSilentAmbientReply = false,
   isCurrentUserAdmin = false,
@@ -139,6 +140,9 @@ export function buildFastAgentSystemPrompt({
   platformEventHandling?: FastAgentPlatformEventHandling;
   platformEventVisibility?: FastAgentPlatformEventVisibility;
   platformEventKind?: FastAgentPlatformEventKind;
+  /** The delegated task settling in this event ran for a custom automation, so
+   * this closeout is that run's report. */
+  automationReport?: boolean;
   retryTaskStartAvailable?: boolean;
   allowSilentAmbientReply?: boolean;
   isCurrentUserAdmin?: boolean;
@@ -389,7 +393,16 @@ ${
 ${
   platformEventKind === 'automation'
     ? `- Execute the automation prompt now as you would a teammate's request: use integrations directly when they suffice, and delegate a task when repository or workspace work is needed. When the event carries \`preferredEnvironmentId\`, launch delegated tasks in that environment (\`${ALL_REPOSITORIES}\` means every active repository) unless the prompt names a different one; without it, route normally. The configured model is a delegated-task default, not the Fast inference model.
-- When the automation asks for launchable suggested tasks and this is a Slack, Discord, Teams, or Telegram report, put each concrete follow-up in the closeout's \`suggestions\` array. Keep the report summary in \`message\`; do not render suggestion cards or launch instructions as inline prose because the delivery layer adds them.
+`
+    : ''
+}${
+  automationReport
+    ? `- The task settling in this event carried out a custom automation run, and this closeout is that run's report. Judge it by the automation's prompt earlier in this conversation, including whether it asked for launchable suggested tasks.
+`
+    : ''
+}${
+  platformEventKind === 'automation' || automationReport
+    ? `- When the automation asks for launchable suggested tasks and this is a Slack, Discord, Teams, or Telegram report, put each concrete follow-up in the closeout's \`suggestions\` array. Keep the report summary in \`message\`; do not render suggestion cards or launch instructions as inline prose because the delivery layer adds them.
 - Each suggestion may independently set \`environmentId\` to an exact environment ID listed under All Environments, \`${ALL_REPOSITORIES}\` for all repositories, or \`${FAST_EXECUTION}\` for Fast mode. This target is independent of the automation's own execution environment. Omit \`environmentId\` only when normal workspace routing should choose at launch time; never invent an ID.
 - If launchable suggestions are unavailable on the current surface, keep follow-ups as ordinary report text and do not promise reaction-triggered launching.
 `

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-service.ts
@@ -1592,6 +1592,7 @@ export async function answerFastAgentQuestion({
   platformEventHandling = 'default',
   platformEventVisibility = 'optional',
   platformEventKind = 'delegated_task',
+  automationReport = false,
   defaultImageArtifactIds = [],
   allowSilentAmbientReply = false,
   platformEventTranscriptPayload,
@@ -1626,6 +1627,9 @@ export async function answerFastAgentQuestion({
   platformEventHandling?: FastAgentPlatformEventHandling;
   platformEventVisibility?: FastAgentPlatformEventVisibility;
   platformEventKind?: FastAgentPlatformEventKind;
+  /** The settling delegated task ran for a custom automation; its closeout is
+   * the run's report and may carry launchable suggestions. */
+  automationReport?: boolean;
   /** Child-selected images to carry through when the parent model omits the
    * optional attachment argument while composing the child update. */
   defaultImageArtifactIds?: string[];
@@ -3089,6 +3093,7 @@ export async function answerFastAgentQuestion({
       platformEventHandling,
       platformEventVisibility,
       platformEventKind,
+      automationReport,
       retryTaskStartAvailable: Boolean(adapter.retryTaskStart),
       allowSilentAmbientReply,
       isCurrentUserAdmin: currentUser.isAdmin,
@@ -3691,7 +3696,7 @@ export async function answerFastAgentQuestion({
               args.suggestions?.length &&
               (args.purpose !== 'closeout' ||
                 !platformEvent ||
-                platformEventKind !== 'automation' ||
+                (platformEventKind !== 'automation' && !automationReport) ||
                 !['slack', 'discord', 'teams', 'telegram'].includes(
                   conversation.surface,
                 ))

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-task-launcher.ts
@@ -168,6 +168,9 @@ export type FastAgentSlackTaskLauncherParams = {
   initiator?: TaskInitiator;
   /** Opt the child into the native Slack task card in the parent thread. */
   liveTaskStream?: boolean;
+  /** The custom automation this thread runs for; marks the child's settle as
+   * that automation's report. */
+  customAutomationId?: string;
   /**
    * Repository the child runs against when the launch is pinned to a bare
    * repository rather than an environment. Defaults to all repositories.
@@ -205,6 +208,9 @@ export function createFastAgentSlackTaskLauncher(
       payload: {
         repo: params.repoForPayload ?? ALL_REPOSITORIES,
         description: prompt,
+        ...(params.customAutomationId
+          ? { customAutomationId: params.customAutomationId }
+          : {}),
         communicationProvider: 'slack',
         communicationTeamId: params.teamId,
         ...(params.teamDomain

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -1143,6 +1143,152 @@ describe('deliverFastAgentParentEvent', () => {
     );
   });
 
+  it('posts suggestions beneath the Slack report when an automation task settles', async () => {
+    const pendingParent = {
+      sessionId: parent.sessionId,
+      conversation: {
+        surface: 'slack' as const,
+        workspaceId: 'T123',
+        conversationId: 'automation-1:occurrence-1',
+        replyTarget: { channelId: 'C123' },
+      },
+    };
+    const suggestions = [
+      { title: 'Quarantine the flaky spec', brief: 'Skip it until fixed.' },
+    ];
+    mocks.answerQuestion.mockImplementationOnce(
+      async ({
+        adapter,
+      }: {
+        adapter: { postReply: (reply: unknown) => unknown };
+      }) =>
+        adapter.postReply({
+          purpose: 'closeout',
+          message: 'Two flaky specs found.',
+          suggestions,
+        }),
+    );
+
+    await deliverFastAgentParentEvent({
+      parent: pendingParent,
+      event: {
+        type: 'task_settled',
+        taskId: 'child-task-1',
+        runId: 42,
+        customAutomationId: 'automation-1',
+        status: 'completed',
+        taskUrl: 'https://roomote.example/task/child-task-1',
+        pullRequests: [],
+      },
+    });
+
+    expect(mocks.answerQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platformEventKind: 'delegated_task',
+        automationReport: true,
+      }),
+    );
+    expect(mocks.appendSuggestionInstruction).toHaveBeenCalledWith(
+      'Two flaky specs found.',
+      'slack',
+      true,
+    );
+    expect(mocks.postSlackSuggestions).toHaveBeenCalledWith({
+      slack: expect.any(Object),
+      channelId: 'C123',
+      threadTs: '101.001',
+      eventId: 'automation-1:task:child-task-1',
+      createdByUserId: 'u1',
+      suggestions,
+    });
+  });
+
+  it('posts Discord suggestions when an automation task settles', async () => {
+    const discordParent = {
+      ...parent,
+      conversation: {
+        surface: 'discord' as const,
+        workspaceId: 'guild-1',
+        conversationId: 'thread-1',
+        replyTarget: { channelId: 'channel-1', threadId: 'thread-1' },
+      },
+    };
+    const suggestions = [
+      { title: 'Verify retry behavior', brief: 'Exercise the failure path.' },
+    ];
+    mocks.answerQuestion.mockImplementationOnce(
+      async ({
+        adapter,
+      }: {
+        adapter: { postReply: (reply: unknown) => unknown };
+      }) =>
+        adapter.postReply({
+          purpose: 'closeout',
+          message: 'Retry failures increased.',
+          suggestions,
+        }),
+    );
+
+    await deliverFastAgentParentEvent({
+      parent: discordParent,
+      event: {
+        type: 'task_settled',
+        taskId: 'child-task-2',
+        runId: 43,
+        customAutomationId: 'automation-2',
+        status: 'completed',
+        taskUrl: 'https://roomote.example/task/child-task-2',
+        pullRequests: [],
+      },
+    });
+
+    expect(mocks.appendSuggestionInstruction).toHaveBeenCalledWith(
+      'Retry failures increased.',
+      'discord',
+      true,
+    );
+    expect(mocks.postDiscordSuggestions).toHaveBeenCalledWith({
+      provider: expect.any(Object),
+      channelId: 'channel-1',
+      threadId: 'thread-1',
+      eventId: 'automation-2:task:child-task-2',
+      createdByUserId: 'u1',
+      suggestions,
+    });
+  });
+
+  it('does not treat an ordinary delegated-task settle as an automation report', async () => {
+    mocks.answerQuestion.mockImplementationOnce(
+      async ({
+        adapter,
+      }: {
+        adapter: { postReply: (reply: unknown) => unknown };
+      }) =>
+        adapter.postReply({
+          purpose: 'closeout',
+          message: 'Done.',
+        }),
+    );
+
+    await deliverFastAgentParentEvent({
+      parent,
+      event: {
+        type: 'task_settled',
+        taskId: 'child-task-3',
+        runId: 44,
+        status: 'completed',
+        taskUrl: 'https://roomote.example/task/child-task-3',
+        pullRequests: [],
+      },
+    });
+
+    expect(mocks.answerQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({ automationReport: false }),
+    );
+    expect(mocks.appendSuggestionInstruction).not.toHaveBeenCalled();
+    expect(mocks.postSlackSuggestions).not.toHaveBeenCalled();
+  });
+
   it('creates the first Slack message when a pending Fast automation settles', async () => {
     const pendingParent = {
       sessionId: parent.sessionId,

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -1980,6 +1980,192 @@ describe('deliverFastAgentParentEvent', () => {
 
   it.each([
     {
+      surface: 'discord' as const,
+      workspaceId: 'dm',
+      channelId: 'discord-dm-1',
+      threadId: undefined,
+      serviceUrl: undefined,
+    },
+    {
+      surface: 'teams' as const,
+      workspaceId: 'tenant-1',
+      channelId: 'teams-channel-1',
+      threadId: 'teams-root-1',
+      serviceUrl: 'https://smba.example.com/amer/',
+    },
+    {
+      surface: 'telegram' as const,
+      workspaceId: 'telegram-chat-1',
+      channelId: 'telegram-chat-1',
+      threadId: undefined,
+      serviceUrl: undefined,
+    },
+  ])(
+    'marks a $surface automation delegation with the automation id',
+    async ({ surface, workspaceId, channelId, threadId, serviceUrl }) => {
+      mocks.answerQuestion.mockImplementationOnce(
+        async ({
+          adapter,
+        }: {
+          adapter: { launchTask: (input: unknown) => unknown };
+        }) =>
+          adapter.launchTask({
+            prompt: 'Inspect the repository.',
+            environmentId: null,
+            model: null,
+            parentSessionId: parent.sessionId,
+            postKickoff: vi.fn().mockResolvedValue(undefined),
+          }),
+      );
+
+      await deliverFastAgentParentEvent({
+        parent: {
+          ...parent,
+          conversation: {
+            surface,
+            workspaceId,
+            conversationId: 'automation-1:occurrence-1',
+            replyTarget: {
+              channelId,
+              ...(threadId ? { threadId } : {}),
+              ...(serviceUrl ? { serviceUrl } : {}),
+            },
+          },
+        },
+        event: {
+          type: 'automation_triggered',
+          eventId: 'automation-1:occurrence-1',
+          automationId: 'automation-1',
+          automationName: 'Weekly scan',
+          prompt: 'Find actionable regressions.',
+          trigger: 'schedule',
+        },
+      });
+
+      expect(mocks.enqueueTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task: expect.objectContaining({
+            payload: expect.objectContaining({
+              customAutomationId: 'automation-1',
+              communicationProvider: surface,
+              fastAgentSessionId: parent.sessionId,
+            }),
+          }),
+        }),
+      );
+    },
+  );
+
+  it('keeps delegating as the automation after its task settles on Teams', async () => {
+    mocks.findTeamsConversationRoute.mockResolvedValueOnce({
+      serviceUrl: 'https://smba.example.com/amer/',
+      workspaceId: 'tenant-1',
+    });
+    mocks.answerQuestion.mockImplementationOnce(
+      async ({
+        adapter,
+      }: {
+        adapter: { launchTask: (input: unknown) => unknown };
+      }) =>
+        adapter.launchTask({
+          prompt: 'Fix the regression the scan found.',
+          environmentId: null,
+          model: null,
+          parentSessionId: parent.sessionId,
+          postKickoff: vi.fn().mockResolvedValue(undefined),
+        }),
+    );
+
+    await deliverFastAgentParentEvent({
+      parent: {
+        ...parent,
+        conversation: {
+          surface: 'teams',
+          workspaceId: 'tenant-1',
+          conversationId: 'teams-conversation-1',
+          replyTarget: {
+            channelId: 'teams-channel-1',
+            threadId: 'teams-root-1',
+            serviceUrl: 'https://smba.example.com/amer/',
+          },
+        },
+      },
+      event: {
+        type: 'task_settled',
+        taskId: 'child-task-1',
+        runId: 42,
+        customAutomationId: 'automation-1',
+        status: 'completed',
+        taskUrl: 'https://roomote.example/task/child-task-1',
+        pullRequests: [],
+      },
+    });
+
+    expect(mocks.enqueueTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          payload: expect.objectContaining({
+            customAutomationId: 'automation-1',
+            communicationProvider: 'teams',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('marks Slack live launches in a bound automation thread with the automation id', async () => {
+    mocks.answerQuestion.mockImplementationOnce(
+      async ({
+        adapter,
+      }: {
+        adapter: { launchTask: (input: unknown) => unknown };
+      }) =>
+        adapter.launchTask({
+          prompt: 'Fix the regression the scan found.',
+          environmentId: null,
+          model: null,
+          parentSessionId: parent.sessionId,
+          postKickoff: vi.fn().mockResolvedValue(undefined),
+        }),
+    );
+
+    await deliverFastAgentParentEvent({
+      parent: {
+        ...parent,
+        conversation: {
+          surface: 'slack',
+          workspaceId: 'T123',
+          conversationId: 'automation-1:occurrence-1',
+          replyTarget: { channelId: 'C123', threadId: '100.001' },
+        },
+      },
+      event: {
+        type: 'task_settled',
+        taskId: 'child-task-1',
+        runId: 42,
+        customAutomationId: 'automation-1',
+        status: 'completed',
+        taskUrl: 'https://roomote.example/task/child-task-1',
+        pullRequests: [],
+      },
+    });
+
+    expect(mocks.createLauncher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: 'C123',
+        threadTs: '100.001',
+        customAutomationId: 'automation-1',
+        initiator: expect.objectContaining({
+          kind: 'automation',
+          key: 'custom_automation',
+          actingUserId: 'u1',
+        }),
+      }),
+    );
+  });
+
+  it.each([
+    {
       surface: 'teams' as const,
       workspaceId: 'tenant-1',
       channelId: 'teams-channel-1',

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -388,6 +388,35 @@ export function buildEventClientMessageSeed(
   }
 }
 
+/**
+ * Events whose closeout is a custom automation's report: the run's own turn,
+ * and the settle of a task that turn delegated. Both may carry launchable
+ * suggestions.
+ */
+function isFastAutomationReportEvent(
+  event: FastAgentParentEvent,
+): event is Extract<
+  FastAgentParentEvent,
+  { type: 'automation_triggered' | 'task_settled' }
+> {
+  return (
+    event.type === 'automation_triggered' ||
+    (event.type === 'task_settled' && Boolean(event.customAutomationId))
+  );
+}
+
+/** Groups a report's suggestion cards; unique per run occurrence. */
+function buildFastAutomationSuggestionEventId(
+  event: Extract<
+    FastAgentParentEvent,
+    { type: 'automation_triggered' | 'task_settled' }
+  >,
+): string {
+  return event.type === 'automation_triggered'
+    ? event.eventId
+    : `${event.customAutomationId}:task:${event.taskId}`;
+}
+
 function buildPrReviewActionNonce(event: FastAgentParentEvent): string {
   return buildSlackClientMessageId(
     `${buildEventClientMessageSeed(event)}:pr-review-action`,
@@ -712,7 +741,7 @@ async function createSlackFastAgentParentTurn(
             : null;
 
         const reportMessage =
-          params.event.type === 'automation_triggered' && !kickoff
+          isFastAutomationReportEvent(params.event) && !kickoff
             ? appendFastAutomationSuggestionInstruction(
                 message,
                 'slack',
@@ -789,14 +818,14 @@ async function createSlackFastAgentParentTurn(
             await releaseRootBindingLock().catch(() => {});
           }
           if (
-            params.event.type === 'automation_triggered' &&
+            isFastAutomationReportEvent(params.event) &&
             suggestions.length > 0
           ) {
             await postFastAutomationSuggestionsToSlack({
               slack,
               channelId: conversation.replyTarget.channelId,
               threadTs: messageTs,
-              eventId: params.event.eventId,
+              eventId: buildFastAutomationSuggestionEventId(params.event),
               createdByUserId: actorUserId,
               suggestions,
             });
@@ -831,14 +860,14 @@ async function createSlackFastAgentParentTurn(
             throw new Error('Slack did not update the Fast automation root.');
           }
           if (
-            params.event.type === 'automation_triggered' &&
+            isFastAutomationReportEvent(params.event) &&
             suggestions.length > 0
           ) {
             await postFastAutomationSuggestionsToSlack({
               slack,
               channelId: conversation.replyTarget.channelId,
               threadTs: rootMessageId,
-              eventId: params.event.eventId,
+              eventId: buildFastAutomationSuggestionEventId(params.event),
               createdByUserId: actorUserId,
               suggestions,
             });
@@ -1220,7 +1249,20 @@ async function createDiscordFastAgentParentTurn(
         sessionId: params.parent.sessionId,
         ...params.footerContext,
       });
-      const bodyText = action ? `${message}\n${action.question}` : message;
+      const settleReport =
+        isFastAutomationReportEvent(params.event) && !kickoff
+          ? params.event
+          : null;
+      const reportMessage = settleReport
+        ? appendFastAutomationSuggestionInstruction(
+            message,
+            'discord',
+            suggestions.length > 0,
+          )
+        : message;
+      const bodyText = action
+        ? `${reportMessage}\n${action.question}`
+        : reportMessage;
       const textWithFooter = `${bodyText}\n\n${footerText}`;
       const posted = await postDiscordFastParentMessageWithFooter({
         provider,
@@ -1271,6 +1313,18 @@ async function createDiscordFastAgentParentTurn(
         conversation,
         messageId: posted.messageId,
       });
+      if (settleReport && suggestions.length > 0) {
+        await postFastAutomationSuggestionsToDiscord({
+          provider,
+          channelId: conversation.replyTarget.channelId,
+          ...(conversation.replyTarget.threadId
+            ? { threadId: conversation.replyTarget.threadId }
+            : {}),
+          eventId: buildFastAutomationSuggestionEventId(settleReport),
+          createdByUserId: actorUserId,
+          suggestions,
+        });
+      }
       if (action) {
         const { superseded } =
           await attachPendingPrReviewActionMessageWithRetirement(
@@ -1367,7 +1421,7 @@ async function createTeamsFastAgentParentTurn(
           sessionId: params.parent.sessionId,
         });
         const reportMessage =
-          params.event.type === 'automation_triggered' && !kickoff
+          isFastAutomationReportEvent(params.event) && !kickoff
             ? appendFastAutomationSuggestionInstruction(
                 message,
                 'teams',
@@ -1423,7 +1477,7 @@ async function createTeamsFastAgentParentTurn(
           images,
         });
         if (
-          params.event.type === 'automation_triggered' &&
+          isFastAutomationReportEvent(params.event) &&
           !kickoff &&
           suggestions.length > 0
         ) {
@@ -1434,7 +1488,7 @@ async function createTeamsFastAgentParentTurn(
             ...(conversation.replyTarget.threadId
               ? { threadId: conversation.replyTarget.threadId }
               : {}),
-            eventId: params.event.eventId,
+            eventId: buildFastAutomationSuggestionEventId(params.event),
             createdByUserId: actorUserId,
             suggestions,
           });
@@ -1500,7 +1554,7 @@ async function createTelegramFastAgentParentTurn(
           sessionId: params.parent.sessionId,
         });
         const reportMessage =
-          params.event.type === 'automation_triggered' && !kickoff
+          isFastAutomationReportEvent(params.event) && !kickoff
             ? appendFastAutomationSuggestionInstruction(
                 message,
                 'telegram',
@@ -1522,7 +1576,7 @@ async function createTelegramFastAgentParentTurn(
           messageId: posted.lastTextMessageId ?? posted.messageId,
         });
         if (
-          params.event.type === 'automation_triggered' &&
+          isFastAutomationReportEvent(params.event) &&
           !kickoff &&
           suggestions.length > 0
         ) {
@@ -1532,7 +1586,7 @@ async function createTelegramFastAgentParentTurn(
             ...(conversation.replyTarget.threadId
               ? { threadId: conversation.replyTarget.threadId }
               : {}),
-            eventId: params.event.eventId,
+            eventId: buildFastAutomationSuggestionEventId(params.event),
             createdByUserId: actorUserId,
             suggestions,
           });
@@ -2122,6 +2176,9 @@ export async function deliverFastAgentParentEventWithLock(
         (params.event.type === 'automation_triggered'
           ? 'automation'
           : 'delegated_task'),
+      automationReport:
+        params.event.type === 'task_settled' &&
+        Boolean(params.event.customAutomationId),
       ...(params.event.type === 'child_message' &&
       params.event.imageArtifactIds?.length
         ? { defaultImageArtifactIds: params.event.imageArtifactIds }

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -437,27 +437,79 @@ type FastAgentParentTurnParams = {
   footerContext: FastSessionReplyFooterContext;
 };
 
-function createFastAgentAutomationTaskLauncher(params: {
-  userId: string;
-  conversation: FastAgentConversation;
+/** The custom automation a Fast conversation is running for, when known. */
+export type FastAutomationLaunchContext = {
   automationId: string;
   automationName: string;
+  trigger: 'schedule' | 'manual';
+};
+
+const AUTOMATION_OCCURRENCE_ID_PATTERN =
+  /^([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}):/iu;
+
+/**
+ * Custom automation conversations on Slack, Teams, Telegram, and Discord DMs
+ * are keyed by the run occurrence, `<automationId>:<claimedAt>`. A Discord
+ * channel run is keyed by its thread instead, so only the event can name
+ * the automation there.
+ */
+function parseCustomAutomationIdFromConversationId(
+  conversationId: string,
+): string | undefined {
+  return AUTOMATION_OCCURRENCE_ID_PATTERN.exec(conversationId)?.[1];
+}
+
+async function resolveFastAutomationLaunchContext(params: {
   event: FastAgentParentEvent;
-}): LaunchFastAgentTask {
-  return createFastAgentTaskLauncher({
-    userId: params.userId,
-    surface: 'system',
-    trigger:
-      params.event.type === 'automation_triggered'
-        ? params.event.trigger
-        : 'schedule',
-    taskUrlCampaign: 'fast-automation-delegation',
+  conversation: FastAgentConversation;
+}): Promise<FastAutomationLaunchContext | null> {
+  if (params.event.type === 'automation_triggered') {
+    return {
+      automationId: params.event.automationId,
+      automationName: params.event.automationName,
+      trigger: params.event.trigger,
+    };
+  }
+  const automationId =
+    (params.event.type === 'task_settled'
+      ? params.event.customAutomationId
+      : undefined) ??
+    parseCustomAutomationIdFromConversationId(
+      params.conversation.conversationId,
+    );
+  if (!automationId) {
+    return null;
+  }
+  const automation = await getCustomAutomationById(automationId);
+  return {
+    automationId,
+    automationName: automation?.name ?? 'Custom automation',
+    trigger: 'schedule',
+  };
+}
+
+/**
+ * Launch options that make a delegated task the automation's own work: it
+ * is attributed to the automation (acting as the run's user), carries the
+ * automation id so its settle is a report, and updates the automation's
+ * last-launched task.
+ */
+function buildFastAutomationLaunchOptions(params: {
+  userId: string;
+  automation: FastAutomationLaunchContext;
+}): Pick<
+  Parameters<typeof createFastAgentTaskLauncher>[0],
+  'initiator' | 'trigger' | 'afterKickoff' | 'onQueueFailure'
+> & { payload: { customAutomationId: string } } {
+  const { automationId } = params.automation;
+  return {
+    trigger: params.automation.trigger,
     initiator: {
       kind: 'automation',
       key: 'custom_automation',
       actor: {
-        externalId: params.automationId,
-        displayName: params.automationName,
+        externalId: automationId,
+        displayName: params.automation.automationName,
       },
       actingUserId: params.userId,
     },
@@ -465,7 +517,7 @@ function createFastAgentAutomationTaskLauncher(params: {
       await db
         .update(customAutomations)
         .set({ lastLaunchedTaskId: taskRun.taskId })
-        .where(eq(customAutomations.id, params.automationId));
+        .where(eq(customAutomations.id, automationId));
     },
     onQueueFailure: async (taskRun) => {
       await db
@@ -473,11 +525,38 @@ function createFastAgentAutomationTaskLauncher(params: {
         .set({ lastLaunchedTaskId: null })
         .where(
           and(
-            eq(customAutomations.id, params.automationId),
+            eq(customAutomations.id, automationId),
             eq(customAutomations.lastLaunchedTaskId, taskRun.taskId),
           ),
         );
     },
+    payload: { customAutomationId: automationId },
+  };
+}
+
+function createFastAgentAutomationTaskLauncher(params: {
+  userId: string;
+  conversation: FastAgentConversation;
+  automationId: string;
+  automationName: string;
+  event: FastAgentParentEvent;
+}): LaunchFastAgentTask {
+  const { payload, ...launchOptions } = buildFastAutomationLaunchOptions({
+    userId: params.userId,
+    automation: {
+      automationId: params.automationId,
+      automationName: params.automationName,
+      trigger:
+        params.event.type === 'automation_triggered'
+          ? params.event.trigger
+          : 'schedule',
+    },
+  });
+  return createFastAgentTaskLauncher({
+    userId: params.userId,
+    surface: 'system',
+    taskUrlCampaign: 'fast-automation-delegation',
+    ...launchOptions,
     buildTask: ({
       prompt,
       environmentId,
@@ -489,7 +568,7 @@ function createFastAgentAutomationTaskLauncher(params: {
       payload: {
         repo: ALL_REPOSITORIES,
         description: prompt,
-        customAutomationId: params.automationId,
+        ...payload,
         ...buildFastAgentChildTaskMetadata({
           sessionId: parentSessionId,
           conversation: params.conversation,
@@ -695,6 +774,22 @@ async function createSlackFastAgentParentTurn(
               : {}),
             channelId: conversation.replyTarget.channelId,
             threadTs: threadId!,
+            // A bound automation thread keeps delegating as the automation,
+            // so later launches settle as its reports too.
+            ...(customAutomationId
+              ? {
+                  customAutomationId,
+                  initiator: {
+                    kind: 'automation',
+                    key: 'custom_automation',
+                    actor: {
+                      externalId: customAutomationId,
+                      displayName: automationName,
+                    },
+                    actingUserId: actorUserId,
+                  },
+                }
+              : {}),
           }),
       // A resumed turn edits the retry notice its predecessor posted, so the
       // queue-side adapter needs the same in-place replacement as the
@@ -962,11 +1057,21 @@ export function createFastAgentDiscordTaskLauncher(params: {
   >;
   userId: string;
   conversation: Extract<FastAgentConversation, { surface: 'discord' }>;
+  /** Set when the conversation is a custom automation run. */
+  automation?: FastAutomationLaunchContext | null;
 }): LaunchFastAgentTask {
+  const { payload: automationPayload, ...automationLaunchOptions } =
+    params.automation
+      ? buildFastAutomationLaunchOptions({
+          userId: params.userId,
+          automation: params.automation,
+        })
+      : { payload: {} };
   return createFastAgentTaskLauncher({
     userId: params.userId,
     surface: 'discord',
     taskUrlCampaign: 'fast-delegation',
+    ...automationLaunchOptions,
     buildTask: async ({
       prompt,
       environmentId,
@@ -987,6 +1092,7 @@ export function createFastAgentDiscordTaskLauncher(params: {
         payload: {
           repo: ALL_REPOSITORIES,
           description: prompt,
+          ...automationPayload,
           communicationProvider: 'discord',
           communicationChannelId:
             thread?.parentChannelId ??
@@ -1032,11 +1138,21 @@ export function createFastAgentCommunicationTaskLauncher(params: {
     { surface: 'teams' | 'telegram' }
   >;
   serviceUrl?: string;
+  /** Set when the conversation is a custom automation run. */
+  automation?: FastAutomationLaunchContext | null;
 }): LaunchFastAgentTask {
+  const { payload: automationPayload, ...automationLaunchOptions } =
+    params.automation
+      ? buildFastAutomationLaunchOptions({
+          userId: params.userId,
+          automation: params.automation,
+        })
+      : { payload: {} };
   return createFastAgentTaskLauncher({
     userId: params.userId,
     surface: params.conversation.surface,
     taskUrlCampaign: 'fast-delegation',
+    ...automationLaunchOptions,
     buildTask: ({
       prompt,
       environmentId,
@@ -1048,6 +1164,7 @@ export function createFastAgentCommunicationTaskLauncher(params: {
       payload: {
         repo: ALL_REPOSITORIES,
         description: prompt,
+        ...automationPayload,
         communicationProvider: params.conversation.surface,
         communicationChannelId: params.conversation.replyTarget.channelId,
         ...(params.conversation.replyTarget.threadId
@@ -1145,11 +1262,16 @@ async function createDiscordFastAgentParentTurn(
 
   const actorUserId = requireFastAgentActorUserId(session, params.actorUserId);
   const conversation = session.conversation;
+  const automation = await resolveFastAutomationLaunchContext({
+    event: params.event,
+    conversation,
+  });
   const adapter: FastAgentTurnAdapter = {
     launchTask: createFastAgentDiscordTaskLauncher({
       provider,
       userId: actorUserId,
       conversation,
+      automation,
     }),
     postReply: async ({
       message,
@@ -1400,6 +1522,10 @@ async function createTeamsFastAgentParentTurn(
         userId: actorUserId,
         conversation,
         serviceUrl,
+        automation: await resolveFastAutomationLaunchContext({
+          event: params.event,
+          conversation,
+        }),
       }),
       replaceReply: createTeamsFastReplyReplacer({
         provider,
@@ -1534,6 +1660,10 @@ async function createTelegramFastAgentParentTurn(
       launchTask: createFastAgentCommunicationTaskLauncher({
         userId: actorUserId,
         conversation,
+        automation: await resolveFastAutomationLaunchContext({
+          event: params.event,
+          conversation,
+        }),
       }),
       replaceReply: createTelegramFastReplyReplacer({
         provider,

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -438,7 +438,7 @@ type FastAgentParentTurnParams = {
 };
 
 /** The custom automation a Fast conversation is running for, when known. */
-export type FastAutomationLaunchContext = {
+type FastAutomationLaunchContext = {
   automationId: string;
   automationName: string;
   trigger: 'schedule' | 'manual';


### PR DESCRIPTION
## What changed

Launchable suggestion cards were only posted on the initial `automation_triggered` turn. An automation that delegated its work to a task therefore never rendered them: the result arrived on a `task_settled` turn, which was not treated as a report. After #2251 that is the normal shape of an environment automation, so the gap became visible.

- A `task_settled` event carrying a `customAutomationId` is now an automation report on every surface.
- Delivery flags the turn with `automationReport`. The Fast prompt tells the turn that this closeout is the run's report, to judge it by the automation prompt earlier in the conversation, and offers the same suggestion guidance the initial turn gets. The closeout tool accepts `suggestions` for these turns.
- Slack, Discord, Teams, and Telegram append the "react to start" instruction and post the cards beneath the settle report. Cards are grouped by `<automationId>:task:<taskId>` so retries stay idempotent.
- Ordinary delegated-task settles in non-automation Sessions are unchanged.

## Validation

- sdk parent-event suite (54): new cases for Slack and Discord settle-time suggestions and for a non-automation settle staying unflagged.
- cloud-agents: prompt test for the report guidance; service test that suggestions pass through a `task_settled` closeout when flagged.
- `check-types:fast` and oxlint clean.
- One pre-existing failure in `fast-agent-service.test.ts` ("reports local storage exhaustion") fails identically on develop on this machine and is unrelated.
