### PR TITLE
[Fix] Snowflake connections fail with encrypted private keys

### DIFF
--- a/apps/api/src/handlers/mcp/__tests__/snowflake-auth.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/snowflake-auth.test.ts
@@ -1,3 +1,5 @@
+import { createPrivateKey, generateKeyPairSync } from 'node:crypto';
+
 import { Hono } from 'hono';
 import type { RunTokenContext } from '@roomote/types';
 
@@ -74,6 +76,25 @@ vi.mock('snowflake-sdk', () => ({
 
 import { db } from '@roomote/db/server';
 import { snowflakeMcp } from '../snowflake';
+
+const PRIVATE_KEY_PASSPHRASE = 'test-pem-passphrase';
+const { privateKey: encryptedPrivateKey } = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  privateKeyEncoding: {
+    type: 'pkcs8',
+    format: 'pem',
+    cipher: 'aes-256-cbc',
+    passphrase: PRIVATE_KEY_PASSPHRASE,
+  },
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+});
+const unencryptedPrivateKey = createPrivateKey({
+  key: encryptedPrivateKey,
+  format: 'pem',
+  passphrase: PRIVATE_KEY_PASSPHRASE,
+})
+  .export({ type: 'pkcs8', format: 'pem' })
+  .toString();
 
 function createInitializeRequest(id: number) {
   return {
@@ -309,9 +330,8 @@ describe('snowflake MCP auth and tool handling', () => {
     mockFindConnection.mockResolvedValue(
       mockConnectionRow({
         encryptedPassword: 'enc:legacy-password',
-        encryptedPrivateKey:
-          'enc:-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----',
-        encryptedPrivateKeyPassphrase: 'enc:pem-passphrase',
+        encryptedPrivateKey: `enc:${encryptedPrivateKey}`,
+        encryptedPrivateKeyPassphrase: `enc:${PRIVATE_KEY_PASSPHRASE}`,
       }),
     );
 
@@ -334,17 +354,145 @@ describe('snowflake MCP auth and tool handling', () => {
         | undefined;
     expect(lastCreateConnectionCall).toBeDefined();
     const [connectionConfig] = lastCreateConnectionCall ?? [];
+    if (!connectionConfig) {
+      throw new Error('Expected Snowflake connection options');
+    }
     expect(connectionConfig).toEqual(
       expect.objectContaining({
         account: 'xy12345.us-east-1',
         username: 'roomote',
         authenticator: 'SNOWFLAKE_JWT',
-        privateKey:
-          '-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----',
-        privateKeyPass: 'pem-passphrase',
+        privateKey: expect.stringContaining('-----BEGIN PRIVATE KEY-----'),
       }),
     );
     expect(connectionConfig).not.toHaveProperty('password');
+    expect(connectionConfig).not.toHaveProperty('privateKeyPass');
+    expect(connectionConfig.privateKey).not.toBe(encryptedPrivateKey);
+    expect(() =>
+      createPrivateKey({
+        key: connectionConfig.privateKey as string,
+        format: 'pem',
+      }),
+    ).not.toThrow();
+  });
+
+  it('continues to accept unencrypted PKCS8 private keys', async () => {
+    mockFindConnection.mockResolvedValue(
+      mockConnectionRow({
+        encryptedPassword: undefined,
+        encryptedPrivateKey: `enc:${unencryptedPrivateKey}`,
+        encryptedPrivateKeyPassphrase: undefined,
+      }),
+    );
+
+    const response = await postMcp(
+      createApp(createRunToken()),
+      createInitializeRequest(77),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSnowflakeCreateConnection).not.toHaveBeenCalled();
+  });
+
+  it('rejects an incorrect private key passphrase without exposing secrets', async () => {
+    mockFindConnection.mockResolvedValue(
+      mockConnectionRow({
+        encryptedPassword: undefined,
+        encryptedPrivateKey: `enc:${encryptedPrivateKey}`,
+        encryptedPrivateKeyPassphrase: 'enc:wrong-secret-passphrase',
+      }),
+    );
+
+    const response = await postMcp(
+      createApp(createRunToken()),
+      createInitializeRequest(73),
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(500);
+    expect(body).toContain('Snowflake private key or passphrase is invalid');
+    expect(body).not.toContain('wrong-secret-passphrase');
+    expect(body).not.toContain(encryptedPrivateKey);
+    expect(mockSnowflakeCreateConnection).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-RSA PKCS8 private keys', async () => {
+    const { privateKey: encryptedEcPrivateKey } = generateKeyPairSync('ec', {
+      namedCurve: 'P-256',
+      privateKeyEncoding: {
+        type: 'pkcs8',
+        format: 'pem',
+        cipher: 'aes-256-cbc',
+        passphrase: PRIVATE_KEY_PASSPHRASE,
+      },
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+    });
+    mockFindConnection.mockResolvedValue(
+      mockConnectionRow({
+        encryptedPassword: undefined,
+        encryptedPrivateKey: `enc:${encryptedEcPrivateKey}`,
+        encryptedPrivateKeyPassphrase: `enc:${PRIVATE_KEY_PASSPHRASE}`,
+      }),
+    );
+
+    const response = await postMcp(
+      createApp(createRunToken()),
+      createInitializeRequest(74),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { message: 'Snowflake private key or passphrase is invalid' },
+    });
+    expect(mockSnowflakeCreateConnection).not.toHaveBeenCalled();
+  });
+
+  it('rejects RSA private keys smaller than 2048 bits', async () => {
+    const { privateKey: shortPrivateKey } = generateKeyPairSync('rsa', {
+      modulusLength: 1024,
+      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      publicKeyEncoding: { type: 'spki', format: 'pem' },
+    });
+    mockFindConnection.mockResolvedValue(
+      mockConnectionRow({
+        encryptedPassword: undefined,
+        encryptedPrivateKey: `enc:${shortPrivateKey}`,
+        encryptedPrivateKeyPassphrase: undefined,
+      }),
+    );
+
+    const response = await postMcp(
+      createApp(createRunToken()),
+      createInitializeRequest(75),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { message: 'Snowflake private key or passphrase is invalid' },
+    });
+    expect(mockSnowflakeCreateConnection).not.toHaveBeenCalled();
+  });
+
+  it('redacts Snowflake SDK connection errors', async () => {
+    mockSnowflakeConnect.mockImplementationOnce((callback) => {
+      callback?.(new Error(`Login failed for ${PRIVATE_KEY_PASSPHRASE}`));
+      return {} as never;
+    });
+
+    const response = await postMcp(createApp(createRunToken()), {
+      jsonrpc: '2.0',
+      id: 76,
+      method: 'tools/call',
+      params: {
+        name: 'execute_sql',
+        arguments: { sql: 'SELECT 1 AS RESULT' },
+      },
+    });
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('Snowflake connection failed');
+    expect(body).not.toContain(PRIVATE_KEY_PASSPHRASE);
   });
 
   it('returns normalized table descriptions', async () => {

--- a/apps/api/src/handlers/mcp/__tests__/snowflake-auth.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/snowflake-auth.test.ts
@@ -168,7 +168,7 @@ function mockConnectionRow(overrides?: Record<string, unknown>) {
       username: 'roomote',
       role: 'ANALYST',
       warehouse: 'ROOMOTE_WH',
-      encryptedPassword: 'enc:secret',
+      encryptedPrivateKey: `enc:${unencryptedPrivateKey}`,
       ...(overrides ?? {}),
     },
   } as Awaited<ReturnType<typeof db.query.mcpConnections.findFirst>>;
@@ -305,7 +305,7 @@ describe('snowflake MCP auth and tool handling', () => {
       expect.objectContaining({
         account: 'xy12345.us-east-1',
         username: 'roomote',
-        password: 'secret',
+        authenticator: 'SNOWFLAKE_JWT',
       }),
     );
   });
@@ -340,7 +340,7 @@ describe('snowflake MCP auth and tool handling', () => {
       expect.objectContaining({
         account: 'xy12345.us-east-1',
         username: 'roomote',
-        password: 'secret',
+        authenticator: 'SNOWFLAKE_JWT',
       }),
     );
     expect(connectionConfig).not.toHaveProperty('warehouse');
@@ -349,7 +349,6 @@ describe('snowflake MCP auth and tool handling', () => {
   it('uses Snowflake JWT auth when a private key is configured', async () => {
     mockFindConnection.mockResolvedValue(
       mockConnectionRow({
-        encryptedPassword: 'enc:legacy-password',
         encryptedPrivateKey: `enc:${encryptedPrivateKey}`,
         encryptedPrivateKeyPassphrase: `enc:${PRIVATE_KEY_PASSPHRASE}`,
       }),
@@ -385,7 +384,6 @@ describe('snowflake MCP auth and tool handling', () => {
         privateKey: expect.stringContaining('-----BEGIN PRIVATE KEY-----'),
       }),
     );
-    expect(connectionConfig).not.toHaveProperty('password');
     expect(connectionConfig).not.toHaveProperty('privateKeyPass');
     expect(connectionConfig.privateKey).not.toBe(encryptedPrivateKey);
     expect(() =>
@@ -399,7 +397,6 @@ describe('snowflake MCP auth and tool handling', () => {
   it('continues to accept unencrypted PKCS8 private keys', async () => {
     mockFindConnection.mockResolvedValue(
       mockConnectionRow({
-        encryptedPassword: undefined,
         encryptedPrivateKey: `enc:${unencryptedPrivateKey}`,
         encryptedPrivateKeyPassphrase: undefined,
       }),
@@ -417,7 +414,6 @@ describe('snowflake MCP auth and tool handling', () => {
   it('rejects an incorrect private key passphrase without exposing secrets', async () => {
     mockFindConnection.mockResolvedValue(
       mockConnectionRow({
-        encryptedPassword: undefined,
         encryptedPrivateKey: `enc:${encryptedPrivateKey}`,
         encryptedPrivateKeyPassphrase: 'enc:wrong-secret-passphrase',
       }),
@@ -449,7 +445,6 @@ describe('snowflake MCP auth and tool handling', () => {
     });
     mockFindConnection.mockResolvedValue(
       mockConnectionRow({
-        encryptedPassword: undefined,
         encryptedPrivateKey: `enc:${encryptedEcPrivateKey}`,
         encryptedPrivateKeyPassphrase: `enc:${PRIVATE_KEY_PASSPHRASE}`,
       }),
@@ -470,7 +465,6 @@ describe('snowflake MCP auth and tool handling', () => {
   it('rejects RSA private keys smaller than 2048 bits', async () => {
     mockFindConnection.mockResolvedValue(
       mockConnectionRow({
-        encryptedPassword: undefined,
         encryptedPrivateKey: `enc:${WEAK_RSA_PRIVATE_KEY}`,
         encryptedPrivateKeyPassphrase: undefined,
       }),

--- a/apps/api/src/handlers/mcp/__tests__/snowflake-auth.test.ts
+++ b/apps/api/src/handlers/mcp/__tests__/snowflake-auth.test.ts
@@ -96,6 +96,26 @@ const unencryptedPrivateKey = createPrivateKey({
   .export({ type: 'pkcs8', format: 'pem' })
   .toString();
 
+// Throwaway 1024-bit RSA key used only to prove that Roomote rejects keys
+// below Snowflake's 2048-bit minimum. It is a static fixture so the test does
+// not have to generate a weak key at runtime.
+const WEAK_RSA_PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAMpUctCsXrXT3N72
+xjom38dV1SjCSykBWPi0SZiCINbAe8HB9poI4OXxV7mgSD08zWL+oHy/+xOrk0Vn
+FpE8lUBuGs/OPmpiMAMpn8afkHui1wjUI4QDYViqnVQ3DZrFgQgmzryliujn5fgt
+FeW8U1oSMOVXxOitwmsz2L9PLPqXAgMBAAECgYBBGExcQKiz/Ta5cVGzUeB7RG0x
+ENmXlrxmP7LR40Pnc8QdQWcyhZq9wBkGOsAjG5XEvMErgaSo3nGiSZlkHsaxgi7Y
+g2FjOrz5dwANoxWfeXviQxeFhTcr9zZ7Kf4XLl67Julr0mrXCFwQjN0tSqKkJqa3
+T01RXZhPOOl2lZSX0QJBAPPzWLkLbfvABV6O8NmoLP6h/f8R+RWNJFfwT346JY7N
+klDVcq4r/PQdgOEF6PtSFoDRILCvWrSRn2S7y19zIs8CQQDUUtNXkJzMOlk3v6mZ
+6o8Gj03XMiWZxB1rc21yhkwuuah+amm3xDYb7usv36N+PZWtGCi4qEANJ6fqpC1Q
+2r25AkEArze6Ii7zcD8bnC9PDwacSshPh0WBgtk9oWwZrLBXCZrd3PFyzWcK6MvI
+Jdf434q2Xw/WSxGoNMnjkpbQHF62QQJANGFakjey9w9OA1rdVINxVYT1Bynv7Mdd
+Gq0XSzGmicBzuPw3qIZXcvy2ONFLXFGFI3baVPPtGVG3M0PdihzswQJAURom6e1h
+RHZARrKx3F4VZFnDiRRy7f+9DIwQt9KGyoyOLOSik/XFhWEE/NtYhC1adrMOaLD/
+4YBjSVQEeHBBgg==
+-----END PRIVATE KEY-----`;
+
 function createInitializeRequest(id: number) {
   return {
     jsonrpc: '2.0',
@@ -448,15 +468,10 @@ describe('snowflake MCP auth and tool handling', () => {
   });
 
   it('rejects RSA private keys smaller than 2048 bits', async () => {
-    const { privateKey: shortPrivateKey } = generateKeyPairSync('rsa', {
-      modulusLength: 1024,
-      privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
-      publicKeyEncoding: { type: 'spki', format: 'pem' },
-    });
     mockFindConnection.mockResolvedValue(
       mockConnectionRow({
         encryptedPassword: undefined,
-        encryptedPrivateKey: `enc:${shortPrivateKey}`,
+        encryptedPrivateKey: `enc:${WEAK_RSA_PRIVATE_KEY}`,
         encryptedPrivateKeyPassphrase: undefined,
       }),
     );

--- a/apps/api/src/handlers/mcp/snowflake/connection.ts
+++ b/apps/api/src/handlers/mcp/snowflake/connection.ts
@@ -1,3 +1,5 @@
+import { createPrivateKey } from 'node:crypto';
+
 import { decrypt } from '@roomote/db/encryption';
 import type { McpConnectionSnowflakeConfig } from '@roomote/types';
 import snowflakeSdk from 'snowflake-sdk';
@@ -16,6 +18,41 @@ class SnowflakeConfigError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'SnowflakeConfigError';
+  }
+}
+
+function normalizePrivateKey(
+  privateKeyPem: string,
+  passphrase: string | undefined,
+): string {
+  try {
+    const trimmedPrivateKey = privateKeyPem.trim();
+    if (
+      !/^-----BEGIN (?:ENCRYPTED )?PRIVATE KEY-----/.test(trimmedPrivateKey)
+    ) {
+      throw new Error('Unsupported private key format');
+    }
+
+    const privateKey = createPrivateKey({
+      key: trimmedPrivateKey,
+      format: 'pem',
+      passphrase,
+    });
+    const modulusLength = privateKey.asymmetricKeyDetails?.modulusLength;
+
+    if (
+      privateKey.asymmetricKeyType !== 'rsa' ||
+      !modulusLength ||
+      modulusLength < 2048
+    ) {
+      throw new Error('Unsupported private key parameters');
+    }
+
+    return privateKey.export({ format: 'pem', type: 'pkcs8' }).toString();
+  } catch {
+    throw new SnowflakeConfigError(
+      'Snowflake private key or passphrase is invalid',
+    );
   }
 }
 
@@ -46,14 +83,17 @@ export function resolveSnowflakeConnectionConfig(
     );
   }
 
+  const authentication = privateKey
+    ? {
+        authenticator: 'SNOWFLAKE_JWT' as const,
+        privateKey: normalizePrivateKey(privateKey, privateKeyPass),
+      }
+    : { password };
+
   return {
     account: config.account,
     username: config.username,
-    ...(privateKey
-      ? { authenticator: 'SNOWFLAKE_JWT' as const }
-      : { password }),
-    privateKey,
-    privateKeyPass,
+    ...authentication,
     role: config.role,
     ...(config.warehouse ? { warehouse: config.warehouse } : {}),
     database: config.database,
@@ -110,9 +150,14 @@ export async function withSnowflakeConnection<T>(
   config: ResolvedSnowflakeConnectionConfig,
   callback: (connection: Connection) => Promise<T>,
 ): Promise<T> {
-  const connection = snowflakeSdk.createConnection(config);
+  let connection: Connection;
 
-  await connect(connection);
+  try {
+    connection = snowflakeSdk.createConnection(config);
+    await connect(connection);
+  } catch {
+    throw new Error('Snowflake connection failed');
+  }
 
   try {
     return await callback(connection);

--- a/apps/api/src/handlers/mcp/snowflake/connection.ts
+++ b/apps/api/src/handlers/mcp/snowflake/connection.ts
@@ -71,29 +71,22 @@ function maybeDecryptSecret(value: string | undefined): string | undefined {
 export function resolveSnowflakeConnectionConfig(
   config: McpConnectionSnowflakeConfig,
 ): ResolvedSnowflakeConnectionConfig {
-  const password = maybeDecryptSecret(config.encryptedPassword);
   const privateKey = maybeDecryptSecret(config.encryptedPrivateKey);
   const privateKeyPass = maybeDecryptSecret(
     config.encryptedPrivateKeyPassphrase,
   );
 
-  if (!password && !privateKey) {
+  if (!privateKey) {
     throw new SnowflakeConfigError(
-      'Snowflake connection requires either a password or a private key',
+      'Snowflake connection requires a private key',
     );
   }
-
-  const authentication = privateKey
-    ? {
-        authenticator: 'SNOWFLAKE_JWT' as const,
-        privateKey: normalizePrivateKey(privateKey, privateKeyPass),
-      }
-    : { password };
 
   return {
     account: config.account,
     username: config.username,
-    ...authentication,
+    authenticator: 'SNOWFLAKE_JWT' as const,
+    privateKey: normalizePrivateKey(privateKey, privateKeyPass),
     role: config.role,
     ...(config.warehouse ? { warehouse: config.warehouse } : {}),
     database: config.database,

--- a/apps/docs/integrations/snowflake.mdx
+++ b/apps/docs/integrations/snowflake.mdx
@@ -20,12 +20,24 @@ identifier, username, role, and PKCS8 PEM-encoded private key. Add the matching
 public key to the Snowflake user first. Supply the private-key passphrase too
 when the key is encrypted.
 
+Generate a dedicated encrypted RSA key on a secure operator machine. Keep the
+private key out of shell arguments, repositories, chat, and logs. For example,
+run `umask 077`, then use `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:3072 -aes-256-cbc -out roomote_snowflake_key.p8` and enter the passphrase interactively. Export only the public key with `openssl pkey -in roomote_snowflake_key.p8 -pubout -out roomote_snowflake_key.pub`.
+
 <Warning>
   The `execute_sql` tool can run any statement permitted by the configured
   Snowflake role, including statements that change data or schema. Use a
   dedicated least-privilege role, preferably read-only when tasks only need
   warehouse context.
 </Warning>
+
+## Rotate from an existing credential
+
+1. Install the new public key in Snowflake's unused `RSA_PUBLIC_KEY_2` slot and verify its fingerprint before changing Roomote.
+2. Enter the encrypted PKCS8 private key and passphrase in **Settings > Integrations > Snowflake**. Leave both fields blank on later edits to keep the stored key.
+3. Run a Roomote task that calls `list_databases`, `list_schemas`, and `execute_sql` with `SELECT CURRENT_USER(), CURRENT_ROLE(), CURRENT_WAREHOUSE()`. Confirm the configured role can read only the intended data.
+4. Review Roomote and Snowflake login logs for a successful JWT login without credential material. A saved connection is not proof that Snowflake accepted it.
+5. After an observation window, revoke the previous password, programmatic access token, or public-key slot and verify a fresh Roomote task still connects.
 
 ## What to expect
 

--- a/apps/docs/integrations/snowflake.mdx
+++ b/apps/docs/integrations/snowflake.mdx
@@ -31,21 +31,13 @@ run `umask 077`, then use `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bi
   warehouse context.
 </Warning>
 
-## Switch from password sign-in to a key pair
-
-Snowflake is retiring password-only sign-in for service users. Connections
-that still store a password show a warning in **Settings > Integrations**
-until an admin edits the connection and saves a private key. Saving a key
-removes the stored password, so Snowflake can drop the password from the
-user afterwards without affecting Roomote.
-
 ## Rotate from an existing credential
 
 1. Install the new public key in Snowflake's unused `RSA_PUBLIC_KEY_2` slot and verify its fingerprint before changing Roomote.
 2. Enter the encrypted PKCS8 private key and passphrase in **Settings > Integrations > Snowflake**. Leave both fields blank on later edits to keep the stored key.
 3. Run a Roomote task that calls `list_databases`, `list_schemas`, and `execute_sql` with `SELECT CURRENT_USER(), CURRENT_ROLE(), CURRENT_WAREHOUSE()`. Confirm the configured role can read only the intended data.
 4. Review Roomote and Snowflake login logs for a successful JWT login without credential material. A saved connection is not proof that Snowflake accepted it.
-5. After an observation window, revoke the previous password, programmatic access token, or public-key slot and verify a fresh Roomote task still connects.
+5. After an observation window, revoke the previous public-key slot and verify a fresh Roomote task still connects.
 
 ## What to expect
 

--- a/apps/docs/integrations/snowflake.mdx
+++ b/apps/docs/integrations/snowflake.mdx
@@ -31,6 +31,14 @@ run `umask 077`, then use `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bi
   warehouse context.
 </Warning>
 
+## Switch from password sign-in to a key pair
+
+Snowflake is retiring password-only sign-in for service users. Connections
+that still store a password show a warning in **Settings > Integrations**
+until an admin edits the connection and saves a private key. Saving a key
+removes the stored password, so Snowflake can drop the password from the
+user afterwards without affecting Roomote.
+
 ## Rotate from an existing credential
 
 1. Install the new public key in Snowflake's unused `RSA_PUBLIC_KEY_2` slot and verify its fingerprint before changing Roomote.

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -2019,6 +2019,9 @@ describe('Integrations settings', () => {
         target: { value: 'pem-passphrase' },
       },
     );
+    expect(
+      screen.getByLabelText('Private Key Passphrase (optional)'),
+    ).toHaveAttribute('type', 'password');
     fireEvent.change(screen.getByLabelText('Role'), {
       target: { value: 'ANALYST' },
     });

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -2088,6 +2088,44 @@ describe('Integrations settings', () => {
     );
   });
 
+  it('warns when the Snowflake connection still signs in with a password', () => {
+    state.deploymentEnablements = [{ mcpId: 'snowflake', enabled: true }];
+    state.userConnections = [
+      {
+        mcpId: 'snowflake',
+        authStatus: 'authenticated',
+      },
+    ];
+    state.snowflakeConnection = {
+      authStatus: 'authenticated',
+      authMethod: 'password',
+      account: 'xy12345.us-east-1',
+      username: 'roomote_user',
+      role: 'ANALYST',
+      warehouse: 'COMPUTE_WH',
+      database: 'ROOMOTE',
+    };
+
+    render(<Integrations />);
+
+    expect(
+      screen.getByText(
+        /signs in to Snowflake with a password.*Edit the connection to switch to a key pair/,
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Edit Snowflake connection' }),
+    );
+
+    expect(
+      screen.getByText(/Paste the private key below and save to switch/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Leave blank to keep the existing private key.'),
+    ).not.toBeInTheDocument();
+  });
+
   it('shows Snowflake connected controls without status copy and supports editing', () => {
     state.deploymentEnablements = [{ mcpId: 'snowflake', enabled: true }];
     state.userConnections = [

--- a/apps/web/src/components/settings/Integrations.test.tsx
+++ b/apps/web/src/components/settings/Integrations.test.tsx
@@ -62,7 +62,6 @@ const state = vi.hoisted(() => ({
   isAdmin: true,
   snowflakeConnection: null as null | {
     authStatus?: string | null;
-    authMethod: 'key_pair' | 'password';
     account: string;
     username: string;
     role: string;
@@ -2029,10 +2028,8 @@ describe('Integrations settings', () => {
 
     expect(mutations.saveSnowflakeConnection).toHaveBeenCalledWith(
       {
-        authMethod: 'key_pair',
         account: 'xy12345.us-east-1',
         username: 'roomote_user',
-        password: '',
         privateKey:
           '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----',
         privateKeyPassphrase: 'pem-passphrase',
@@ -2072,10 +2069,8 @@ describe('Integrations settings', () => {
 
     expect(mutations.saveSnowflakeConnection).toHaveBeenCalledWith(
       {
-        authMethod: 'key_pair',
         account: 'xy12345.us-east-1',
         username: 'roomote_user',
-        password: '',
         privateKey:
           '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----',
         privateKeyPassphrase: '',
@@ -2088,44 +2083,6 @@ describe('Integrations settings', () => {
     );
   });
 
-  it('warns when the Snowflake connection still signs in with a password', () => {
-    state.deploymentEnablements = [{ mcpId: 'snowflake', enabled: true }];
-    state.userConnections = [
-      {
-        mcpId: 'snowflake',
-        authStatus: 'authenticated',
-      },
-    ];
-    state.snowflakeConnection = {
-      authStatus: 'authenticated',
-      authMethod: 'password',
-      account: 'xy12345.us-east-1',
-      username: 'roomote_user',
-      role: 'ANALYST',
-      warehouse: 'COMPUTE_WH',
-      database: 'ROOMOTE',
-    };
-
-    render(<Integrations />);
-
-    expect(
-      screen.getByText(
-        /signs in to Snowflake with a password.*Edit the connection to switch to a key pair/,
-      ),
-    ).toBeInTheDocument();
-
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Edit Snowflake connection' }),
-    );
-
-    expect(
-      screen.getByText(/Paste the private key below and save to switch/),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText('Leave blank to keep the existing private key.'),
-    ).not.toBeInTheDocument();
-  });
-
   it('shows Snowflake connected controls without status copy and supports editing', () => {
     state.deploymentEnablements = [{ mcpId: 'snowflake', enabled: true }];
     state.userConnections = [
@@ -2136,7 +2093,6 @@ describe('Integrations settings', () => {
     ];
     state.snowflakeConnection = {
       authStatus: 'authenticated',
-      authMethod: 'key_pair',
       account: 'xy12345.us-east-1',
       username: 'roomote_user',
       role: 'ANALYST',
@@ -2184,35 +2140,6 @@ describe('Integrations settings', () => {
     expect(
       screen.getByText('Leave blank to keep the existing private key.'),
     ).toBeInTheDocument();
-  });
-
-  it('requires a new private key when editing a legacy PAT-backed Snowflake connection', () => {
-    state.userConnections = [
-      { mcpId: 'snowflake', authStatus: 'authenticated' },
-    ];
-    state.deploymentEnablements = [{ mcpId: 'snowflake', enabled: true }];
-    state.snowflakeConnection = {
-      authStatus: 'authenticated',
-      authMethod: 'password',
-      account: 'xy12345.us-east-1',
-      username: 'roomote_user',
-      role: 'ANALYST',
-    };
-
-    render(<Integrations />);
-
-    fireEvent.click(
-      screen.getByRole('button', { name: 'Edit Snowflake connection' }),
-    );
-
-    expect(
-      screen.queryByText('Leave blank to keep the existing private key.'),
-    ).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
-
-    expect(screen.getByText('Private key is required')).toBeInTheDocument();
-    expect(mutations.saveSnowflakeConnection).not.toHaveBeenCalled();
   });
 
   it('preserves unsaved tool toggles when the same upstream tool state is returned again', () => {

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -777,6 +777,7 @@ function SnowflakeConnectionFields({
             </Label>
             <Input
               id="snowflake-private-key-passphrase"
+              type="password"
               value={form.privateKeyPassphrase}
               onChange={(event) =>
                 onFieldChange('privateKeyPassphrase', event.target.value)

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -149,6 +149,9 @@ function getLinearOauthSetupStatus(
   return status === 'partial' ? 'Configuration incomplete.' : null;
 }
 
+const SNOWFLAKE_PASSWORD_AUTH_NOTICE =
+  'This connection signs in to Snowflake with a password. Snowflake is retiring password-only sign-in for service users.';
+
 type AdminConfiguredIntegrationItemOptions = {
   integration: McpIntegrationDefinition;
   connection?: { authStatus?: string | null };
@@ -161,6 +164,8 @@ type AdminConfiguredIntegrationItemOptions = {
   connectionPending: boolean;
   canConfigure: boolean;
   canManageTools: boolean;
+  status?: ReactNode;
+  statusIcon?: ReactNode;
   openDialog: () => void;
   openToolDialog: () => void;
   disconnectIntegration: () => void;
@@ -499,6 +504,8 @@ function buildAdminConfiguredIntegrationItem({
   connectionPending,
   canConfigure,
   canManageTools,
+  status,
+  statusIcon,
   openDialog,
   openToolDialog,
   disconnectIntegration,
@@ -521,7 +528,8 @@ function buildAdminConfiguredIntegrationItem({
         : `Configure ${integration.name}`
       : undefined,
     isPending,
-    status: undefined,
+    status,
+    statusIcon,
     headerAction:
       canConfigure && connection != null
         ? {
@@ -691,12 +699,14 @@ function SnowflakeConnectionFields({
   fieldErrors,
   formError,
   allowBlankPrivateKey,
+  usesPasswordAuth,
   onFieldChange,
 }: {
   form: SnowflakeFormState;
   fieldErrors: Partial<Record<keyof SnowflakeFormState, string[]>>;
   formError: string | null;
   allowBlankPrivateKey: boolean;
+  usesPasswordAuth: boolean;
   onFieldChange: (field: keyof SnowflakeFormState, value: string) => void;
 }) {
   const fieldClassName =
@@ -704,6 +714,16 @@ function SnowflakeConnectionFields({
 
   return (
     <>
+      {usesPasswordAuth ? (
+        <Alert variant="notice">
+          <TriangleAlert className="size-4" />
+          <AlertDescription>
+            {SNOWFLAKE_PASSWORD_AUTH_NOTICE} Paste the private key below and
+            save to switch this connection to key-pair authentication. The
+            stored password is removed once a key is saved.
+          </AlertDescription>
+        </Alert>
+      ) : null}
       <div className="space-y-4">
         <div className="grid gap-4 md:grid-cols-2">
           <div className="space-y-2">
@@ -1620,6 +1640,8 @@ export function Integrations() {
   );
   const allowsBlankSnowflakePrivateKey =
     snowflakeConnection.data?.authMethod === 'key_pair';
+  const snowflakeUsesPasswordAuth =
+    isSnowflakeConnected && snowflakeConnection.data?.authMethod === 'password';
 
   useEffect(() => {
     if (!isAsanaDialogOpen) {
@@ -2031,6 +2053,12 @@ export function Integrations() {
               connectionPending: snowflakeConnection.isPending,
               canConfigure: true,
               canManageTools: isAdmin,
+              status: snowflakeUsesPasswordAuth
+                ? `${SNOWFLAKE_PASSWORD_AUTH_NOTICE} Edit the connection to switch to a key pair.`
+                : undefined,
+              statusIcon: snowflakeUsesPasswordAuth ? (
+                <TriangleAlert className="size-4" />
+              ) : undefined,
               openDialog: () => setIsSnowflakeDialogOpen(true),
               openToolDialog: () => openMcpToolDialog(integration),
               disconnectIntegration: () =>
@@ -2271,6 +2299,7 @@ export function Integrations() {
     ripplingConnection.isPending,
     ripplingConnectionSummary,
     snowflakeConnection.isPending,
+    snowflakeUsesPasswordAuth,
     isSnowflakeDialogOpen,
     vercelConnection.isPending,
     isVercelDialogOpen,
@@ -3090,6 +3119,7 @@ export function Integrations() {
           fieldErrors={snowflakeFieldErrors}
           formError={snowflakeFormError}
           allowBlankPrivateKey={allowsBlankSnowflakePrivateKey}
+          usesPasswordAuth={snowflakeUsesPasswordAuth}
           onFieldChange={handleSnowflakeFieldChange}
         />
       </AdminConfiguredIntegrationDialog>

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -149,9 +149,6 @@ function getLinearOauthSetupStatus(
   return status === 'partial' ? 'Configuration incomplete.' : null;
 }
 
-const SNOWFLAKE_PASSWORD_AUTH_NOTICE =
-  'This connection signs in to Snowflake with a password. Snowflake is retiring password-only sign-in for service users.';
-
 type AdminConfiguredIntegrationItemOptions = {
   integration: McpIntegrationDefinition;
   connection?: { authStatus?: string | null };
@@ -164,8 +161,6 @@ type AdminConfiguredIntegrationItemOptions = {
   connectionPending: boolean;
   canConfigure: boolean;
   canManageTools: boolean;
-  status?: ReactNode;
-  statusIcon?: ReactNode;
   openDialog: () => void;
   openToolDialog: () => void;
   disconnectIntegration: () => void;
@@ -181,7 +176,6 @@ type SnowflakeFormState = {
 
 type SnowflakeConnectionData = {
   authStatus?: 'pending' | 'authenticated' | 'error' | null;
-  authMethod?: 'key_pair' | 'password';
   account: string;
   username: string;
   role: string;
@@ -504,8 +498,6 @@ function buildAdminConfiguredIntegrationItem({
   connectionPending,
   canConfigure,
   canManageTools,
-  status,
-  statusIcon,
   openDialog,
   openToolDialog,
   disconnectIntegration,
@@ -528,8 +520,7 @@ function buildAdminConfiguredIntegrationItem({
         : `Configure ${integration.name}`
       : undefined,
     isPending,
-    status,
-    statusIcon,
+    status: undefined,
     headerAction:
       canConfigure && connection != null
         ? {
@@ -699,14 +690,12 @@ function SnowflakeConnectionFields({
   fieldErrors,
   formError,
   allowBlankPrivateKey,
-  usesPasswordAuth,
   onFieldChange,
 }: {
   form: SnowflakeFormState;
   fieldErrors: Partial<Record<keyof SnowflakeFormState, string[]>>;
   formError: string | null;
   allowBlankPrivateKey: boolean;
-  usesPasswordAuth: boolean;
   onFieldChange: (field: keyof SnowflakeFormState, value: string) => void;
 }) {
   const fieldClassName =
@@ -714,16 +703,6 @@ function SnowflakeConnectionFields({
 
   return (
     <>
-      {usesPasswordAuth ? (
-        <Alert variant="notice">
-          <TriangleAlert className="size-4" />
-          <AlertDescription>
-            {SNOWFLAKE_PASSWORD_AUTH_NOTICE} Paste the private key below and
-            save to switch this connection to key-pair authentication. The
-            stored password is removed once a key is saved.
-          </AlertDescription>
-        </Alert>
-      ) : null}
       <div className="space-y-4">
         <div className="grid gap-4 md:grid-cols-2">
           <div className="space-y-2">
@@ -1638,10 +1617,6 @@ export function Integrations() {
   const xConnection = useXConnection(
     isAdmin && (isXConnected || isXDialogOpen),
   );
-  const allowsBlankSnowflakePrivateKey =
-    snowflakeConnection.data?.authMethod === 'key_pair';
-  const snowflakeUsesPasswordAuth =
-    isSnowflakeConnected && snowflakeConnection.data?.authMethod === 'password';
 
   useEffect(() => {
     if (!isAsanaDialogOpen) {
@@ -2053,12 +2028,6 @@ export function Integrations() {
               connectionPending: snowflakeConnection.isPending,
               canConfigure: true,
               canManageTools: isAdmin,
-              status: snowflakeUsesPasswordAuth
-                ? `${SNOWFLAKE_PASSWORD_AUTH_NOTICE} Edit the connection to switch to a key pair.`
-                : undefined,
-              statusIcon: snowflakeUsesPasswordAuth ? (
-                <TriangleAlert className="size-4" />
-              ) : undefined,
               openDialog: () => setIsSnowflakeDialogOpen(true),
               openToolDialog: () => openMcpToolDialog(integration),
               disconnectIntegration: () =>
@@ -2299,7 +2268,6 @@ export function Integrations() {
     ripplingConnection.isPending,
     ripplingConnectionSummary,
     snowflakeConnection.isPending,
-    snowflakeUsesPasswordAuth,
     isSnowflakeDialogOpen,
     vercelConnection.isPending,
     isVercelDialogOpen,
@@ -2818,10 +2786,8 @@ export function Integrations() {
     event.preventDefault();
 
     const parsed = saveSnowflakeConnectionSchema.safeParse({
-      authMethod: 'key_pair',
       account: snowflakeForm.account,
       username: snowflakeForm.username,
-      password: '',
       privateKey: snowflakeForm.privateKey,
       privateKeyPassphrase: snowflakeForm.privateKeyPassphrase,
       role: snowflakeForm.role,
@@ -2831,10 +2797,7 @@ export function Integrations() {
       return;
     }
 
-    if (
-      !allowsBlankSnowflakePrivateKey &&
-      parsed.data.privateKey.trim().length === 0
-    ) {
+    if (!isSnowflakeConnected && parsed.data.privateKey.trim().length === 0) {
       setSnowflakeFieldErrors({
         privateKey: ['Private key is required'],
       });
@@ -3118,8 +3081,7 @@ export function Integrations() {
           form={snowflakeForm}
           fieldErrors={snowflakeFieldErrors}
           formError={snowflakeFormError}
-          allowBlankPrivateKey={allowsBlankSnowflakePrivateKey}
-          usesPasswordAuth={snowflakeUsesPasswordAuth}
+          allowBlankPrivateKey={isSnowflakeConnected}
           onFieldChange={handleSnowflakeFieldChange}
         />
       </AdminConfiguredIntegrationDialog>

--- a/apps/web/src/trpc/commands/mcp-connections/index.ts
+++ b/apps/web/src/trpc/commands/mcp-connections/index.ts
@@ -57,17 +57,6 @@ import type {
   SaveXConnectionInput,
 } from '@/types';
 
-type LegacySnowflakePasswordInput = Omit<
-  SaveSnowflakeConnectionInput,
-  'authMethod'
-> & {
-  authMethod: 'password';
-};
-
-type SaveSnowflakeConnectionCommandInput =
-  | SaveSnowflakeConnectionInput
-  | LegacySnowflakePasswordInput;
-
 type VercelConnectionData = {
   authStatus?: 'pending' | 'authenticated' | 'error' | null;
   defaultTeamIdOrSlug?: string;
@@ -783,9 +772,6 @@ export async function getSnowflakeConnectionCommand(auth: UserAuthSuccess) {
 
   return {
     authStatus: connection.authStatus,
-    authMethod: connection.authConfig.encryptedPrivateKey
-      ? ('key_pair' as const)
-      : ('password' as const),
     account: connection.authConfig.account,
     username: connection.authConfig.username,
     role: connection.authConfig.role,
@@ -977,7 +963,7 @@ export async function getGrafanaConnectionCommand(
 
 export async function saveSnowflakeConnectionCommand(
   auth: UserAuthSuccess,
-  input: SaveSnowflakeConnectionCommandInput,
+  input: SaveSnowflakeConnectionInput,
 ) {
   assertAdmin(auth);
   assertCuratedIntegrationsEnabled();
@@ -997,32 +983,16 @@ export async function saveSnowflakeConnectionCommand(
   )
     ? existingConnection.authConfig
     : null;
-  const preservingExistingCredential =
-    input.authMethod === 'password' && input.password.length === 0;
-  const nextEncryptedPassword =
-    input.authMethod === 'password'
-      ? input.password.length > 0
-        ? encrypt(input.password)
-        : existingConfig?.encryptedPassword
-      : undefined;
-  const nextEncryptedPrivateKey =
-    input.authMethod === 'key_pair'
-      ? input.privateKey.trim().length > 0
-        ? encrypt(input.privateKey)
-        : existingConfig?.encryptedPrivateKey
-      : preservingExistingCredential
-        ? existingConfig?.encryptedPrivateKey
-        : undefined;
+  const providedPrivateKey = input.privateKey.trim().length > 0;
+  const nextEncryptedPrivateKey = providedPrivateKey
+    ? encrypt(input.privateKey)
+    : existingConfig?.encryptedPrivateKey;
   const nextEncryptedPrivateKeyPassphrase =
-    input.authMethod === 'key_pair'
-      ? input.privateKeyPassphrase.length > 0
-        ? encrypt(input.privateKeyPassphrase)
-        : input.privateKey.trim().length > 0
-          ? undefined
-          : existingConfig?.encryptedPrivateKeyPassphrase
-      : preservingExistingCredential
-        ? existingConfig?.encryptedPrivateKeyPassphrase
-        : undefined;
+    input.privateKeyPassphrase.length > 0
+      ? encrypt(input.privateKeyPassphrase)
+      : providedPrivateKey
+        ? undefined
+        : existingConfig?.encryptedPrivateKeyPassphrase;
 
   const authConfig = {
     type: 'snowflake' as const,
@@ -1039,9 +1009,6 @@ export async function saveSnowflakeConnectionCommand(
       : existingConfig?.database
         ? { database: existingConfig.database }
         : {}),
-    ...(nextEncryptedPassword
-      ? { encryptedPassword: nextEncryptedPassword }
-      : {}),
     ...(nextEncryptedPrivateKey
       ? { encryptedPrivateKey: nextEncryptedPrivateKey }
       : {}),
@@ -1056,17 +1023,7 @@ export async function saveSnowflakeConnectionCommand(
       : {}),
   };
 
-  if (
-    input.authMethod === 'password' &&
-    !authConfig.encryptedPassword &&
-    !authConfig.encryptedPrivateKey
-  ) {
-    throw new Error(
-      'Programmatic Access Token is required when no Snowflake credential is already stored.',
-    );
-  }
-
-  if (input.authMethod === 'key_pair' && !authConfig.encryptedPrivateKey) {
+  if (!authConfig.encryptedPrivateKey) {
     throw new Error(
       'Private key is required when no Snowflake key pair is already stored.',
     );
@@ -1127,9 +1084,6 @@ export async function saveSnowflakeConnectionCommand(
   }
 
   return {
-    authMethod: nextEncryptedPrivateKey
-      ? ('key_pair' as const)
-      : ('password' as const),
     account: authConfig.account,
     username: authConfig.username,
     role: authConfig.role,

--- a/apps/web/src/types/mcp-connections.ts
+++ b/apps/web/src/types/mcp-connections.ts
@@ -5,10 +5,8 @@ const requiredSnowflakeField = (label: string) =>
   z.string().trim().min(1, `${label} is required`);
 
 export const saveSnowflakeConnectionSchema = z.object({
-  authMethod: z.literal('key_pair').default('key_pair'),
   account: requiredSnowflakeField('Account identifier'),
   username: requiredSnowflakeField('Username'),
-  password: z.string().default(''),
   privateKey: z.string(),
   privateKeyPassphrase: z.string(),
   role: requiredSnowflakeField('Role'),

--- a/packages/sdk/src/server/routers/mcp-connections.test.ts
+++ b/packages/sdk/src/server/routers/mcp-connections.test.ts
@@ -449,7 +449,7 @@ describe('mcpConnectionsRouter.getMcpServerConfigs', () => {
           username: 'roomote',
           role: 'ANALYST',
           warehouse: 'ROOMOTE_WH',
-          encryptedPassword: 'enc:secret',
+          encryptedPrivateKey: 'enc:private-key',
         },
       }),
     ]);
@@ -832,7 +832,7 @@ describe('mcpConnectionsRouter.getMcpServerConfigs', () => {
           account: 'xy12345.us-east-1',
           username: 'roomote',
           role: 'ANALYST',
-          encryptedPassword: 'enc:secret',
+          encryptedPrivateKey: 'enc:private-key',
         },
       }),
     ]);

--- a/packages/types/src/mcp-oauth.ts
+++ b/packages/types/src/mcp-oauth.ts
@@ -95,8 +95,9 @@ export interface McpConnectionOAuthConfig {
 /**
  * Organization-scoped Snowflake connection config stored in mcpConnections.authConfig.
  *
- * Secrets are expected to be encrypted before persistence. The current backend
- * accepts both encrypted and plaintext secret values so a later admin flow can
+ * Snowflake connections authenticate with a key pair only. Secrets are
+ * expected to be encrypted before persistence. The current backend accepts
+ * both encrypted and plaintext secret values so a later admin flow can
  * migrate the write path without breaking existing rows.
  */
 export interface McpConnectionSnowflakeConfig {
@@ -107,7 +108,6 @@ export interface McpConnectionSnowflakeConfig {
   warehouse?: string;
   database?: string;
   schema?: string;
-  encryptedPassword?: string;
   encryptedPrivateKey?: string;
   encryptedPrivateKeyPassphrase?: string;
   allowedStatementTypes?: string[];


### PR DESCRIPTION
Supersedes #1664 (rebased onto current develop, CodeQL alert resolved).

## What's broken

`snowflake-sdk` only applies `privateKeyPass` when it loads a key from `privateKeyPath`. An inline `privateKey` is passed straight to `jwt.sign`, so an encrypted PKCS8 private key pasted into **Settings > Integrations > Snowflake** saves fine but every task fails at connect time. Unencrypted keys have always worked.

## What changed

- Decrypts encrypted PKCS8 private keys in API memory with Node crypto and passes the SDK a normalized unencrypted PKCS8 key.
- Accepts only RSA keys with a modulus of at least 2048 bits; malformed keys, wrong passphrases, unsupported key types, and SDK failures return credential-safe errors.
- Masks the passphrase input in Settings.
- Documents secure key generation and staged rotation in the Snowflake integration docs.
- Removes the dead password/PAT fallback that was never reachable from the UI: the `encryptedPassword` config field, the `password` and `authMethod` inputs, the legacy save branch, and the password-based tests. Snowflake connections are key-pair only.
- Uses a static 1024-bit test fixture instead of generating a weak key at runtime, so CodeQL no longer flags the minimum-key-size test.

## Verification

- `apps/api` Snowflake auth suite: 13 tests pass (encrypted and unencrypted RSA keys, wrong passphrase, EC key rejection, weak key rejection, error redaction).
- `apps/web` Integrations settings suite: 68 tests pass; mcp-connections command tests pass.
- `packages/sdk` mcp-connections router suite: 36 tests pass.
- `pnpm lint:fast`, `pnpm check-types`, and `pnpm knip` pass.
- A live Snowflake JWT login was not run from this environment; production acceptance still needs a controlled smoke test against a real account.
