### PR TITLE
[Fix] Task model chip shows built-in reasoning level before role defaults load

### DIFF
--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.client.test.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.client.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TaskRunDetail } from '@/lib/server/task-runs';
+
+const { launchModelsData, useMutationMock, useQueryMock } = vi.hoisted(() => ({
+  launchModelsData: {
+    current: null as {
+      defaultModelId: string;
+      defaultReasoningEffort: string;
+      models: Array<{ id: string; displayName: string }>;
+    } | null,
+  },
+  useMutationMock: vi.fn(),
+  useQueryMock: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: useMutationMock,
+  useQuery: useQueryMock,
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('@/trpc/client', () => ({
+  useTRPC: () => ({
+    taskModels: {
+      roleDefaults: {
+        queryOptions: vi.fn((input, options) => ({ input, ...options })),
+      },
+    },
+    sandboxSession: {
+      updateTaskModelSelection: {
+        mutationOptions: vi.fn((options) => options),
+      },
+      byTaskId: { queryKey: vi.fn(() => ['sandboxSession']) },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/task-models/useLaunchTaskModels', () => ({
+  useLaunchTaskModels: () => ({
+    data: launchModelsData.current,
+    isPending: launchModelsData.current === null,
+  }),
+}));
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }));
+
+import { TaskModelSwitcher } from './TaskModelSwitcher';
+
+const taskRun = {
+  id: 6500,
+  payload: {
+    harnessModelOverrides: { 'opencode-server': 'openai/gpt-6-astra' },
+  },
+} as unknown as TaskRunDetail;
+
+describe('TaskModelSwitcher', () => {
+  beforeEach(() => {
+    useMutationMock.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    // Role defaults are gated on the popover being open, so the closed chip
+    // renders before that query has any data.
+    useQueryMock.mockReturnValue({ data: undefined });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+    launchModelsData.current = null;
+  });
+
+  it('shows the deployment coding level on the closed chip when the run has no per-task level', () => {
+    launchModelsData.current = {
+      defaultModelId: 'openai/gpt-6-astra',
+      defaultReasoningEffort: 'low',
+      models: [{ id: 'openai/gpt-6-astra', displayName: 'GPT-6 Astra' }],
+    };
+
+    render(<TaskModelSwitcher taskRun={taskRun} />);
+
+    const chip = screen.getByRole('button', { name: 'Models for this task' });
+    expect(chip).toHaveTextContent('GPT-6 Astra');
+    expect(chip).toHaveTextContent('Low');
+    expect(chip).not.toHaveTextContent('Medium');
+  });
+
+  it('prefers the per-task level stamped on the run payload', () => {
+    launchModelsData.current = {
+      defaultModelId: 'openai/gpt-6-astra',
+      defaultReasoningEffort: 'low',
+      models: [{ id: 'openai/gpt-6-astra', displayName: 'GPT-6 Astra' }],
+    };
+
+    render(
+      <TaskModelSwitcher
+        taskRun={
+          {
+            ...taskRun,
+            payload: { ...taskRun.payload, reasoningEffort: 'high' },
+          } as unknown as TaskRunDetail
+        }
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Models for this task' }),
+    ).toHaveTextContent('High');
+  });
+});

--- a/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
+++ b/apps/web/src/app/(sandbox)/task/[taskId]/prompt-input/TaskModelSwitcher.tsx
@@ -176,11 +176,20 @@ export function TaskModelSwitcher({
     model: payloadCodingModel ?? null,
     reasoningEffort: payloadCodingEffort,
   };
+  // Role defaults only load once the popover opens, but the chip renders
+  // before that. Fall back to the launch options (already loaded for display
+  // names), which carry the deployment's coding model and reasoning level,
+  // so the closed chip does not show the built-in constant instead of the
+  // configured level.
   const effectiveCodingModel =
-    codingSelection.model ?? roleDefaults?.defaultModelId ?? null;
+    codingSelection.model ??
+    roleDefaults?.defaultModelId ??
+    launchModels?.defaultModelId ??
+    null;
   const effectiveCodingEffort =
     codingSelection.reasoningEffort ??
     roleDefaults?.roles.coding.reasoningEffort ??
+    launchModels?.defaultReasoningEffort ??
     DEFAULT_MODEL_ROLE_REASONING_EFFORTS.coding;
 
   const hasRoleOverrides = useMemo(


### PR DESCRIPTION
## Summary

The per-task model chip in the task composer showed **Medium** on freshly launched tasks even when the deployment's coding model was configured at **Low**. Opening the popover flipped the label to Low.

Cause: the chip's fallback chain was `payload.reasoningEffort` → `taskModels.roleDefaults` → the built-in coding constant (`medium`). The `roleDefaults` query is gated on the popover being open, and fresh launches at the deployment default model do not stamp a per-task level onto the run payload, so the closed chip fell through to the constant.

Fix: fall back to `taskModels.launchOptions` (already loaded by the switcher for model display names), which carries the deployment's coding model and reasoning level, before the built-in constant. Applied to both the model and the level so the closed chip matches what the run actually uses.

## Validation

- New client test `TaskModelSwitcher.client.test.tsx`: the closed chip shows the launch-options level when the payload has none, and a payload-stamped level still wins. The first case fails without the fix.
- `tsc --noEmit`, oxlint, oxfmt, and residual ESLint clean on the changed files; pre-push suite passed.