### PR TITLE
[Improve] Match the Skills settings list to the Automations UI

### DIFF
--- a/apps/web/src/components/settings/InstanceSkills.client.test.tsx
+++ b/apps/web/src/components/settings/InstanceSkills.client.test.tsx
@@ -17,6 +17,7 @@ const { state, createMock, updateMock, deleteMock } = vi.hoisted(() => ({
         description: 'My instructions',
         content: '# My skill body',
         canManage: true,
+        createdByName: 'Me',
       },
       {
         id: '00000000-0000-4000-8000-000000000002',
@@ -24,6 +25,7 @@ const { state, createMock, updateMock, deleteMock } = vi.hoisted(() => ({
         description: 'Another member created this',
         content: '# Shared skill body',
         canManage: false,
+        createdByName: 'Teammate',
       },
     ],
     isAdmin: false,
@@ -154,46 +156,35 @@ it('makes Skills navigation and creation available to members without environmen
 it('lets members view every body but only manage skills authorized by the server', async () => {
   renderSkills();
   await screen.findByText('my-skill');
+  const list = screen.getByRole('list', { name: 'Shared skills' });
+  expect(within(list).getByText('Created by Me')).toBeInTheDocument();
+  expect(within(list).getByText('Created by Teammate')).toBeInTheDocument();
   expect(
-    within(screen.getByRole('list', { name: 'Shared skills' })).getAllByRole(
-      'button',
-    ),
-  ).toHaveLength(2);
+    within(list).getByRole('button', { name: 'Edit my-skill' }),
+  ).toBeInTheDocument();
   expect(
-    screen.queryByRole('button', { name: /^Edit |^Delete / }),
+    within(list).getByRole('button', { name: 'Delete my-skill' }),
+  ).toBeInTheDocument();
+  expect(
+    within(list).queryByRole('button', { name: 'Edit shared-skill' }),
+  ).not.toBeInTheDocument();
+  expect(
+    within(list).queryByRole('button', { name: 'Delete shared-skill' }),
   ).not.toBeInTheDocument();
   fireEvent.click(screen.getByText('my-skill'));
   const ownedDialog = screen.getByRole('dialog');
   expect(within(ownedDialog).getByText('# My skill body')).toBeInTheDocument();
-  expect(
-    within(ownedDialog).getByRole('button', { name: 'Edit my-skill' }),
-  ).toBeInTheDocument();
-  expect(
-    within(ownedDialog).getByRole('button', { name: 'Delete my-skill' }),
-  ).toBeInTheDocument();
   fireEvent.click(
     within(ownedDialog).getAllByRole('button', { name: 'Close' })[0]!,
   );
   fireEvent.click(screen.getByText('shared-skill'));
   expect(
-    screen.queryByRole('button', { name: 'Edit shared-skill' }),
-  ).not.toBeInTheDocument();
-  expect(
-    screen.queryByRole('button', { name: 'Delete shared-skill' }),
-  ).not.toBeInTheDocument();
-  expect(
     within(screen.getByRole('dialog')).getByText('# Shared skill body'),
   ).toBeInTheDocument();
-  expect(
-    within(screen.getByRole('dialog')).queryByRole('button', {
-      name: /^Edit|^Delete/,
-    }),
-  ).not.toBeInTheDocument();
 });
 
 it('shows document-size validation instead of silently refusing to save', async () => {
   renderSkills();
-  fireEvent.click(await screen.findByRole('button', { name: 'View my-skill' }));
   fireEvent.click(await screen.findByRole('button', { name: 'Edit my-skill' }));
   const dialog = screen.getByRole('dialog');
   fireEvent.change(within(dialog).getByLabelText('Content'), {
@@ -209,7 +200,6 @@ it('shows document-size validation instead of silently refusing to save', async 
 
 it('updates a creator skill and invalidates the catalog', async () => {
   const { invalidate } = renderSkills();
-  fireEvent.click(await screen.findByRole('button', { name: 'View my-skill' }));
   fireEvent.click(await screen.findByRole('button', { name: 'Edit my-skill' }));
   const dialog = screen.getByRole('dialog');
   expect(within(dialog).getByLabelText('Content')).toHaveValue(
@@ -231,7 +221,6 @@ it('updates a creator skill and invalidates the catalog', async () => {
 
 it('requires confirmation before deleting and refreshes the catalog', async () => {
   const { invalidate } = renderSkills();
-  fireEvent.click(await screen.findByRole('button', { name: 'View my-skill' }));
   fireEvent.click(
     await screen.findByRole('button', { name: 'Delete my-skill' }),
   );
@@ -240,7 +229,6 @@ it('requires confirmation before deleting and refreshes the catalog', async () =
     within(screen.getByRole('dialog')).getByRole('button', { name: 'Cancel' }),
   );
   expect(deleteMock).not.toHaveBeenCalled();
-  fireEvent.click(screen.getByRole('button', { name: 'View my-skill' }));
   fireEvent.click(screen.getByRole('button', { name: 'Delete my-skill' }));
   fireEvent.click(
     within(screen.getByRole('dialog')).getByRole('button', {

--- a/apps/web/src/components/settings/InstanceSkills.tsx
+++ b/apps/web/src/components/settings/InstanceSkills.tsx
@@ -9,14 +9,16 @@ import type { z } from 'zod';
 import { toast } from 'sonner';
 import { useTRPC } from '@/trpc/client';
 import {
+  BasicTooltip,
   Button,
+  Card,
+  CardContent,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  EmptyState,
   ErrorState,
   Form,
   FormControl,
@@ -32,7 +34,11 @@ import {
 } from '@/components/system';
 
 type SkillDefinition = z.infer<typeof createCustomSkillInputSchema>;
-type Skill = SkillDefinition & { id: string; canManage: boolean };
+type Skill = SkillDefinition & {
+  id: string;
+  canManage: boolean;
+  createdByName?: string | null;
+};
 
 function SkillEditor({
   skill,
@@ -216,40 +222,94 @@ export function InstanceSkills({
   return (
     <>
       {list.isPending ? (
-        <div className="space-y-2">
-          <Skeleton className="h-16 w-full" />
-          <Skeleton className="h-16 w-full" />
-        </div>
+        <Card variant="snug" data-testid="shared-skills-skeleton">
+          <CardContent>
+            <div className="divide-y divide-background">
+              {Array.from({ length: 2 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="flex items-start gap-3 py-3 first:pt-0 last:pb-0"
+                >
+                  <div className="flex-1 space-y-2">
+                    <Skeleton className="h-4 w-48" />
+                    <Skeleton className="h-3 w-full max-w-lg" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
       ) : list.isError ? (
         <ErrorState
           title="Failed to load skills"
           description={list.error.message}
         />
       ) : list.data.length === 0 ? (
-        <EmptyState
-          title="No shared skills yet"
-          description="Add a skill to share reusable instructions with your team."
-        />
+        <p className="text-sm text-muted-foreground">
+          No shared skills yet. Add a skill to share reusable instructions with
+          your team.
+        </p>
       ) : (
-        <ul className="divide-y" aria-label="Shared skills">
-          {list.data.map((skill) => (
-            <li key={skill.id} className="py-3">
-              <button
-                type="button"
-                className="block w-full min-w-0 rounded-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                onClick={() => setViewing(skill)}
-                aria-label={`View ${skill.name}`}
-              >
-                <span className="block break-words font-medium hover:underline">
-                  {skill.name}
-                </span>
-                <span className="line-clamp-2 break-words text-sm text-muted-foreground">
-                  {skill.description}
-                </span>
-              </button>
-            </li>
-          ))}
-        </ul>
+        <Card variant="snug">
+          <CardContent>
+            <ul
+              className="divide-y divide-background"
+              aria-label="Shared skills"
+            >
+              {list.data.map((skill) => (
+                <li
+                  key={skill.id}
+                  className="flex items-start justify-between gap-3 py-3 first:pt-0 last:pb-0"
+                >
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 space-y-1 rounded-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    onClick={() => setViewing(skill)}
+                    aria-label={`View ${skill.name}`}
+                  >
+                    <span className="block break-words text-sm font-semibold hover:underline">
+                      {skill.name}
+                    </span>
+                    <span className="line-clamp-2 break-words text-sm text-muted-foreground">
+                      {skill.description}
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      Created by {skill.createdByName ?? 'Unknown'}
+                    </span>
+                  </button>
+                  <div className="flex shrink-0 items-center gap-1">
+                    {skill.canManage ? (
+                      <>
+                        <BasicTooltip content="Edit">
+                          <Button
+                            type="button"
+                            size="icon"
+                            variant="ghost"
+                            aria-label={`Edit ${skill.name}`}
+                            onClick={() => setEditor({ skill })}
+                          >
+                            <Pencil />
+                          </Button>
+                        </BasicTooltip>
+                        <BasicTooltip content="Delete">
+                          <Button
+                            type="button"
+                            size="icon"
+                            variant="ghost"
+                            aria-label={`Delete ${skill.name}`}
+                            onClick={() => setDeleting(skill)}
+                          >
+                            <Trash2 />
+                          </Button>
+                        </BasicTooltip>
+                      </>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
       )}
       {editor ? (
         <SkillEditor skill={editor.skill} onClose={() => setEditor(null)} />
@@ -270,29 +330,6 @@ export function InstanceSkills({
             {viewing?.content}
           </pre>
           <DialogFooter>
-            {viewing?.canManage ? (
-              <>
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setDeleting(viewing);
-                    setViewing(null);
-                  }}
-                  aria-label={`Delete ${viewing.name}`}
-                >
-                  <Trash2 /> Delete
-                </Button>
-                <Button
-                  onClick={() => {
-                    setEditor({ skill: viewing });
-                    setViewing(null);
-                  }}
-                  aria-label={`Edit ${viewing.name}`}
-                >
-                  <Pencil /> Edit
-                </Button>
-              </>
-            ) : null}
             <Button variant="outline" onClick={() => setViewing(null)}>
               Close
             </Button>

--- a/apps/web/src/components/settings/pages/SkillsSettingsPage.tsx
+++ b/apps/web/src/components/settings/pages/SkillsSettingsPage.tsx
@@ -12,8 +12,8 @@ export function SkillsSettingsPage() {
       pageId="skills"
       showHeaderActionOnMobile
       headerAction={
-        <Button onClick={() => setIsCreating(true)}>
-          <Plus />
+        <Button size="sm" onClick={() => setIsCreating(true)}>
+          <Plus className="size-4" />
           Add Skill
         </Button>
       }

--- a/apps/web/src/trpc/routers/instance-skills.test.ts
+++ b/apps/web/src/trpc/routers/instance-skills.test.ts
@@ -78,7 +78,12 @@ describe('instanceSkills router with real database authorization', () => {
 
     for (const auth of [memberAuth, otherAuth, adminAuth]) {
       expect(await caller(auth).list()).toEqual(
-        expect.arrayContaining([expect.objectContaining({ name: input.name })]),
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: input.name,
+            createdByName: expect.any(String),
+          }),
+        ]),
       );
       expect(await caller(auth).get({ skillId })).toMatchObject({
         ...input,

--- a/packages/db/src/lib/__tests__/custom-skills.test.ts
+++ b/packages/db/src/lib/__tests__/custom-skills.test.ts
@@ -111,6 +111,7 @@ it('lets members create instance skills and exposes full records with actor-spec
     });
     expect(await listCustomSkills(actor)).toContainEqual({
       ...stored,
+      createdByName: expect.any(String),
       canManage,
     });
   }

--- a/packages/db/src/lib/custom-skills.ts
+++ b/packages/db/src/lib/custom-skills.ts
@@ -66,11 +66,17 @@ export async function listCustomSkills(actorUserId: string) {
   return db.transaction(async (tx) => {
     const actor = await requireMember(tx, actorUserId);
     const skills = await tx
-      .select()
+      .select({
+        skill: instanceSkills,
+        createdByName: users.name,
+        createdByEmail: users.email,
+      })
       .from(instanceSkills)
+      .leftJoin(users, eq(users.id, instanceSkills.createdByUserId))
       .orderBy(asc(instanceSkills.name));
-    return skills.map((skill) => ({
+    return skills.map(({ skill, createdByName, createdByEmail }) => ({
       ...skill,
+      createdByName: createdByName || createdByEmail || null,
       canManage: actor.role === 'admin' || skill.createdByUserId === actor.id,
     }));
   });


### PR DESCRIPTION
## Summary
- Render shared skills in the same snug card rows used by custom automations on `/automations`: semibold name, muted description, and right-aligned ghost icon actions with tooltips.
- Move Edit and Delete onto each row (only for skills the user can manage). The view dialog keeps the content preview and a Close button; clicking the name still opens it.
- Show `Created by <name>` on each row, matching automation rows. The list query left-joins users and returns `createdByName` (name, falling back to email).
- Size the Add Skill header button like the automations New button.
- Loading skeleton and empty state follow the automations styling.

## Testing
- Client, router, and db skill test suites updated and passing.
- `tsc` clean for `@roomote/db`, `@roomote/web`, and `@roomote/cloud-agents`; oxlint and oxfmt pass; pre-push suite passed.
- Verified visually on a local instance against `/automations`.