### PR TITLE
[Feat] Refresh task memories with pull request outcomes

### DIFF
--- a/.changeset/memory-pr-outcome-loop.md
+++ b/.changeset/memory-pr-outcome-loop.md
@@ -1,0 +1,7 @@
+---
+'@roomote/db': patch
+'@roomote/sdk': patch
+'@roomote/bullmq': patch
+---
+
+Refresh a task's Memory pages when a pull request it opened merges or closes unmerged, so recall can tell work that shipped from work that was abandoned.

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
@@ -96,6 +96,7 @@ import {
   isBrainRateLimited,
   postToBrain,
   redactBrainText,
+  summarizePullRequestOutcome,
 } from '../brain-outbox-drain';
 
 describe('PR fact resume cursor', () => {
@@ -480,6 +481,84 @@ describe('task memory page identity', () => {
     expect(page.content).toMatch(
       /^---\ntype: task-memory\ntitle: "[^"]+"\ncreated: 2026-08-13T10:00:00\.000Z\n/,
     );
+  });
+});
+
+describe('task memory pull request outcomes', () => {
+  const base = {
+    runId: 7,
+    taskId: 'task-1',
+    taskTitle: 'Ship the fix',
+    completedAt: new Date('2026-08-13T10:00:00Z'),
+    environmentName: null,
+    agentSummary: 'Opened a PR with the durable approach.',
+  };
+  const pr = {
+    repository: 'owner/repo',
+    prNumber: 42,
+    prTitle: 'Serialize the writer',
+    prUrl: 'https://example.test/owner/repo/pull/42',
+  };
+
+  it('stamps a merged outcome the completion-time summary could not know', () => {
+    const page = buildMemoryPage({
+      ...base,
+      pullRequests: [{ ...pr, status: 'merged' }],
+    });
+
+    expect(page.content).toContain('\npr_outcome: merged\n');
+    expect(page.content).toContain(
+      '- owner/repo#42: Serialize the writer (https://example.test/owner/repo/pull/42): merged',
+    );
+    expect(page.content).toContain(
+      'Outcome: the pull request was merged, so this work shipped.',
+    );
+  });
+
+  it('records work that did not ship when every PR closed unmerged', () => {
+    const page = buildMemoryPage({
+      ...base,
+      pullRequests: [
+        { ...pr, status: 'closed' },
+        { ...pr, prNumber: 43, status: 'closed' },
+      ],
+    });
+
+    expect(page.content).toContain('\npr_outcome: closed\n');
+    expect(page.content).toContain(
+      'Outcome: the pull requests closed without merging, so this work did not ship as written.',
+    );
+  });
+
+  it('treats any merge as shipped even when a sibling PR was closed', () => {
+    expect(
+      summarizePullRequestOutcome([{ status: 'closed' }, { status: 'merged' }]),
+    ).toBe('merged');
+  });
+
+  it('does not claim an outcome for open, draft, or unknown status', () => {
+    expect(summarizePullRequestOutcome([{ status: 'open' }])).toBe('open');
+    expect(summarizePullRequestOutcome([{ status: 'draft' }])).toBe('open');
+    expect(summarizePullRequestOutcome([{ status: null }])).toBe('open');
+    expect(summarizePullRequestOutcome([])).toBeNull();
+
+    const page = buildMemoryPage({
+      ...base,
+      pullRequests: [{ ...pr, status: null }],
+    });
+
+    expect(page.content).toContain('\npr_outcome: open\n');
+    expect(page.content).toContain(': status unknown');
+    expect(page.content).toContain(
+      'Outcome: the pull request was still open when this memory was last refreshed.',
+    );
+  });
+
+  it('omits the outcome field entirely when the task opened no PR', () => {
+    const page = buildMemoryPage({ ...base, pullRequests: [] });
+
+    expect(page.content).not.toContain('pr_outcome');
+    expect(page.content).not.toContain('## Pull requests');
   });
 });
 

--- a/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
+++ b/apps/bullmq/src/scheduled-jobs/__tests__/brain-outbox-drain.test.ts
@@ -536,10 +536,35 @@ describe('task memory pull request outcomes', () => {
     ).toBe('merged');
   });
 
