### PR TITLE
[Fix] Sentry MCP exposes almost no tools behind the catalog gateway

### DIFF
--- a/apps/docs/integrations/sentry.mdx
+++ b/apps/docs/integrations/sentry.mdx
@@ -15,13 +15,30 @@ performance context from production.
 
 ## How setup works
 
-Admins connect Sentry once from **Settings > Integrations**.
+Admins connect Sentry once from **Settings > Integrations**. Sentry's consent
+screen lists four access groups, all selected by default:
+
+- **Inspect Issues & Events** is read-only: issues, events, traces, replays,
+  releases, monitors, profiles, documentation, and project metadata.
+- **Seer**, **Triage Issues**, and **Manage Projects & Teams** grant write
+  access: AI analysis runs, resolving and assigning issues, and creating or
+  editing projects, teams, DSNs, and uptime monitors.
+
+Roomote does not restrict the connection beyond what you approve there. For a
+read-only connection, leave only **Inspect Issues & Events** selected. You can
+also disable individual tools afterwards from the integration's tool settings.
+Most Sentry operations run through the `execute_sentry_tool` gateway, so
+disabling that tool removes the whole catalog rather than a single operation.
 
 ## What to expect
 
 Sentry gives Roomote incident and performance context during a task. It can also
-support scheduled read-only Sentry triage. The final decision, code change, and
-review still happen in the normal task and repository flow.
+support scheduled Sentry triage. The final decision, code change, and review
+still happen in the normal task and repository flow.
+
+Roomote agents are instructed to treat Sentry as read-only unless a request
+explicitly asks them to change Sentry state. That instruction is not enforced
+by Roomote; the access you approve on Sentry's consent screen is the boundary.
 
 ## Scope a triage request
 

--- a/packages/types/src/__tests__/mcp-tool-policy.test.ts
+++ b/packages/types/src/__tests__/mcp-tool-policy.test.ts
@@ -125,3 +125,15 @@ describe('monday.com MCP tool policy', () => {
     expect(allowedToolNames).not.toContain('all_monday_api');
   });
 });
+
+describe('Sentry MCP tool policy', () => {
+  it('does not allowlist tool names', () => {
+    // mcp.sentry.dev is catalog-first: tools/list advertises a small top-level
+    // surface and everything else runs through execute_sentry_tool, so a
+    // static name list silently hides most of the server. Read-only access is
+    // chosen by the admin in Sentry's consent dialog (the "Inspect Issues &
+    // Events" skill) and narrowed further with the per-deployment disabled
+    // tools list.
+    expect(getAllowedIntegrationMcpToolNames('sentry')).toBeUndefined();
+  });
+});

