### PR TITLE
[Improve] Pin PR review updates above the session composer

### DIFF
--- a/apps/docs/fast-sessions.mdx
+++ b/apps/docs/fast-sessions.mdx
@@ -130,6 +130,20 @@ work.
 
 Fast turns also survive API or worker interruptions. Roomote durably admits the turn before acknowledging it, records every action the turn takes as it happens, and resumes unfinished work on another process. The resumed run receives the transcript of its earlier attempt, up to the point it was cut off, so it continues from there instead of repeating actions or asking you to send the request again. If the cut lands on the final reply itself, the resumed run finishes from the transcript: a reply that was recorded is not posted again, and a reply the process died while posting goes out once more without another model request. This covers turns started by a typed message, by an emoji reaction, and by platform events such as a setup kickoff. Provider-side retry waits are honored the same way: short waits keep the turn in place, and longer waits park it durably until the scheduled time.
 
+### Pull Request Reviews
+
+PR-review updates appear in a compact strip above the Session composer. The strip
+stays visible while you scroll and shows the latest update for each pull request,
+instead of repeating review notifications in the conversation. Your messages and
+the agent's ordinary replies remain in the transcript.
+
+Use **Fix findings** to address the current feedback, **Auto-resolve** to enable
+automatic resolution for that PR, or **Dismiss** to decline the offer. **View
+review** opens the linked review task when available, or the pull request on its
+source-control provider. An active linked review shows **Reviewing…**; reported
+approval, merge, and closure replace the earlier feedback state. Completed review
+status can be dismissed from the strip.
+
 ### Message Suggestions
 
 An empty task or Session composer can show one contextual follow-up after an

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.client.test.tsx
@@ -4,6 +4,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import {
   ACP_ENVELOPE_EVENT_TYPES,
@@ -1056,9 +1057,7 @@ describe('FastSessionTranscript', () => {
       />,
     );
 
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Resolve these issues' }),
-    );
+    fireEvent.click(screen.getByRole('button', { name: 'Fix findings' }));
     await waitFor(() =>
       expect(reviewActionMutate).toHaveBeenCalledWith({
         sessionId: '22222222-2222-4222-8222-222222222222',
@@ -1066,12 +1065,111 @@ describe('FastSessionTranscript', () => {
         choice: 'yes',
       }),
     );
-    expect(
-      await screen.findByText('Resolving the current review issues.'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Addressing findings…')).toBeInTheDocument();
   });
 
-  it('hides dismissed offers and renders late-click states without controls', async () => {
+  it('pins only the latest PR review outside the scrolling transcript and opens its task', async () => {
+    const old = reviewOfferMessage();
+    const prReview = {
+      url: 'https://github.com/acme/web/pull/42',
+      repository: 'acme/web',
+      number: 42,
+      summary: 'Provider coverage is missing.',
+      findingCount: 1,
+      status: 'feedback',
+      reviewTaskId: 'review-task-42',
+    };
+    const latest = {
+      ...old,
+      id: 'offer-2',
+      eventId: 'turn-offer-2:assistant:0',
+      ts: 3,
+      payload: {
+        prReview,
+        prReviewAction: {
+          ...old.payload.prReviewAction,
+          deliveryId: 'delivery-2',
+        },
+      },
+    };
+    reviewActionMutate.mockResolvedValue({ status: 'resolved' });
+    render(
+      <FastSessionTranscript
+        sessionId="session-1"
+        canReply
+        initialMessages={[
+          {
+            ...old,
+            payload: {
+              ...old.payload,
+              prReview: { ...prReview, findingCount: 2 },
+            },
+          },
+          latest,
+        ]}
+      />,
+    );
+    const strip = screen.getByLabelText('Pull request reviews');
+    expect(screen.getByRole('log')).not.toContainElement(strip);
+    expect(
+      within(screen.getByRole('log')).queryByText('Review feedback remains.'),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText('PR #42')).toHaveLength(1);
+    expect(screen.getByText('1 unresolved finding')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'View review' }));
+    expect(openTaskPanel).toHaveBeenCalledWith('review-task-42');
+    fireEvent.click(screen.getByRole('button', { name: 'Fix finding' }));
+    await waitFor(() =>
+      expect(reviewActionMutate).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        deliveryId: 'delivery-2',
+        choice: 'yes',
+      }),
+    );
+
+    act(() =>
+      FakeEventSource.instances.at(-1)?.emit('messages', {
+        messages: [
+          {
+            ...latest,
+            id: 'approval',
+            eventId: 'approval:assistant:0',
+            ts: 4,
+            payload: {
+              prReview: { ...prReview, status: 'approved', findingCount: 0 },
+            },
+          },
+        ],
+      }),
+    );
+    expect(await screen.findByText('Approved')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Fix finding' }),
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss review' }));
+    expect(screen.queryByText('Approved')).not.toBeInTheDocument();
+  });
+
+  it('keeps a failed review action available for retry', async () => {
+    reviewActionMutate.mockRejectedValueOnce(new Error('offline'));
+    render(
+      <FastSessionTranscript
+        sessionId="session-1"
+        initialMessages={[reviewOfferMessage()]}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Fix findings' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not update this review',
+    );
+    expect(screen.getByRole('button', { name: 'Fix findings' })).toBeEnabled();
+    reviewActionMutate.mockResolvedValueOnce({ status: 'resolved' });
+    fireEvent.click(screen.getByRole('button', { name: 'Fix findings' }));
+    expect(await screen.findByText('Addressing findings…')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('removes dismissed and superseded offers from the pinned area', async () => {
     const { rerender } = render(
       <FastSessionTranscript
         sessionId="22222222-2222-4222-8222-222222222222"
@@ -1085,7 +1183,7 @@ describe('FastSessionTranscript', () => {
       screen.queryByTestId('pr-review-action-offer'),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Resolve these issues' }),
+      screen.queryByRole('button', { name: 'Fix findings' }),
     ).not.toBeInTheDocument();
 
     rerender(
@@ -1099,9 +1197,11 @@ describe('FastSessionTranscript', () => {
         messages: [reviewOfferMessage('stale')],
       });
     });
-    expect(
-      await screen.findByText('This offer was already handled or has expired.'),
-    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Fix findings' }),
+      ).not.toBeInTheDocument(),
+    );
   });
   it('renders persisted user and assistant text with task transcript primitives', () => {
     render(

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/FastSessionTranscript.tsx
@@ -2,6 +2,7 @@
 
 import {
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useReducer,
@@ -17,6 +18,7 @@ import {
   getTextFromContentBlocks,
   inferAcpMessageKind,
   parsePrReviewActionOffer,
+  parseSessionPrReviewUpdate,
   type AcpMessage,
   type PrReviewActionChoice,
   type AcpEventType,
@@ -49,11 +51,13 @@ import {
   useOpenSessionTasksPanel,
   useSessionRunningTaskCount,
   useSessionTaskStateRevision,
+  SessionReviewTasksContext,
 } from './session-task-panel-context';
 import { useNarrationMode } from '@/hooks/useNarrationMode';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { truncatePageTitle } from '@/lib/page-title';
-import { PrReviewActionOffer } from '@/components/ai-elements/pr-review-action-offer';
+import { SessionPrReviewStrip } from './SessionPrReviewStrip';
+import { getSessionPrReviews } from './session-pr-reviews';
 import {
   findPendingSessionInputRequest,
   SessionUserInputCard,
@@ -306,6 +310,7 @@ export function FastSessionTranscript({
   const openTasksPanel = useOpenSessionTasksPanel();
   const runningTaskCount = useSessionRunningTaskCount();
   const taskStateRevision = useSessionTaskStateRevision();
+  const reviewTasks = useContext(SessionReviewTasksContext);
   const { enabled: narrationModeEnabled } = useNarrationMode();
   const displayMode = narrationModeEnabled ? 'narration' : 'default';
   const slackMentionScope = useMemo<SlackMentionScope>(
@@ -552,7 +557,9 @@ export function FastSessionTranscript({
           (message) =>
             message.eventType !== ACP_ENVELOPE_EVENT_TYPES.RequestUserInput &&
             message.eventType !==
-              ACP_ENVELOPE_EVENT_TYPES.RequestUserInputResponse,
+              ACP_ENVELOPE_EVENT_TYPES.RequestUserInputResponse &&
+            !parsePrReviewActionOffer(message.payload) &&
+            !parseSessionPrReviewUpdate(message.payload),
         )
         .map((message) => {
           const uiMessage = toAcpUiMessage({
@@ -607,13 +614,9 @@ export function FastSessionTranscript({
     () => findPendingSessionInputRequest(messages),
     [messages],
   );
-  const reviewOffers = useMemo(
-    () =>
-      messages.flatMap((message) => {
-        const offer = parsePrReviewActionOffer(message.payload);
-        return offer ? [offer] : [];
-      }),
-    [messages],
+  const reviews = useMemo(
+    () => getSessionPrReviews(messages, reviewTasks),
+    [messages, reviewTasks],
   );
   const uiMessages = useMemo(
     () =>
@@ -785,17 +788,6 @@ export function FastSessionTranscript({
                 onOpenTasks={openTasksPanel}
               />
             ) : null}
-            {reviewOffers.map((offer) => (
-              <PrReviewActionOffer
-                key={offer.deliveryId}
-                className="mt-3 rounded-lg border border-border/70 bg-muted/40 px-3 py-3"
-                offer={offer}
-                showQuestion
-                onAction={(choice) =>
-                  handleReviewAction(offer.deliveryId, choice)
-                }
-              />
-            ))}
             {pendingInputRequest ? (
               <div className="mt-3">
                 {pendingInputRequest.preset === 'setup_starter_tasks' ? (
@@ -814,6 +806,7 @@ export function FastSessionTranscript({
           </ConversationContent>
           <ConversationScrollButton />
         </Conversation>
+        <SessionPrReviewStrip reviews={reviews} onAction={handleReviewAction} />
         {canReply && !pendingInputRequest ? (
           <div className="mx-auto w-full shrink-0 overflow-clip rounded-t-md rounded-b-3xl border-2 border-background bg-card outline-0 outline-offset-[-2px] outline-accent-foreground transition-[background-color,border-color,outline-width] has-[textarea:focus]:outline-2 @[56rem]:rounded-t-lg">
             <SessionPromptInput

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionPrReviewStrip.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionPrReviewStrip.client.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { SessionPrReviewStrip } from './SessionPrReviewStrip';
+import type { SessionReview } from './session-pr-reviews';
+
+function review(number: number): SessionReview {
+  return {
+    key: `pr-${number}`,
+    revision: `feedback-${number}`,
+    review: {
+      url: `https://github.com/example/project/pull/${number}`,
+      repository: 'example/project',
+      number,
+      summary: `Feedback for ${number}`,
+      findingCount: 1,
+      status: 'feedback',
+    },
+    offer: {
+      deliveryId: `delivery-${number}`,
+      question: 'Resolve?',
+      status: 'pending',
+    },
+  };
+}
+
+it('keeps multiple PRs compact and expands one set of actions at a time', () => {
+  render(
+    <SessionPrReviewStrip
+      reviews={[review(42), review(43)]}
+      onAction={vi.fn()}
+    />,
+  );
+  expect(screen.getAllByRole('button', { name: 'Fix finding' })).toHaveLength(
+    1,
+  );
+  expect(screen.getByText('Feedback for 43')).toBeInTheDocument();
+  expect(screen.queryByText('Feedback for 42')).not.toBeInTheDocument();
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Review details for PR #42' }),
+  );
+  expect(screen.getByText('Feedback for 42')).toBeInTheDocument();
+  expect(screen.queryByText('Feedback for 43')).not.toBeInTheDocument();
+  expect(
+    within(
+      screen.getByRole('region', { name: 'Review of example/project PR #42' }),
+    ).getByRole('button', { name: 'Fix finding' }),
+  ).toBeInTheDocument();
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Review details for PR #42' }),
+  );
+  expect(
+    screen.queryByRole('button', { name: 'Fix finding' }),
+  ).not.toBeInTheDocument();
+});

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionPrReviewStrip.stories.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionPrReviewStrip.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { SessionPrReviewStrip } from './SessionPrReviewStrip';
+import type { SessionReview } from './session-pr-reviews';
+
+const pending: SessionReview = {
+  key: 'pr-42',
+  revision: 'feedback-1',
+  review: {
+    url: 'https://github.com/example/project/pull/42',
+    repository: 'example/project',
+    number: 42,
+    summary:
+      'The provider catalog is missing coverage for an additional route.',
+    findingCount: 1,
+    status: 'feedback',
+  },
+  offer: {
+    deliveryId: 'delivery-1',
+    question: 'Resolve the review feedback?',
+    status: 'pending',
+  },
+};
+
+const meta: Meta<typeof SessionPrReviewStrip> = {
+  title: 'Sessions/Pinned PR review',
+  component: SessionPrReviewStrip,
+  parameters: { layout: 'centered' },
+  args: {
+    reviews: [pending],
+    onAction: async (_deliveryId, choice) =>
+      choice === 'dismiss'
+        ? 'dismissed'
+        : choice === 'auto'
+          ? 'auto_resolved'
+          : 'resolved',
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex h-[640px] w-[420px] max-w-[calc(100vw-32px)] flex-col overflow-hidden rounded-2xl border border-border bg-background">
+        <div className="border-b border-border px-4 py-4 text-sm font-medium">
+          Update provider support
+        </div>
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-4 text-sm">
+          <p>Add the missing model providers and open a PR.</p>
+          <p>The implementation is complete in PR #42. Validation passed.</p>
+          <p>I started a review of the changes.</p>
+          {Array.from({ length: 8 }, (_, index) => (
+            <p key={index} className="text-muted-foreground">
+              Earlier conversation · {index + 1}
+            </p>
+          ))}
+        </div>
+        <Story />
+        <div className="shrink-0 bg-card px-4 pb-4 pt-3">
+          <textarea
+            aria-label="Message agent"
+            placeholder="Message agent"
+            className="h-16 w-full resize-none bg-transparent text-sm outline-none"
+          />
+          <div className="text-xs text-muted-foreground">+ &nbsp; Model</div>
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Feedback: Story = {};
+export const Reviewing: Story = {
+  args: { reviews: [{ ...pending, reviewing: true }] },
+};
+export const Approved: Story = {
+  args: {
+    reviews: [
+      {
+        ...pending,
+        offer: null,
+        review: { ...pending.review!, status: 'approved', findingCount: 0 },
+      },
+    ],
+  },
+};
+export const MultiplePullRequests: Story = {
+  args: {
+    reviews: [
+      pending,
+      {
+        ...pending,
+        key: 'pr-43',
+        revision: 'feedback-2',
+        review: {
+          ...pending.review!,
+          number: 43,
+          url: 'https://github.com/example/project/pull/43',
+        },
+        offer: { ...pending.offer!, deliveryId: 'delivery-2' },
+      },
+    ],
+  },
+};

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionPrReviewStrip.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionPrReviewStrip.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState } from 'react';
+import removeMd from 'remove-markdown';
+import type {
+  PrReviewActionChoice,
+  PrReviewActionOfferStatus,
+} from '@roomote/types';
+import {
+  Button,
+  BasicTooltip,
+  ChevronDown,
+  GitPullRequest,
+  X,
+} from '@/components/system';
+import { PrReviewActionOffer } from '@/components/ai-elements/pr-review-action-offer';
+import { useOpenSessionTaskPanel } from './session-task-panel-context';
+import type { SessionReview } from './session-pr-reviews';
+
+function ReviewRow({
+  item,
+  onAction,
+  expanded,
+  onToggle,
+}: {
+  item: SessionReview;
+  expanded: boolean;
+  onToggle?: () => void;
+  onAction: (
+    deliveryId: string,
+    choice: PrReviewActionChoice,
+  ) => Promise<PrReviewActionOfferStatus>;
+}) {
+  const openTask = useOpenSessionTaskPanel();
+  const [dismissed, setDismissed] = useState(false);
+  const [actionStatus, setActionStatus] =
+    useState<PrReviewActionOfferStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const { review, offer, reviewing } = item;
+  const status = actionStatus ?? offer?.status;
+  const terminal =
+    review?.status === 'approved' ||
+    review?.status === 'merged' ||
+    review?.status === 'closed';
+  if (
+    dismissed ||
+    (!reviewing && !terminal && (status === 'dismissed' || status === 'stale'))
+  )
+    return null;
+  const acting = status === 'resolved' || status === 'auto_resolved';
+  const label = reviewing
+    ? 'Reviewing…'
+    : terminal
+      ? {
+          approved: 'Approved',
+          merged: 'Merged',
+          closed: 'Closed',
+          feedback: '',
+        }[review.status]
+      : status === 'auto_resolved'
+        ? 'Auto-resolve enabled'
+        : acting
+          ? 'Addressing findings…'
+          : review?.findingCount != null && review.findingCount > 0
+            ? `${review.findingCount} unresolved ${review.findingCount === 1 ? 'finding' : 'findings'}`
+            : 'Review feedback';
+
+  return (
+    <section
+      aria-label={
+        review
+          ? `Review of ${review.repository} PR #${review.number}`
+          : 'PR review'
+      }
+      className="min-w-0 px-4 py-3"
+    >
+      <div className="flex min-w-0 items-center gap-2 text-sm">
+        <GitPullRequest className="size-4 shrink-0 text-muted-foreground" />
+        <BasicTooltip content={review?.repository || 'Pull request review'}>
+          <span className="shrink-0 font-medium">
+            {review ? `PR #${review.number}` : 'PR review'}
+          </span>
+        </BasicTooltip>
+        <span
+          className="min-w-0 flex-1 truncate text-muted-foreground"
+          role="status"
+        >
+          {label}
+        </span>
+        {item.reviewTaskId && openTask ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => openTask(item.reviewTaskId!)}
+          >
+            View review
+          </Button>
+        ) : review ? (
+          <Button size="sm" variant="ghost" asChild>
+            <a href={review.url} target="_blank" rel="noopener noreferrer">
+              View review
+            </a>
+          </Button>
+        ) : null}
+        {terminal ? (
+          <BasicTooltip content="Dismiss review">
+            <Button
+              size="icon"
+              variant="ghost"
+              aria-label="Dismiss review"
+              onClick={() => setDismissed(true)}
+            >
+              <X />
+            </Button>
+          </BasicTooltip>
+        ) : null}
+        {onToggle && !terminal && !reviewing && !acting ? (
+          <Button
+            size="icon"
+            variant="ghost"
+            aria-label={`Review details for ${review ? `PR #${review.number}` : 'pull request'}`}
+            aria-expanded={expanded}
+            onClick={onToggle}
+          >
+            <ChevronDown className={expanded ? 'rotate-180' : undefined} />
+          </Button>
+        ) : null}
+      </div>
+      {expanded && !reviewing && !terminal && !acting && review?.summary ? (
+        <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+          {removeMd(review.summary)}
+        </p>
+      ) : null}
+      {expanded && !reviewing && !terminal && !acting && offer ? (
+        <PrReviewActionOffer
+          className="mt-2"
+          labels={{
+            yes: review?.findingCount === 1 ? 'Fix finding' : 'Fix findings',
+            auto: 'Auto-resolve',
+            dismiss: 'Dismiss',
+          }}
+          offer={offer}
+          onAction={async (choice) => {
+            setError(null);
+            try {
+              const nextStatus = await onAction(offer.deliveryId, choice);
+              setActionStatus(nextStatus);
+              return nextStatus;
+            } catch {
+              setError('Could not update this review. Please try again.');
+              return status ?? offer.status;
+            }
+          }}
+        />
+      ) : null}
+      {error ? (
+        <p className="mt-2 text-xs text-destructive" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+export function SessionPrReviewStrip({
+  reviews,
+  onAction,
+}: {
+  reviews: SessionReview[];
+  onAction: (
+    deliveryId: string,
+    choice: PrReviewActionChoice,
+  ) => Promise<PrReviewActionOfferStatus>;
+}) {
+  const [expandedKey, setExpandedKey] = useState<string | null | undefined>(
+    undefined,
+  );
+  const selectedKey =
+    expandedKey === undefined ||
+    (expandedKey !== null && !reviews.some((item) => item.key === expandedKey))
+      ? reviews.at(-1)?.key
+      : expandedKey;
+  if (reviews.length === 0) return null;
+  return (
+    <div
+      aria-label="Pull request reviews"
+      className="max-h-52 shrink-0 overflow-y-auto border-t border-border/60 bg-card divide-y divide-border/60"
+    >
+      {reviews.map((item) => (
+        <ReviewRow
+          key={`${item.key}:${item.revision}:${item.offer?.status ?? ''}:${item.review?.status ?? ''}:${item.reviewing ?? false}`}
+          item={item}
+          expanded={reviews.length === 1 || selectedKey === item.key}
+          onToggle={
+            reviews.length > 1
+              ? () => setExpandedKey(selectedKey === item.key ? null : item.key)
+              : undefined
+          }
+          onAction={onAction}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.tsx
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/SessionWorkspace.tsx
@@ -85,6 +85,7 @@ import {
   OpenSessionTasksPanelContext,
   SessionRunningTaskCountContext,
   SessionTaskStateRevisionContext,
+  SessionReviewTasksContext,
   type SessionArtifactViewerSelection,
 } from './session-task-panel-context';
 import { DelegatedTaskCard } from '../../task/[taskId]/messages/acp/DelegatedTaskCard';
@@ -1074,7 +1075,11 @@ export function SessionWorkspace({
                       <OpenSessionTasksPanelContext.Provider
                         value={openTasksPanel}
                       >
-                        {children}
+                        <SessionReviewTasksContext.Provider
+                          value={sessionTasks}
+                        >
+                          {children}
+                        </SessionReviewTasksContext.Provider>
                       </OpenSessionTasksPanelContext.Provider>
                     </SessionTaskStateRevisionContext.Provider>
                   </SessionRunningTaskCountContext.Provider>

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/session-pr-reviews.client.test.ts
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/session-pr-reviews.client.test.ts
@@ -1,0 +1,112 @@
+import { getSessionPrReviews } from './session-pr-reviews';
+import { RunStatus } from '@roomote/types';
+import type { SessionReviewTask } from './session-task-panel-context';
+
+const review = {
+  url: 'https://github.com/acme/web/pull/42',
+  repository: 'acme/web',
+  number: 42,
+  summary: 'Missing coverage',
+  findingCount: 1,
+  status: 'feedback',
+};
+const offer = {
+  deliveryId: 'delivery-1',
+  question: 'Resolve?',
+  status: 'pending',
+};
+const message = {
+  id: 'message-1',
+  payload: { prReview: review, prReviewAction: offer },
+};
+
+it('keeps distinct repositories and hosts separate even for the same PR number', () => {
+  expect(
+    getSessionPrReviews(
+      [
+        message,
+        {
+          id: 'message-2',
+          payload: {
+            prReview: {
+              ...review,
+              url: 'https://gitlab.example/other/project/-/merge_requests/42',
+            },
+          },
+        },
+      ],
+      [],
+    ),
+  ).toHaveLength(2);
+});
+
+it('does not resurrect an old action after a newer dismissal or approval', () => {
+  const dismissed = {
+    id: 'message-2',
+    payload: {
+      prReview: review,
+      prReviewAction: { ...offer, status: 'dismissed' },
+    },
+  };
+  expect(getSessionPrReviews([message, dismissed], [])).toEqual([]);
+  const approved = {
+    id: 'message-3',
+    payload: { prReview: { ...review, status: 'approved', findingCount: 0 } },
+  };
+  const [latest] = getSessionPrReviews([message, dismissed, approved], []);
+  expect(latest?.offer).toBeNull();
+  expect(latest?.review?.status).toBe('approved');
+});
+
+it('keeps legacy action offers usable without inventing PR context', () => {
+  const [latest] = getSessionPrReviews(
+    [{ id: 'legacy', payload: { prReviewAction: offer } }],
+    [],
+  );
+  expect(latest?.review).toBeNull();
+  expect(latest?.offer).toEqual(offer);
+});
+
+it('shows an active review and prefers its task over older completed reviews', () => {
+  const active: SessionReviewTask = {
+    taskId: 'active',
+    workflow: 'pr_review',
+    latestRun: { status: RunStatus.Running },
+    pullRequests: [
+      { url: review.url, number: 42, repository: 'acme/web', status: 'open' },
+    ],
+  };
+  const completed: SessionReviewTask = {
+    ...active,
+    taskId: 'old',
+    latestRun: { status: RunStatus.Completed },
+  };
+  const [latest] = getSessionPrReviews([message], [active, completed]);
+  expect(latest?.reviewing).toBe(true);
+  expect(latest?.reviewTaskId).toBe('active');
+  expect(getSessionPrReviews([], [active])[0]?.reviewing).toBe(true);
+  expect(getSessionPrReviews([], [completed])).toEqual([]);
+});
+
+it('retires the fix action when the PR has merged', () => {
+  const [latest] = getSessionPrReviews(
+    [message],
+    [
+      {
+        taskId: 'review',
+        workflow: 'pr_review',
+        latestRun: { status: RunStatus.Completed },
+        pullRequests: [
+          {
+            url: review.url,
+            number: 42,
+            repository: 'acme/web',
+            status: 'merged',
+          },
+        ],
+      },
+    ],
+  );
+  expect(latest?.offer).toBeNull();
+  expect(latest?.review?.status).toBe('merged');
+});

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/session-pr-reviews.ts
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/session-pr-reviews.ts
@@ -1,0 +1,99 @@
+import {
+  isTaskExecutingTurn,
+  parsePrReviewActionOffer,
+  parseSessionPrReviewUpdate,
+  type PrReviewActionOffer,
+  type SessionPrReviewUpdate,
+} from '@roomote/types';
+import type { SessionReviewTask } from './session-task-panel-context';
+
+export interface SessionReview {
+  key: string;
+  revision: string;
+  review: SessionPrReviewUpdate | null;
+  offer: PrReviewActionOffer | null;
+  reviewTaskId?: string;
+  reviewing?: boolean;
+}
+
+export function getSessionPrReviews(
+  messages: Array<{ id: string; payload: Record<string, unknown> | null }>,
+  tasks: SessionReviewTask[],
+): SessionReview[] {
+  const reviews = new Map<string, SessionReview>();
+  // Messages are in transcript order. Keep the latest update, including
+  // dismissals, so an older pending action cannot reappear underneath it.
+  for (const message of messages) {
+    const review = parseSessionPrReviewUpdate(message.payload);
+    const offer = parsePrReviewActionOffer(message.payload);
+    if (!review && !offer) continue;
+    const key = review?.url ?? offer!.deliveryId;
+    reviews.set(key, {
+      key,
+      revision: message.id,
+      review,
+      offer,
+      reviewTaskId: review?.reviewTaskId,
+    });
+  }
+
+  for (const task of tasks) {
+    const reviewing = isTaskExecutingTurn(
+      task.latestRun?.status,
+      task.latestRun?.taskPhase,
+    );
+    for (const pr of task.pullRequests) {
+      const current = reviews.get(pr.url);
+      if (pr.status === 'merged' || pr.status === 'closed') {
+        if (current?.review) {
+          reviews.set(pr.url, {
+            ...current,
+            review: { ...current.review, status: pr.status },
+            offer: null,
+            reviewing: false,
+          });
+        }
+        continue;
+      }
+      if (
+        task.workflow !== 'pr_review' ||
+        current?.review?.status === 'merged' ||
+        current?.review?.status === 'closed'
+      )
+        continue;
+      // A live review takes precedence over completed review tasks for this PR.
+      if (current?.reviewing) continue;
+      if (current) {
+        reviews.set(pr.url, {
+          ...current,
+          reviewTaskId: reviewing
+            ? task.taskId
+            : (current.reviewTaskId ?? task.taskId),
+          reviewing,
+        });
+      } else if (reviewing && pr.number !== null) {
+        reviews.set(pr.url, {
+          key: pr.url,
+          revision: task.taskId,
+          reviewTaskId: task.taskId,
+          reviewing: true,
+          offer: null,
+          review: {
+            url: pr.url,
+            repository: pr.repository ?? '',
+            number: pr.number,
+            summary: '',
+            findingCount: null,
+            status: 'feedback',
+          },
+        });
+      }
+    }
+  }
+  return [...reviews.values()].filter(
+    ({ offer, reviewing, review }) =>
+      reviewing ||
+      (offer?.status !== 'dismissed' && offer?.status !== 'stale') ||
+      (review && review.status !== 'feedback'),
+  );
+}

--- a/apps/web/src/app/(sandbox)/sessions/[sessionId]/session-task-panel-context.ts
+++ b/apps/web/src/app/(sandbox)/sessions/[sessionId]/session-task-panel-context.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext } from 'react';
+import type { RunStatus } from '@roomote/types';
 
 export const OpenSessionTaskPanelContext = createContext<
   ((taskId: string) => void) | null
@@ -21,6 +22,19 @@ export const SessionRunningTaskCountContext = createContext(0);
 /** Fingerprint of the session's delegated-task state; see
  * `computeTaskStateRevision`. Drives composer-suggestion refreshes. */
 export const SessionTaskStateRevisionContext = createContext('');
+
+export interface SessionReviewTask {
+  taskId: string;
+  workflow: string;
+  latestRun: { status: RunStatus; taskPhase?: string | null } | null;
+  pullRequests: Array<{
+    url: string;
+    number: number | null;
+    repository: string | null;
+    status: string | null;
+  }>;
+}
+export const SessionReviewTasksContext = createContext<SessionReviewTask[]>([]);
 
 export function useOpenSessionTaskPanel() {
   return useContext(OpenSessionTaskPanelContext);

--- a/apps/web/src/components/ai-elements/pr-review-action-offer.tsx
+++ b/apps/web/src/components/ai-elements/pr-review-action-offer.tsx
@@ -24,6 +24,7 @@ export function PrReviewActionOffer({
   className,
   showQuestion = false,
   testId = 'pr-review-action-offer',
+  labels = PR_REVIEW_ACTION_LABELS,
 }: {
   offer: PrReviewActionOfferData;
   onAction: (
@@ -32,6 +33,7 @@ export function PrReviewActionOffer({
   className?: string;
   showQuestion?: boolean;
   testId?: string;
+  labels?: Record<PrReviewActionChoice, string>;
 }) {
   const [status, setStatus] = useState(offer.status);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -60,7 +62,7 @@ export function PrReviewActionOffer({
             disabled={isSubmitting}
             onClick={() => submit('yes')}
           >
-            {PR_REVIEW_ACTION_LABELS.yes}
+            {labels.yes}
           </Button>
           <Button
             size="sm"
@@ -68,7 +70,7 @@ export function PrReviewActionOffer({
             disabled={isSubmitting}
             onClick={() => submit('auto')}
           >
-            {PR_REVIEW_ACTION_LABELS.auto}
+            {labels.auto}
           </Button>
           <Button
             size="sm"
@@ -76,7 +78,7 @@ export function PrReviewActionOffer({
             disabled={isSubmitting}
             onClick={() => submit('dismiss')}
           >
-            {PR_REVIEW_ACTION_LABELS.dismiss}
+            {labels.dismiss}
           </Button>
         </div>
       ) : (

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.test.ts
@@ -696,10 +696,71 @@ describe('deliverFastAgentParentEvent', () => {
     expect(mocks.answerQuestion).toHaveBeenCalledWith(
       expect.objectContaining({
         platformEventTranscriptPayload: {
+          prReview: {
+            url: 'https://github.com/acme/web/pull/42',
+            repository: 'acme/web',
+            number: 42,
+            summary: 'Review feedback remains.',
+            findingCount: null,
+            status: 'feedback',
+          },
           prReviewAction: {
             deliveryId: '22222222-2222-4222-8222-222222222222',
             question: 'Resolve these issues?',
             status: 'pending',
+          },
+        },
+      }),
+    );
+  });
+
+  it('includes approval context without requiring a fix offer', async () => {
+    await deliverFastAgentParentEvent({
+      parent: {
+        sessionId: parent.sessionId,
+        conversation: {
+          surface: 'web',
+          workspaceId: 'user-1',
+          conversationId: 'session-1',
+        },
+      },
+      event: {
+        type: 'pull_request_feedback',
+        feedbackId: 'approved-1',
+        taskId: 'task-1',
+        runId: 42,
+        taskUrl: 'https://roomote.example/task/task-1',
+        reviewTaskId: 'review-42',
+        pullRequest: {
+          provider: 'gitlab',
+          host: 'gitlab.example',
+          repository: 'acme/web',
+          number: 42,
+          title: 'Provider coverage',
+          url: 'https://gitlab.example/acme/web/-/merge_requests/42',
+          status: 'open',
+        },
+        summary: 'No findings remain.',
+        reviewResult: {
+          reviewKind: 'sync',
+          outcome: 'approved',
+          findingCount: 0,
+          approvalStatus: 'approved',
+          headSha: 'abc123',
+        },
+      },
+    });
+    expect(mocks.answerQuestion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platformEventTranscriptPayload: {
+          prReview: {
+            reviewTaskId: 'review-42',
+            url: 'https://gitlab.example/acme/web/-/merge_requests/42',
+            repository: 'acme/web',
+            number: 42,
+            summary: 'No findings remain.',
+            findingCount: 0,
+            status: 'approved',
           },
         },
       }),

--- a/packages/sdk/src/server/lib/fast-agent-parent-event.ts
+++ b/packages/sdk/src/server/lib/fast-agent-parent-event.ts
@@ -232,6 +232,7 @@ export type FastAgentParentEvent =
       suggestedActionQuestion?: string;
       suggestedActionPrompt?: string;
       reviewActionDeliveryId?: string;
+      reviewTaskId?: string;
       reviewResult?: {
         reviewKind: 'initial' | 'sync' | null;
         outcome: string | null;
@@ -2101,16 +2102,44 @@ export async function deliverFastAgentParentEventWithLock(
       params.event.imageArtifactIds?.length
         ? { defaultImageArtifactIds: params.event.imageArtifactIds }
         : {}),
-      ...(params.event.type === 'pull_request_feedback' &&
-      params.event.reviewActionDeliveryId &&
-      params.event.suggestedActionQuestion
+      ...(params.event.type === 'pull_request_feedback' ||
+      params.event.type === 'pull_request_status_changed'
         ? {
             platformEventTranscriptPayload: {
-              prReviewAction: {
-                deliveryId: params.event.reviewActionDeliveryId,
-                question: params.event.suggestedActionQuestion,
-                status: 'pending',
+              prReview: {
+                ...(params.event.type === 'pull_request_feedback' &&
+                params.event.reviewTaskId
+                  ? { reviewTaskId: params.event.reviewTaskId }
+                  : {}),
+                url: params.event.pullRequest.url,
+                repository: params.event.pullRequest.repository,
+                number: params.event.pullRequest.number,
+                summary:
+                  params.event.type === 'pull_request_feedback'
+                    ? params.event.summary
+                    : '',
+                findingCount:
+                  params.event.type === 'pull_request_feedback'
+                    ? (params.event.reviewResult?.findingCount ?? null)
+                    : null,
+                status:
+                  params.event.type === 'pull_request_status_changed'
+                    ? params.event.status
+                    : params.event.reviewResult?.approvalStatus === 'approved'
+                      ? 'approved'
+                      : 'feedback',
               },
+              ...(params.event.type === 'pull_request_feedback' &&
+              params.event.reviewActionDeliveryId &&
+              params.event.suggestedActionQuestion
+                ? {
+                    prReviewAction: {
+                      deliveryId: params.event.reviewActionDeliveryId,
+                      question: params.event.suggestedActionQuestion,
+                      status: 'pending',
+                    },
+                  }
+                : {}),
             },
           }
         : {}),

--- a/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pr-feedback.ts
+++ b/packages/sdk/src/server/lib/task-runs/notify-fast-agent-parent-on-pr-feedback.ts
@@ -190,6 +190,7 @@ export async function notifyFastAgentParentOnPrFeedback(params: {
           }),
           pullRequest,
           summary: params.summary,
+          ...(params.reviewTaskId ? { reviewTaskId: params.reviewTaskId } : {}),
           ...(params.reviewResult ? { reviewResult: params.reviewResult } : {}),
           ...(params.suggestedActionQuestion
             ? { suggestedActionQuestion: params.suggestedActionQuestion }

--- a/packages/types/src/__tests__/pr-review-action.test.ts
+++ b/packages/types/src/__tests__/pr-review-action.test.ts
@@ -2,6 +2,7 @@ import {
   buildPrReviewActionCallbackData,
   parsePrReviewActionCallbackData,
   parsePrReviewActionOffer,
+  parseSessionPrReviewUpdate,
 } from '../pr-review-action';
 
 describe('pr review action callback data', () => {
@@ -50,6 +51,32 @@ describe('pr review action callback data', () => {
     });
     expect(
       parsePrReviewActionOffer({ prReviewAction: { status: 'pending' } }),
+    ).toBeNull();
+  });
+
+  it('accepts provider-neutral review context and rejects unsafe or incomplete data', () => {
+    const review = {
+      url: 'https://gitlab.example/team/repo/-/merge_requests/42',
+      repository: 'team/repo',
+      number: 42,
+      summary: 'Missing tests',
+      findingCount: 1,
+      status: 'feedback',
+    };
+    expect(parseSessionPrReviewUpdate({ prReview: review })).toEqual(review);
+    for (const override of [
+      { url: 'javascript:alert(1)' },
+      { number: -1 },
+      { findingCount: -1 },
+      { findingCount: '2' },
+      { status: 'unknown' },
+    ]) {
+      expect(
+        parseSessionPrReviewUpdate({ prReview: { ...review, ...override } }),
+      ).toBeNull();
+    }
+    expect(
+      parseSessionPrReviewUpdate({ prReview: { status: 'approved' } }),
     ).toBeNull();
   });
 });

--- a/packages/types/src/pr-review-action.ts
+++ b/packages/types/src/pr-review-action.ts
@@ -28,6 +28,45 @@ export interface PrReviewActionOffer {
   status: PrReviewActionOfferStatus;
 }
 
+/** Canonical PR context for session review updates, independent of action offers. */
+export interface SessionPrReviewUpdate {
+  reviewTaskId?: string;
+  url: string;
+  repository: string;
+  number: number;
+  summary: string;
+  findingCount: number | null;
+  status: 'feedback' | 'approved' | 'merged' | 'closed';
+}
+
+export function parseSessionPrReviewUpdate(
+  payload: Record<string, unknown> | null | undefined,
+): SessionPrReviewUpdate | null {
+  const value = payload?.prReview;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const review = value as Record<string, unknown>;
+  if (
+    typeof review.url !== 'string' ||
+    !/^https?:\/\//i.test(review.url) ||
+    typeof review.repository !== 'string' ||
+    !Number.isInteger(review.number) ||
+    Number(review.number) <= 0 ||
+    typeof review.summary !== 'string' ||
+    (review.reviewTaskId !== undefined &&
+      typeof review.reviewTaskId !== 'string') ||
+    !(
+      review.findingCount === null ||
+      (Number.isInteger(review.findingCount) &&
+        Number(review.findingCount) >= 0)
+    ) ||
+    !['feedback', 'approved', 'merged', 'closed'].includes(
+      String(review.status),
+    )
+  )
+    return null;
+  return review as unknown as SessionPrReviewUpdate;
+}
+
 export function parsePrReviewActionOffer(
   payload: Record<string, unknown> | null | undefined,
 ): PrReviewActionOffer | null {


### PR DESCRIPTION
## What changed

PR-review notifications previously accumulated as repeated prose and action offers in the Session transcript. Show the latest review update for each PR in a compact strip above the composer, keeping it visible while the conversation scrolls. Multiple PRs use expandable status rows with one set of actions open at a time.

The strip retains the existing resolve, auto-resolve, and dismiss actions; shows active linked reviews and reported approval/closure; and opens the review task when available, falling back to the provider PR. Review events now carry structured PR context so grouping, finding counts, and links do not depend on parsing agent prose. Structured review notifications leave the scrolling transcript; ordinary conversation stays there. Legacy offers remain usable without inventing missing PR context.

Includes Session docs and Storybook examples for feedback, reviewing, approval, and multiple PRs. No schema changes.

## Screenshots

Real Storybook components in a 420px session pane, using synthetic example data.

### Unresolved feedback — review actions stay above the composer

![Unresolved feedback — review actions stay above the composer](https://github.com/user-attachments/assets/47f1fa95-f2f9-4533-8656-4e681c6b757d)

### Approved — the review collapses to a compact status row

![Approved — the review collapses to a compact status row](https://github.com/user-attachments/assets/515890bc-af7d-46e3-b052-3a27547d4de4)

### Multiple PRs — one expanded set of actions at a time

![Multiple PRs — one expanded set of actions at a time](https://github.com/user-attachments/assets/02607fdf-04e5-4d5e-ae8f-1796fb42cdf2)

## How it was tested

- 136 focused web tests passed across the Session transcript, workspace, review strip/state selection, and existing task review-action rendering.
- 64 SDK tests passed for parent-event delivery and review-feedback forwarding. These mock collaborators; a temporary Vitest config disabled the database global setup and was removed afterward.
- 5 shared review payload/callback tests passed.
- Full pre-push suite passed: Oxlint, residual ESLint, fast type checks, and Knip. Changed files were formatted and git diff checks passed.
- Browser verification with real Storybook components in a 420px pane: pinned positioning while scrolling, fix-action transition, compact approval, and multiple-PR layout.
- No live-provider actions or full database-backed test suite were run.

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is scoped to the Session PR-review presentation
- [x] Lint and type checks pass locally as described above
- [x] Regression tests and visual validation are included
- [x] No secrets or customer data are included
- [ ] If this change should appear in the changelog, I ran pnpm changeset