-  it('does not claim an outcome for open, draft, or unknown status', () => {
+  it('reports open and draft PRs as not yet an outcome', () => {
     expect(summarizePullRequestOutcome([{ status: 'open' }])).toBe('open');
     expect(summarizePullRequestOutcome([{ status: 'draft' }])).toBe('open');
-    expect(summarizePullRequestOutcome([{ status: null }])).toBe('open');
+    expect(
+      summarizePullRequestOutcome([{ status: 'closed' }, { status: 'open' }]),
+    ).toBe('open');
+
+    const page = buildMemoryPage({
+      ...base,
+      pullRequests: [{ ...pr, status: 'open' }],
+    });
+
+    expect(page.content).toContain('\npr_outcome: open\n');
+    expect(page.content).toContain(
+      'Outcome: the pull request was still open when this memory was last refreshed.',
+    );
+  });
+
+  it('keeps a never-observed status unknown instead of calling it open', () => {
+    // A failed details fetch leaves the association's status null. That PR
+    // may already be merged or closed, so the page must not claim otherwise.
+    expect(summarizePullRequestOutcome([{ status: null }])).toBeNull();
+    expect(summarizePullRequestOutcome([{}])).toBeNull();
+    expect(
+      summarizePullRequestOutcome([{ status: 'closed' }, { status: null }]),
+    ).toBeNull();
+    expect(
+      summarizePullRequestOutcome([{ status: null }, { status: 'merged' }]),
+    ).toBe('merged');
     expect(summarizePullRequestOutcome([])).toBeNull();
 
     const page = buildMemoryPage({
@@ -547,11 +572,10 @@ describe('task memory pull request outcomes', () => {
       pullRequests: [{ ...pr, status: null }],
     });
 
-    expect(page.content).toContain('\npr_outcome: open\n');
+    expect(page.content).not.toContain('pr_outcome');
     expect(page.content).toContain(': status unknown');
-    expect(page.content).toContain(
-      'Outcome: the pull request was still open when this memory was last refreshed.',
-    );
+    expect(page.content).not.toContain('Outcome:');
+    expect(page.content).toContain('## Pull requests');
   });
 
   it('omits the outcome field entirely when the task opened no PR', () => {

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -238,7 +238,10 @@ export async function postToBrain(
  * One word for what became of a task's pull requests, for the page
  * frontmatter. Merged wins because shipped work is what later recall should
  * weight; a task whose every PR closed unmerged is the failure worth
- * remembering; anything still open is not an outcome yet.
+ * remembering; anything still open is not an outcome yet. A status that was
+ * never observed (the details fetch failed and the row kept its null) is not
+ * "open": the page says nothing about the outcome until one is known, so a PR
+ * that was already terminal when it went unfetched is never recorded as open.
  */
 type TaskPullRequestOutcome = 'merged' | 'closed' | 'open';
 
@@ -251,6 +254,10 @@ export function summarizePullRequestOutcome(
 
   if (pullRequests.some((pr) => pr.status === 'merged')) {
     return 'merged';
+  }
+
+  if (pullRequests.some((pr) => pr.status == null)) {
+    return null;
   }
 
   if (pullRequests.every((pr) => pr.status === 'closed')) {
@@ -278,10 +285,10 @@ function describePullRequestStatus(
 }
 
 function describePullRequestOutcome(
-  outcome: TaskPullRequestOutcome | null,
+  outcome: TaskPullRequestOutcome,
   count: number,
 ): string {
-  const noun = count === 1 ? 'The pull request' : 'The pull requests';
+  const noun = count === 1 ? 'the pull request' : 'the pull requests';
 
   switch (outcome) {
     case 'merged':
@@ -289,9 +296,9 @@ function describePullRequestOutcome(
         ? 'Outcome: the pull request was merged, so this work shipped.'
         : 'Outcome: at least one pull request was merged, so this work shipped.';
     case 'closed':
-      return `Outcome: ${noun.toLowerCase()} closed without merging, so this work did not ship as written. Treat the approach with that in mind.`;
-    default:
-      return `Outcome: ${noun.toLowerCase()} ${count === 1 ? 'was' : 'were'} still open when this memory was last refreshed.`;
+      return `Outcome: ${noun} closed without merging, so this work did not ship as written. Treat the approach with that in mind.`;
+    case 'open':
+      return `Outcome: ${noun} ${count === 1 ? 'was' : 'were'} still open when this memory was last refreshed.`;
   }
 }
 
@@ -371,8 +378,12 @@ export function buildMemoryPage(input: {
           '',
           ...prLines,
           '',
-          describePullRequestOutcome(outcome, input.pullRequests.length),
-          '',
+          ...(outcome
+            ? [
+                describePullRequestOutcome(outcome, input.pullRequests.length),
+                '',
+              ]
+            : []),
         ]
       : []),
   ].join('\n');

--- a/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
+++ b/apps/bullmq/src/scheduled-jobs/brain-outbox-drain.ts
@@ -36,6 +36,7 @@ import {
 import {
   BRAIN_COLLECTOR_IDS,
   BRAIN_PAGE_TYPES,
+  type PullRequestStatus,
   RunStatus,
   brainNamespacePrefix,
   getLinkedEnvironmentIdFromPayload,
@@ -234,6 +235,67 @@ export async function postToBrain(
 }
 
 /**
+ * One word for what became of a task's pull requests, for the page
+ * frontmatter. Merged wins because shipped work is what later recall should
+ * weight; a task whose every PR closed unmerged is the failure worth
+ * remembering; anything still open is not an outcome yet.
+ */
+type TaskPullRequestOutcome = 'merged' | 'closed' | 'open';
+
+export function summarizePullRequestOutcome(
+  pullRequests: Array<{ status?: PullRequestStatus | null }>,
+): TaskPullRequestOutcome | null {
+  if (pullRequests.length === 0) {
+    return null;
+  }
+
+  if (pullRequests.some((pr) => pr.status === 'merged')) {
+    return 'merged';
+  }
+
+  if (pullRequests.every((pr) => pr.status === 'closed')) {
+    return 'closed';
+  }
+
+  return 'open';
+}
+
+function describePullRequestStatus(
+  status: PullRequestStatus | null | undefined,
+): string {
+  switch (status) {
+    case 'merged':
+      return 'merged';
+    case 'closed':
+      return 'closed without merging';
+    case 'draft':
+      return 'still open as a draft';
+    case 'open':
+      return 'still open';
+    default:
+      return 'status unknown';
+  }
+}
+
+function describePullRequestOutcome(
+  outcome: TaskPullRequestOutcome | null,
+  count: number,
+): string {
+  const noun = count === 1 ? 'The pull request' : 'The pull requests';
+
+  switch (outcome) {
+    case 'merged':
+      return count === 1
+        ? 'Outcome: the pull request was merged, so this work shipped.'
+        : 'Outcome: at least one pull request was merged, so this work shipped.';
+    case 'closed':
+      return `Outcome: ${noun.toLowerCase()} closed without merging, so this work did not ship as written. Treat the approach with that in mind.`;
+    default:
+      return `Outcome: ${noun.toLowerCase()} ${count === 1 ? 'was' : 'were'} still open when this memory was last refreshed.`;
+  }
+}
+
+/**
  * Build the memory page for a completed run. Deliberately deterministic and
  * conservative: only structured, known-safe fields (title, repos, PRs,
  * timestamps, provenance). LLM distillation of decisions/rationale layers on
@@ -251,18 +313,20 @@ export function buildMemoryPage(input: {
     prNumber: number | null;
     prTitle: string | null;
     prUrl: string;
+    status?: PullRequestStatus | null;
   }>;
 }): IngestPage {
   const completedAtIso = input.completedAt?.toISOString();
   const completed = completedAtIso ?? 'unknown';
   const completedDate = completedAtIso?.slice(0, 10);
+  const outcome = summarizePullRequestOutcome(input.pullRequests);
   const prLines = input.pullRequests.map((pr) => {
     const label =
       pr.repository && pr.prNumber
         ? `${pr.repository}#${pr.prNumber}`
         : pr.prUrl;
 
-    return `- ${label}${pr.prTitle ? `: ${pr.prTitle}` : ''} (${pr.prUrl})`;
+    return `- ${label}${pr.prTitle ? `: ${pr.prTitle}` : ''} (${pr.prUrl}): ${describePullRequestStatus(pr.status)}`;
   });
 
   const content = [
@@ -285,6 +349,11 @@ export function buildMemoryPage(input: {
         // retrieval (gbrain sources) or admin triage later without
         // re-ingesting.
         input.environmentName && `environment: ${input.environmentName}`,
+        // What became of the work, as of the latest ingestion. The agent's
+        // summary is written at completion and cannot know this; the page is
+        // re-put when a linked pull request merges or closes so recall can
+        // tell shipped work from abandoned work.
+        outcome && `pr_outcome: ${outcome}`,
         'provenance: roomote-task-memory',
       ],
     }),
@@ -296,7 +365,16 @@ export function buildMemoryPage(input: {
     ...(input.agentSummary
       ? [input.agentSummary, '']
       : ['## Outcome', '', `Task completed at ${completed}.`, '']),
-    ...(prLines.length > 0 ? ['## Pull requests', '', ...prLines, ''] : []),
+    ...(prLines.length > 0
+      ? [
+          '## Pull requests',
+          '',
+          ...prLines,
+          '',
+          describePullRequestOutcome(outcome, input.pullRequests.length),
+          '',
+        ]
+      : []),
   ].join('\n');
 
   return {
@@ -594,6 +672,7 @@ async function drainOneBatch(connection: {
             prNumber: pr.prNumber,
             prTitle: pr.prTitle,
             prUrl: pr.prUrl,
+            status: pr.status,
           })),
         });
 

--- a/apps/docs/memory.mdx
+++ b/apps/docs/memory.mdx
@@ -18,7 +18,10 @@ Roomote task.
 Roomote fills Memory from what it can already see:
 
 - **completed Roomote tasks**, including a short memory the agent writes about
-  its own work: what it decided, why, and what is still open
+  its own work: what it decided, why, and what is still open. When a pull
+  request the task opened later merges or closes unmerged, the task's memory is
+  refreshed with that outcome, so recall can tell work that shipped from work
+  that was abandoned
 - **pull requests** from your connected source-control provider
 - **public Slack channels** the Roomote bot has been added to
 - **public Discord server channels and active public threads** the Roomote bot

--- a/packages/db/src/lib/__tests__/brain.test.ts
+++ b/packages/db/src/lib/__tests__/brain.test.ts
@@ -26,6 +26,7 @@ import {
   settleBrainMemoryEvent,
   maybeEnqueueBrainMemoryEvent,
   saveBrainAgentSummary,
+  requeueBrainMemoryEventsForTasks,
   resetBrainIngestionState,
   canonicalizeBrainCollectorItemSlugs,
   deleteBrainCollectorItems,
@@ -601,6 +602,87 @@ describe('saveBrainAgentSummary', () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]?.agentSummary).toBe('written before finish');
+  });
+});
+
+describe('requeueBrainMemoryEventsForTasks', () => {
+  it('hands settled memories back with a fresh budget and a bumped revision', async () => {
+    const run = await makeCompletedRun();
+    await maybeEnqueueBrainMemoryEvent(db, run.id);
+    const [claimed] = await claimPendingBrainMemoryEvents(db, 10);
+    await settleBrainMemoryEvent(db, claimed!.id, claimed!.revision, 'done');
+
+    const touched = await requeueBrainMemoryEventsForTasks(db, [run.taskId]);
+
+    const [event] = await db
+      .select()
+      .from(brainMemoryEvents)
+      .where(eq(brainMemoryEvents.runId, run.id));
+
+    expect(touched).toBe(1);
+    expect(event?.status).toBe('pending');
+    expect(event?.attempts).toBe(0);
+    expect(event?.revision).toBe(claimed!.revision + 1);
+  });
+
+  it('creates the row for a completed run that never had one', async () => {
+    const run = await makeCompletedRun();
+
+    const touched = await requeueBrainMemoryEventsForTasks(db, [run.taskId]);
+
+    const events = await db
+      .select()
+      .from(brainMemoryEvents)
+      .where(eq(brainMemoryEvents.runId, run.id));
+
+    expect(touched).toBe(1);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.status).toBe('pending');
+  });
+
+  it('leaves a claimed row with its single writer and fences its completion', async () => {
+    const run = await makeCompletedRun();
+    await maybeEnqueueBrainMemoryEvent(db, run.id);
+    const claimed = (await claimPendingBrainMemoryEvents(db, 10)).find(
+      (candidate) => candidate.runId === run.id,
+    );
+
+    await requeueBrainMemoryEventsForTasks(db, [run.taskId]);
+
+    const [held] = await db
+      .select()
+      .from(brainMemoryEvents)
+      .where(eq(brainMemoryEvents.id, claimed!.id));
+    expect(held!.status).toBe('processing');
+    expect(held!.revision).toBe(claimed!.revision + 1);
+
+    const result = await settleBrainMemoryEvent(
+      db,
+      claimed!.id,
+      claimed!.revision,
+      'done',
+    );
+    expect(result).toBe('superseded');
+  });
+
+  it('ignores runs that did not complete and unknown tasks', async () => {
+    const task = await taskFactory.create({ state: 'active' });
+    createdTaskIds.push(task.id);
+    await db.insert(taskRuns).values({
+      taskId: task.id,
+      kind: 'fresh',
+      payloadKind: TaskPayloadKind.StandardTask,
+      payload: {
+        repo: 'test/repo',
+        description: 'running fixture',
+      } as CreateTaskRun['payload'],
+      status: RunStatus.Running,
+    });
+
+    expect(
+      await requeueBrainMemoryEventsForTasks(db, [task.id, 'no-such-task']),
+    ).toBe(0);
+    expect(await requeueBrainMemoryEventsForTasks(db, [])).toBe(0);
   });
 });
 

--- a/packages/db/src/lib/brain.ts
+++ b/packages/db/src/lib/brain.ts
@@ -423,6 +423,44 @@ export async function saveBrainAgentSummary(
 }
 
 /**
+ * Re-ingest every completed run of a task after something the task produced
+ * reached an outcome the memory should carry (a linked pull request merged or
+ * was closed unmerged). The page content is rebuilt from live rows by the
+ * drainer, so this only needs to hand the rows back: a settled row returns to
+ * 'pending' with a fresh retry budget and a bumped revision (same fencing as
+ * saveBrainAgentSummary, so an in-flight writer re-puts rather than strands
+ * the stale snapshot), a claimed row keeps its single writer, and a completed
+ * run that never got a row (Memory enabled after the fact) gets one now.
+ * Returns how many rows were touched; zero when the task has no completed run.
+ */
+export async function requeueBrainMemoryEventsForTasks(
+  database: DatabaseOrTransaction,
+  taskIds: string[],
+): Promise<number> {
+  if (taskIds.length === 0) {
+    return 0;
+  }
+
+  const rows = (await database.execute(
+    sql`INSERT INTO ${brainMemoryEvents} (run_id)
+        SELECT id FROM ${taskRuns}
+        WHERE task_id IN (${sql.join(
+          taskIds.map((taskId) => sql`${taskId}`),
+          sql`, `,
+        )}) AND status = ${RunStatus.Completed}
+        ON CONFLICT (run_id) DO UPDATE SET
+          revision = ${brainMemoryEvents}.revision + 1,
+          status = CASE WHEN ${brainMemoryEvents}.status = 'processing' THEN 'processing' ELSE 'pending' END,
+          attempts = CASE WHEN ${brainMemoryEvents}.status = 'processing' THEN ${brainMemoryEvents}.attempts ELSE 0 END,
+          last_error = NULL,
+          updated_at = now()
+        RETURNING id`,
+  )) as unknown as Array<{ id: string }>;
+
+  return rows.length;
+}
+
+/**
  * Backfill: enqueue outbox events for every already-completed run, so
  * connecting the brain sucks in the deployment's task history rather than
  * only learning from tasks completed after enablement. Idempotent via the

--- a/packages/sdk/src/server/lib/pull-requests/__tests__/update-task-pr-status.test.ts
+++ b/packages/sdk/src/server/lib/pull-requests/__tests__/update-task-pr-status.test.ts
@@ -3,6 +3,7 @@ const {
   mockDbSelect,
   mockEnqueueTaskSleep,
   mockReturning,
+  mockRequeueBrainMemoryEventsForTasks,
   mockSyncTaskStateFromRuns,
   mockTransaction,
 } = vi.hoisted(() => {
@@ -10,6 +11,7 @@ const {
   const mockDbSelect = vi.fn();
   const mockEnqueueTaskSleep = vi.fn();
   const mockReturning = vi.fn();
+  const mockRequeueBrainMemoryEventsForTasks = vi.fn();
   const mockSyncTaskStateFromRuns = vi.fn();
   const mockTransaction = vi.fn(async (callback: (tx: unknown) => unknown) =>
     callback({
@@ -29,6 +31,7 @@ const {
     mockDbSelect,
     mockEnqueueTaskSleep,
     mockReturning,
+    mockRequeueBrainMemoryEventsForTasks,
     mockSyncTaskStateFromRuns,
     mockTransaction,
   };
@@ -43,6 +46,8 @@ vi.mock('@roomote/db/server', async () => {
   return {
     ...actual,
     db: { transaction: mockTransaction, select: mockDbSelect },
+    requeueBrainMemoryEventsForTasks: (...args: unknown[]) =>
+      mockRequeueBrainMemoryEventsForTasks(...args),
     syncTaskStateFromRuns: (...args: unknown[]) =>
       mockSyncTaskStateFromRuns(...args),
   };
@@ -70,6 +75,7 @@ describe('updateTaskPrStatus', () => {
     mockReturning.mockResolvedValue([]);
     mockSyncTaskStateFromRuns.mockResolvedValue(undefined);
     mockEnqueueTaskSleep.mockResolvedValue(true);
+    mockRequeueBrainMemoryEventsForTasks.mockResolvedValue(0);
   });
 
   afterEach(() => {
@@ -202,6 +208,70 @@ describe('updateTaskPrStatus', () => {
 
     expect(mockSyncTaskStateFromRuns).not.toHaveBeenCalled();
     expect(mockLinkedTasks).not.toHaveBeenCalled();
+  });
+  it('re-ingests the memories of every task whose PR just merged', async () => {
+    mockReturning.mockResolvedValue([
+      { taskId: 'task-2', createdByRoomote: false },
+      { taskId: 'task-1', createdByRoomote: true },
+      { taskId: 'task-1', createdByRoomote: false },
+    ]);
+    // The originating-task workflow lookup that follows a merge.
+    mockDbSelect.mockReturnValue({
+      from: () => ({ where: () => Promise.resolve([]) }),
+    });
+
+    await updateTaskPrStatus('github', 'owner/repo', 42, 'merged');
+
+    expect(mockRequeueBrainMemoryEventsForTasks).toHaveBeenCalledTimes(1);
+    expect(mockRequeueBrainMemoryEventsForTasks).toHaveBeenCalledWith(
+      expect.any(Object),
+      ['task-1', 'task-2'],
+    );
+  });
+
+  it('re-ingests memories when a PR closes unmerged', async () => {
+    mockReturning.mockResolvedValue([
+      { taskId: 'task-1', createdByRoomote: false },
+    ]);
+
+    await updateTaskPrStatus('github', 'owner/repo', 42, 'closed');
+
+    expect(mockRequeueBrainMemoryEventsForTasks).toHaveBeenCalledWith(
+      expect.any(Object),
+      ['task-1'],
+    );
+  });
+
+  it('does not re-ingest when nothing transitioned or the PR is still open', async () => {
+    mockReturning.mockResolvedValue([]);
+    await updateTaskPrStatus('github', 'owner/repo', 42, 'closed');
+
+    mockReturning.mockResolvedValue([
+      { taskId: 'task-1', createdByRoomote: false },
+    ]);
+    await updateTaskPrStatus('github', 'owner/repo', 42, 'open');
+
+    expect(mockRequeueBrainMemoryEventsForTasks).not.toHaveBeenCalled();
+  });
+
+  it('keeps the webhook healthy when the memory requeue fails', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockReturning.mockResolvedValue([
+      { taskId: 'task-1', createdByRoomote: false },
+    ]);
+    mockRequeueBrainMemoryEventsForTasks.mockRejectedValue(
+      new Error('brain db down'),
+    );
+
+    await expect(
+      updateTaskPrStatus('github', 'owner/repo', 42, 'closed'),
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to requeue memories'),
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
   });
 });
 

--- a/packages/sdk/src/server/lib/pull-requests/update-task-pr-status.ts
+++ b/packages/sdk/src/server/lib/pull-requests/update-task-pr-status.ts
@@ -9,6 +9,7 @@ import {
   inArray,
   ne,
   or,
+  requeueBrainMemoryEventsForTasks,
   syncTaskStateFromRuns,
 } from '@roomote/db/server';
 import { captureActivationPrMerged } from '@roomote/telemetry/server';
@@ -91,13 +92,16 @@ export async function updateTaskPrStatus(
     eq(taskPullRequests.repository, repository),
     eq(taskPullRequests.prNumber, prNumber),
   );
+  // Terminal statuses only update rows that are not already there, so the
+  // returned rows are the associations that actually transitioned and a
+  // replayed webhook does not re-trigger the downstream work below.
   const matchingStatus = and(
     matchingPullRequest,
-    ...(status === 'merged'
+    ...(status === 'merged' || status === 'closed'
       ? [
           or(
             isNull(taskPullRequests.status),
-            ne(taskPullRequests.status, 'merged'),
+            ne(taskPullRequests.status, status),
           ),
         ]
       : []),
@@ -146,6 +150,21 @@ export async function updateTaskPrStatus(
         error,
       );
     });
+  }
+
+  if ((status === 'merged' || status === 'closed') && updated.length > 0) {
+    // The task's memory pages were written at completion, before anyone knew
+    // whether the work would ship. Re-ingest them so recall carries the
+    // outcome. Best-effort: a Memory hiccup must not fail the webhook.
+    const taskIds = [...new Set(updated.map((row) => row.taskId))].sort();
+    try {
+      await requeueBrainMemoryEventsForTasks(db, taskIds);
+    } catch (error) {
+      console.error(
+        `[updateTaskPrStatus] Failed to requeue memories for ${taskIds.join(', ')} after ${status} PR:`,
+        error,
+      );
+    }
   }
 
   if (status !== 'merged' || updated.length === 0) {


### PR DESCRIPTION
## Related issue

None. Internal Roomote work.

## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

## What changed

Task memories are written when a run completes, before anyone knows whether the work will ship. This closes that loop.

When a pull request linked to a task merges or closes unmerged, every completed run of that task is re-ingested into Memory. The rebuilt page now carries:

- a `pr_outcome: merged | closed | open` frontmatter field, so recall can filter shipped work from abandoned work
- the status on each pull request line
- a plain-language outcome line. Closed-unmerged pages say the work did not ship as written and to treat the approach with that in mind

The agent's own summary is unchanged; the outcome sits beside it.

The hook is the shared task PR status writer in the SDK, so GitHub, GitLab, Gitea, Azure DevOps, and Bitbucket all get it. The requeue runs after the transaction and is best-effort: a Memory failure logs and never fails the webhook. It reuses the outbox revision fence, so a row the drainer is mid-write on is superseded rather than stranded, and a completed run that never had a row (Memory enabled later) gets one.

One adjacent behavior change: a `closed` status now only updates rows that are not already closed, matching what `merged` already did, so a replayed webhook does not re-trigger downstream work.

Docs updated in `apps/docs/memory.mdx`.

## How it was tested

- Real-DB tests for `requeueBrainMemoryEventsForTasks`: settled rows return to pending with a bumped revision and fresh budget, missing rows are created, a claimed row keeps its writer and the stale settle is superseded, non-completed runs and unknown tasks are ignored.
- Unit tests for `updateTaskPrStatus`: requeue fires once with deduplicated sorted task ids on merge and on close, does not fire when nothing transitioned or the PR is still open, and a requeue failure is logged without failing the call.
- Unit tests for `buildMemoryPage`: merged, closed, mixed, open, unknown, and no-PR cases.
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` pass.

Not manually exercised end to end against a live deployment yet.

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [x] If this change should appear in the changelog, I ran `pnpm changeset`