--- a/packages/types/src/mcp-oauth.ts
+++ b/packages/types/src/mcp-oauth.ts
@@ -507,6 +507,8 @@ export const MCP_INTEGRATIONS: McpIntegration[] = [
     description: `Enable Sentry so this deployment can access alerts and performance indicators from ${PRODUCT_NAME} tasks.`,
     icon: 'sentry',
     connectionScope: 'deployment',
+    instructions:
+      'Sentry advertises only a few tools directly (find_organizations, find_projects, search_issues, search_events, get_sentry_resource). Reach everything else (issue details, event stack traces, breadcrumbs, tag values, issue events, releases, traces, replays, attachments, monitors, alert rules, docs) by calling search_sentry_tools with a short query, then execute_sentry_tool with the returned tool name and arguments. Which tools exist depends on the access the admin granted when connecting. Treat Sentry as read-only unless the request explicitly asks to change Sentry state: do not resolve, assign, ignore, or otherwise update issues, and do not create or modify projects, teams, DSNs, or monitors on your own initiative.',
   },
   {
     id: 'pylon',

--- a/packages/types/src/mcp-tool-policy.ts
+++ b/packages/types/src/mcp-tool-policy.ts
@@ -96,27 +96,6 @@ const PYLON_READ_ONLY_TOOL_NAMES = [
   'get_account',
 ] as const;
 
-const SENTRY_READ_ONLY_TOOL_NAMES = [
-  'whoami',
-  'find_organizations',
-  'find_teams',
-  'find_projects',
-  'find_releases',
-  'get_issue_details',
-  'get_issue_tag_values',
-  'get_trace_details',
-  'get_replay_details',
-  'get_event_attachment',
-  'search_events',
-  'find_dsns',
-  'search_docs',
-  'get_doc',
-  'search_issues',
-  'search_issue_events',
-  'get_profile_details',
-  'get_sentry_resource',
-] as const;
-
 const JIRA_SHARED_TOOL_NAMES = [
   'atlassianUserInfo',
   'getAccessibleAtlassianResources',
@@ -218,7 +197,10 @@ const INTEGRATION_MCP_ALLOWED_TOOL_NAMES: Readonly<
   monday: MONDAY_READ_ONLY_TOOL_NAMES,
   pylon: PYLON_READ_ONLY_TOOL_NAMES,
   railway: RAILWAY_READ_ONLY_TOOL_NAMES,
-  sentry: SENTRY_READ_ONLY_TOOL_NAMES,
+  // Sentry is intentionally absent: mcp.sentry.dev is catalog-first, so
+  // tools/list advertises a small top-level surface and everything else runs
+  // through execute_sentry_tool. A static name list silently hid most of the
+  // server. Access is chosen by the admin in Sentry's consent dialog instead.
   x: X_READ_ONLY_TOOL_NAMES,
 };
 


### PR DESCRIPTION
## Problem

Deployments with Sentry connected keep filing platform issues like "Sentry integration connected, but discovery for issue details, events, releases, and stack traces returned zero tools."

Sentry's hosted MCP server (`mcp.sentry.dev`) became catalog-first in June 2026 ([getsentry/sentry-mcp#1067](https://github.com/getsentry/sentry-mcp/pull/1067), renamed in [#1085](https://github.com/getsentry/sentry-mcp/pull/1085)). `tools/list` now advertises only nine top-level tools, and every other catalog operation (`get_issue_details`, `get_event_stacktrace`, `find_releases`, `get_issue_tag_values`, `search_issue_events`, `get_trace_details`, ...) is reached by naming it in `execute_sentry_tool`.

Our Sentry read-only allowlist is an intersection filter on `tools/list`. It did not include `search_sentry_tools` / `execute_sentry_tool`, and 13 of its 18 names no longer appear upstream. Net result: a connected Sentry exposed exactly five tools, the proxy returned success, and agents concluded the integration was broken.

## Fix

Drop the Sentry allowlist instead of chasing upstream names. Static name lists have now silently broken three integrations (Better Stack in #1192, X, and Sentry), and a name-based guard cannot see through the `execute_sentry_tool` gateway anyway.

Read-only is now the admin's choice on Sentry's consent screen. It lists four access groups, all selected by default; only **Inspect Issues & Events** is read-only, while **Seer**, **Triage Issues**, and **Manage Projects & Teams** grant writes. The per-deployment disabled-tools list still narrows what is advertised.

- `packages/types/src/mcp-tool-policy.ts`: remove `SENTRY_READ_ONLY_TOOL_NAMES` and the `sentry` allowlist entry, with a comment explaining why. A test guards against re-adding one.
- `packages/types/src/mcp-oauth.ts`: Sentry `instructions` tell agents (sandbox and Fast) to discover with `search_sentry_tools` and run with `execute_sentry_tool`, that availability depends on what the admin granted, and to treat Sentry as read-only unless a request explicitly asks to change state.
- `apps/docs/integrations/sentry.mdx`: document the consent-screen groups, how to get a read-only connection, that disabling `execute_sentry_tool` removes the whole catalog, and that the read-only behaviour is instruction-based rather than enforced by Roomote.

No proxy or policy-engine changes. Other allowlisted integrations are untouched.

## Validation

- `packages/types` policy tests, `apps/api` MCP proxy tests, and `apps/web` mcp-connections tests pass.
- `pnpm lint:fast`, `pnpm check-types:fast`, `pnpm knip` clean.
