### PR TITLE
[Fix] Review handoffs fail with 403 User context required

### DIFF
--- a/apps/api/src/handlers/tasks/__tests__/fastSessionTaskCommunication.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/fastSessionTaskCommunication.test.ts
@@ -361,8 +361,16 @@ describe('Fast session communication through task routes', () => {
     );
     expect(bystanderSend.status).toBe(200);
 
+    // A run without a human driver mints a user-less token. The handler
+    // resolves the actor from the run's acting user, then the task's human
+    // owner; an automation task with neither still has no actor.
+    const orphanTask = await taskFactory.create();
+    const orphanRun = await runFactory.create({
+      taskId: orphanTask.id,
+      actingUserId: null,
+    });
     const deploymentRun: RunTokenContext = {
-      runId: 1,
+      runId: orphanRun.id,
       userId: null,
       principal: 'deployment',
       tokenType: 'run',
@@ -377,6 +385,22 @@ describe('Fast session communication through task routes', () => {
       },
     );
     expect(noActor.status).toBe(403);
+
+    // The same token shape resolves to the task's human owner when one exists.
+    const ownedTask = await taskFactory.create({ initiatorUserId: owner.id });
+    const ownedRun = await runFactory.create({
+      taskId: ownedTask.id,
+      actingUserId: null,
+    });
+    const ownerResolved = await createApp({
+      ...deploymentRun,
+      runId: ownedRun.id,
+    }).request(`/tasks/${session.id}/send_message`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'Resolved through task owner' }),
+    });
+    expect(ownerResolved.status).toBe(200);
 
     mocks.queueReply.mockResolvedValueOnce(false);
     const unavailable = await createApp(userAuth(owner.id)).request(

--- a/apps/api/src/handlers/tasks/__tests__/sendMessageUserContext.test.ts
+++ b/apps/api/src/handlers/tasks/__tests__/sendMessageUserContext.test.ts
@@ -1,0 +1,160 @@
+import { Hono } from 'hono';
+
+import type { RunTokenContext } from '@roomote/types';
+
+import type { Variables } from '../../../types';
+import { mcpAuthMiddleware } from '../../mcp/middleware';
+import { sendMessage } from '../sendMessage';
+import { steerMessage } from '../steerMessage';
+
+const {
+  mockSendMessageToTask,
+  mockSteerMessageToTask,
+  mockTaskRunsFindFirst,
+  mockGetTaskHumanOwnerUserIds,
+} = vi.hoisted(() => ({
+  mockSendMessageToTask: vi.fn(),
+  mockSteerMessageToTask: vi.fn(),
+  mockTaskRunsFindFirst: vi.fn(),
+  mockGetTaskHumanOwnerUserIds: vi.fn(),
+}));
+
+vi.mock('@roomote/db/server', () => ({
+  eq: vi.fn((...args) => ({ type: 'eq', args })),
+  taskRuns: {},
+  getTaskHumanOwnerUserIds: (...args: unknown[]) =>
+    mockGetTaskHumanOwnerUserIds(...args),
+  db: {
+    query: {
+      taskRuns: {
+        findFirst: (...args: unknown[]) => mockTaskRunsFindFirst(...args),
+      },
+    },
+  },
+}));
+
+vi.mock('../sendMessageToTask', () => ({
+  sendMessageToTask: (...args: unknown[]) => mockSendMessageToTask(...args),
+  steerMessageToTask: (...args: unknown[]) => mockSteerMessageToTask(...args),
+}));
+
+vi.mock('../fastSessionCommunication', () => ({
+  sendMessageToFastSessionForUser: vi.fn(),
+}));
+
+function createApp(authContext: RunTokenContext) {
+  const app = new Hono<{ Variables: Variables }>();
+
+  app.use('*', async (c, next) => {
+    c.set('authContext', authContext);
+    await next();
+  });
+  app.use('*', mcpAuthMiddleware);
+  app.post('/tasks/:taskId/send_message', sendMessage);
+  app.post('/tasks/:taskId/steer_message', steerMessage);
+
+  return app;
+}
+
+const userlessRunAuth: RunTokenContext = {
+  runId: 555,
+  userId: null,
+  principal: 'deployment',
+  tokenType: 'run',
+  version: 1,
+};
+
+function post(app: Hono<{ Variables: Variables }>, path: string) {
+  return app.request(
+    new Request(`http://localhost${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ message: 'Review results: looks good' }),
+    }),
+  );
+}
+
+describe('send_message / steer_message user context', () => {
+  beforeEach(() => {
+    mockSendMessageToTask.mockReset();
+    mockSendMessageToTask.mockResolvedValue({ success: true, result: {} });
+    mockSteerMessageToTask.mockReset();
+    mockSteerMessageToTask.mockResolvedValue({ success: true, result: {} });
+    mockTaskRunsFindFirst.mockReset();
+    mockGetTaskHumanOwnerUserIds.mockReset();
+    mockGetTaskHumanOwnerUserIds.mockResolvedValue([]);
+  });
+
+  it('send_message resolves the current acting user for a userless run token', async () => {
+    mockTaskRunsFindFirst.mockResolvedValue({
+      actingUserId: 'user-current',
+      taskId: 'task-review',
+    });
+
+    const response = await post(
+      createApp(userlessRunAuth),
+      '/tasks/task-impl/send_message',
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSendMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: 'task-impl', userId: 'user-current' }),
+    );
+  });
+
+  it('send_message falls back to the task human owner when the run has no acting user', async () => {
+    mockTaskRunsFindFirst.mockResolvedValue({
+      actingUserId: null,
+      taskId: 'task-review',
+    });
+    mockGetTaskHumanOwnerUserIds.mockResolvedValue(['user-owner']);
+
+    const response = await post(
+      createApp(userlessRunAuth),
+      '/tasks/task-impl/send_message',
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockGetTaskHumanOwnerUserIds).toHaveBeenCalledWith(
+      expect.anything(),
+      'task-review',
+    );
+    expect(mockSendMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-owner' }),
+    );
+  });
+
+  it('steer_message resolves the run user the same way', async () => {
+    mockTaskRunsFindFirst.mockResolvedValue({
+      actingUserId: null,
+      taskId: 'task-review',
+    });
+    mockGetTaskHumanOwnerUserIds.mockResolvedValue(['user-owner']);
+
+    const response = await post(
+      createApp(userlessRunAuth),
+      '/tasks/task-impl/steer_message',
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSteerMessageToTask).toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: 'task-impl', userId: 'user-owner' }),
+    );
+  });
+
+  it('still rejects when no user can be resolved for the run', async () => {
+    mockTaskRunsFindFirst.mockResolvedValue({
+      actingUserId: null,
+      taskId: 'task-review',
+    });
+
+    const response = await post(
+      createApp(userlessRunAuth),
+      '/tasks/task-impl/send_message',
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'User context required' });
+    expect(mockSendMessageToTask).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/handlers/tasks/sendMessage.ts
+++ b/apps/api/src/handlers/tasks/sendMessage.ts
@@ -2,7 +2,7 @@ import type { Context } from 'hono';
 import { isEnvVarRequestFulfillmentClientMessageId } from '@roomote/types';
 
 import type { Variables } from '../../types';
-import type { McpAuth } from '../mcp/middleware';
+import { resolveMcpTaskOrSessionUserId, type McpAuth } from '../mcp/middleware';
 import {
   type SendMessageSenderMode,
   sendMessageToTask,
@@ -82,7 +82,11 @@ function parseOptionalControlString(
 export async function sendMessage(
   c: Context<{ Variables: Variables & { mcpAuth: McpAuth } }>,
 ): Promise<Response> {
-  const auth = c.get('mcpAuth');
+  const requestAuth = c.get('mcpAuth');
+  const auth = {
+    ...requestAuth,
+    userId: await resolveMcpTaskOrSessionUserId(requestAuth),
+  };
 
   if (!auth.userId) {
     return c.json({ error: 'User context required' }, 403);

--- a/apps/api/src/handlers/tasks/steerMessage.ts
+++ b/apps/api/src/handlers/tasks/steerMessage.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono';
 
 import type { Variables } from '../../types';
-import type { McpAuth } from '../mcp/middleware';
+import { resolveMcpTaskOrSessionUserId, type McpAuth } from '../mcp/middleware';
 import { steerMessageToTask } from './sendMessageToTask';
 import { sendMessageToFastSessionForUser } from './fastSessionCommunication';
 
@@ -13,7 +13,11 @@ import { sendMessageToFastSessionForUser } from './fastSessionCommunication';
 export async function steerMessage(
   c: Context<{ Variables: Variables & { mcpAuth: McpAuth } }>,
 ): Promise<Response> {
-  const auth = c.get('mcpAuth');
+  const requestAuth = c.get('mcpAuth');
+  const auth = {
+    ...requestAuth,
+    userId: await resolveMcpTaskOrSessionUserId(requestAuth),
+  };
 
   if (!auth.userId) {
     return c.json({ error: 'User context required' }, 403);


### PR DESCRIPTION
## Problem

A PR review launched without a human driver runs with a token that carries no user claim (the controller intentionally mints it that way). When the review tried to hand its results to the linked implementation task, the worker's `send_message` tool got back:

```
Failed to send message: 403 User context required
```

The GitHub review itself was unaffected; only the linked-task notification was dropped.

## Cause

#1981 taught `launchTask` and the Session handlers to resolve the user from the run (current acting user, then the task's human owner) instead of the mint-time token claim. `send_message` and `steer_message` never got that change and still rejected on the raw token user before any handoff logic ran.

## Fix

- `sendMessage` and `steerMessage` now resolve the user via `resolveMcpTaskOrSessionUserId`, matching `launchTask`. The 403 remains for runs where nothing resolves.
- Added `sendMessageUserContext.test.ts` covering acting-user resolution, human-owner fallback, steer parity, and the still-403 case.

## Validation

- Targeted vitest: new test file + `launchTask.test.ts` pass
- `tsc --noEmit` for `@roomote/api` clean
- oxfmt clean