### PR TITLE
[Improve] Show full recent session titles on hover

### DIFF
--- a/apps/web/src/components/layout/side-nav/SideNavSessionItem.tsx
+++ b/apps/web/src/components/layout/side-nav/SideNavSessionItem.tsx
@@ -25,7 +25,10 @@ export function SideNavSessionItem({
           : 'text-muted-foreground hover:text-accent-foreground',
       )}
     >
-      <span className="min-w-0 flex-1 line-clamp-1 text-sm font-medium leading-5 wrap-break-word">
+      <span
+        title={session.title}
+        className="min-w-0 flex-1 line-clamp-1 text-sm font-medium leading-5 wrap-break-word"
+      >
         {session.title}
       </span>
     </Link>


### PR DESCRIPTION
## Why this PR exists

- [x] I am a maintainer / this is internal Roomote work

## What changed

Recent session titles in the expanded sidebar now show the full title on hover, using the same native `title` tooltip as the session header.

## How it was tested

Manual: expand the sidebar, hover a truncated Recent sessions title, and confirm the full title appears without changing navigation.

## Screenshots

**Copied this existing experience:**
<img width="589" height="101" alt="existing_behavior" src="https://github.com/user-attachments/assets/83e9c226-a6b3-4340-a01d-88381950043c" />

**And applied it to the Recent tasks sidebar:**
<img width="286" height="275" alt="new_recent_sessions_tooltip" src="https://github.com/user-attachments/assets/d3940124-e5fe-4df8-87c8-ec17a77ad2a9" />

## Checklist

- [x] The PR title follows the repo convention
- [x] This PR is small and scoped to one change
- [x] `pnpm lint` and `pnpm check-types` pass locally
- [x] I added tests or included a clear manual validation note above
- [x] I removed secrets, tokens, private keys, and customer data from code, logs, and screenshots
- [ ] If this change should appear in the changelog, I ran `pnpm changeset`


Made with [Cursor](https://cursor.com)