### PR TITLE
[Fix] Sandbox integration calls send args: null on gpt-5.x models

### DIFF
--- a/.changeset/integration-tool-args-required.md
+++ b/.changeset/integration-tool-args-required.md
@@ -1,0 +1,5 @@
+---
+'roomote': patch
+---
+
+Fix on-demand integration calls from sandbox tasks: `call_integration_tool` now declares `args` as a required, non-recursive object on both the member MCP server and Fast, so gpt-5.x models stop sending `args: null` and Sentry, Linear, and Notion lookups run again.

--- a/apps/worker/src/mcp/roomote-mcp-server/__tests__/on-demand-integrations-registration.test.ts
+++ b/apps/worker/src/mcp/roomote-mcp-server/__tests__/on-demand-integrations-registration.test.ts
@@ -43,7 +43,7 @@ describe('roomote MCP on-demand integration tool registration', () => {
     expect(tools.call_integration_tool).toBeDefined();
   });
 
-  it('exposes integration call args as an object with arbitrary JSON values', async () => {
+  it('exposes integration call args as a required, ref-free object', async () => {
     process.env.ROOMOTE_ON_DEMAND_MCP_CATALOG_PATH = '/tmp/catalog.json';
     const { roomoteMcpServer } = await import('../index.js');
     const [clientTransport, serverTransport] =
@@ -59,17 +59,21 @@ describe('roomote MCP on-demand integration tool registration', () => {
       );
       const argsSchema = callTool?.inputSchema.properties?.args as
         | {
-            anyOf?: Array<{
-              type?: string;
-              additionalProperties?: { anyOf?: Array<{ type?: string }> };
-            }>;
+            type?: string;
+            anyOf?: unknown[];
+            additionalProperties?: { anyOf?: Array<{ type?: string }> };
           }
         | undefined;
-      const objectSchema = argsSchema?.anyOf?.find(
-        (schema) => schema.type === 'object',
-      );
 
-      expect(objectSchema?.additionalProperties?.anyOf).toEqual(
+      // The member server makes optional fields nullable, which would turn
+      // `args` into `anyOf [object, null]`; gpt-5.x models then send null on
+      // every call. A recursive value schema would serialize to `$ref`s that
+      // downstream schema rewrites leave dangling. Neither may come back.
+      expect(callTool?.inputSchema.required).toContain('args');
+      expect(argsSchema?.type).toBe('object');
+      expect(argsSchema?.anyOf).toBeUndefined();
+      expect(JSON.stringify(callTool?.inputSchema)).not.toContain('$ref');
+      expect(argsSchema?.additionalProperties?.anyOf).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ type: 'string' }),
           expect.objectContaining({ type: 'object' }),

--- a/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-schemas.test.ts
+++ b/packages/cloud-agents/src/server/fast-agent/__tests__/fast-agent-native-tool-schemas.test.ts
@@ -368,7 +368,6 @@ describe('Fast native tool schemas as OpenAI receives them', () => {
     const serverSchema = z.object(CALL_INTEGRATION_TOOL_TOOL.inputSchema);
     const base = { integrationId: 'example', toolName: 'nested_tool' };
     for (const args of [
-      undefined,
       {},
       {
         text: 'value',
@@ -395,6 +394,10 @@ describe('Fast native tool schemas as OpenAI receives them', () => {
     for (const args of [null, 'text', [], 42, false]) {
       expect(validate({ ...base, args })).toBe(false);
     }
+    // Omitting args is rejected too: the field is required so the provider
+    // schema never carries a null alternative.
+    expect(validate(base)).toBe(false);
+    expect(serverSchema.safeParse(base).success).toBe(false);
   });
 
   it('preserves required Sentry organization scope through generated tool execution and server parsing', async () => {

--- a/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
+++ b/packages/cloud-agents/src/server/fast-agent/fast-agent-native-tool-bridge.ts
@@ -463,7 +463,9 @@ export default {
     toolName: z.string().min(1).describe(${JSON.stringify(CALL_INTEGRATION_TOOL_ARG_DESCRIPTIONS.toolName)}),
     // OpenCode renames $defs without rewriting refs. Keep JSON value types
     // concrete but non-recursive; nested values are validated server-side.
-    args: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(z.unknown()), z.record(z.string(), z.unknown())])).optional().describe(${JSON.stringify(CALL_INTEGRATION_TOOL_ARG_DESCRIPTIONS.args)}),
+    // Required (not optional) so no provider ever sees a null alternative
+    // that gpt-5.x models prefer over filling in an object.
+    args: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), z.null(), z.array(z.unknown()), z.record(z.string(), z.unknown())])).describe(${JSON.stringify(CALL_INTEGRATION_TOOL_ARG_DESCRIPTIONS.args)}),
   },
   execute: (args, context) => invoke(${JSON.stringify(CALL_INTEGRATION_TOOL_TOOL.name)}, args, context),
 }

--- a/packages/types/src/integration-tool-lookup.ts
+++ b/packages/types/src/integration-tool-lookup.ts
@@ -77,19 +77,24 @@ export const FIND_INTEGRATION_TOOLS_ARG_DESCRIPTIONS = {
 export const CALL_INTEGRATION_TOOL_ARG_DESCRIPTIONS = {
   integrationId: `Exact on-demand integration id from ${FAST_AGENT_NATIVE_TOOL_NAMES.findIntegrationTools}`,
   toolName: 'Exact tool name on that integration',
-  args: "Tool arguments matching the tool's input schema",
+  args: "Tool arguments matching the tool's input schema. Pass {} when the tool takes none.",
 } as const;
 
-const integrationToolArgumentValueSchema: z.ZodType<unknown> = z.lazy(() =>
-  z.union([
-    z.string(),
-    z.number(),
-    z.boolean(),
-    z.null(),
-    z.array(integrationToolArgumentValueSchema),
-    z.record(integrationToolArgumentValueSchema),
-  ]),
-);
+/**
+ * Argument values stay concrete but non-recursive on the wire. A recursive
+ * `z.lazy` schema serializes to JSON-pointer `$ref`s that OpenCode and
+ * provider schema rewrites leave dangling; gpt-5.x models then read `args`
+ * as unsatisfiable and send `null` on every call. Nested values are
+ * validated by the integration's own schema when the tool runs.
+ */
+const integrationToolArgumentValueSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null(),
+  z.array(z.unknown()),
+  z.record(z.unknown()),
+]);
 
 /**
  * The on-demand integration tools as the model sees them on every surface.
@@ -154,9 +159,12 @@ export const CALL_INTEGRATION_TOOL_TOOL = {
       .trim()
       .min(1)
       .describe(CALL_INTEGRATION_TOOL_ARG_DESCRIPTIONS.toolName),
+    // Required on purpose: an optional field becomes `anyOf [object, null]`
+    // on the member MCP server (see NullableOptionalsMcpServer), and gpt-5.x
+    // models take the null branch for a property-less object even when the
+    // integration tool needs arguments.
     args: z
       .record(integrationToolArgumentValueSchema)
-      .optional()
       .describe(CALL_INTEGRATION_TOOL_ARG_DESCRIPTIONS.args),
   },
   annotations: {


### PR DESCRIPTION
## What changed

`call_integration_tool` now declares `args` as a **required, non-recursive** record on both surfaces that expose it: the shared MCP schema in `packages/types/src/integration-tool-lookup.ts` (registered by the sandbox member server) and the Fast custom-tool wrapper. The value schema uses the same concrete JSON union #2295 introduced for Fast. The description tells the model to pass `{}` when a tool takes no arguments.

Tests now assert that the live MCP schema lists `args` as required, has no `anyOf` at the `args` level, and contains no `$ref`; the Fast schema test asserts that omitting `args` is rejected by both the generated OpenCode schema and the server-side parse.

## Why

Since v1.3.0 every sandbox `call_integration_tool` call from gpt-5.x models has carried `args: null`, so every scoped Sentry, Linear, and Notion lookup fails validation. Agents then file "integration arguments cannot be passed" platform-issue reports and post setup-blocker messages to Slack. On one deployment real arguments went from ~250/day (Sep 3) to 7/day on v1.3.0 and 0/day from v1.3.1 onward. OpenCode is pinned, so it is not the variable.

Two schema changes caused it:

1. #2176 made optional MCP fields nullable, turning `args` into `anyOf [object, null]`.
2. #2237 made the argument value schema a recursive `z.lazy`, which zod-to-json-schema serializes as `$ref: "#/properties/args/anyOf/0/additionalProperties"`.

#2295 fixed the recursion for the Fast wrapper only and left the shared MCP schema unchanged.

## Verification

Replayed the model's exact situation through OpenRouter (`openai/gpt-5.6-sol`, forced `call_integration_tool`, `find_projects` schema in context, 6 samples per variant):

| `args` schema variant | `args` sent |
| --- | --- |
| Production today: `anyOf [object, null]` + recursive `$ref` | `null` 6/6 |
| v1.3.0 shape: `anyOf [object, null]`, no recursion | `null` 6/6 |
| Optional + non-recursive: `anyOf [object-union, null]` | `null` 6/6 |
| **This PR: required, non-recursive** | `{"organizationSlug": "…"}` 6/6 |

Any null alternative is enough for the model to take it, which is why `args` is required rather than only non-recursive. Zero-argument tools worked before this change because models sent `{}` or omitted the field; with `{}` they still work, and the server handler keeps its `?? {}` fallback.

Targeted suites pass: worker `on-demand-integrations-registration` and `sentry-on-demand-dispatch`, cloud-agents `fast-agent-native-tool-schemas`, `fast-agent-native-tool-bridge`, `fast-agent-integration-broker`, the Fast service integration-tool cases, and all `@roomote/types` tests. `pnpm check-types:fast` passes.