### PR TITLE
[Fix] Voice previews fail silently on restricted OpenAI keys

### DIFF
--- a/.changeset/voice-preview-permission.md
+++ b/.changeset/voice-preview-permission.md
@@ -1,0 +1,5 @@
+---
+"@roomote/web": patch
+---
+
+Voice previews now say when the OpenAI key lacks the Audio model permission instead of a generic failure.

--- a/apps/docs/integrations/voice.mdx
+++ b/apps/docs/integrations/voice.mdx
@@ -15,7 +15,10 @@ separate from any key used for task inference, so voice can be billed and
 revoked on its own.
 
 The setup dialog also lets the admin choose any voice supported by GPT-Live and
-play a short AI-generated preview before saving. New and previously unset
+play a short AI-generated preview before saving. Previews use OpenAI's speech
+endpoint, so a restricted key needs the **Audio** model permission
+(`api.model.audio.request`) in addition to GPT-Live access; without it, calls
+still work and the dialog says what the key is missing. New and previously unset
 connections use Marin, one of OpenAI's recommended voices. Existing voice
 selections stay unchanged.
 

--- a/apps/web/src/components/settings/Integrations.tsx
+++ b/apps/web/src/components/settings/Integrations.tsx
@@ -1270,6 +1270,14 @@ function VoiceConnectionFields({
               {OPENAI_REALTIME_VOICE_OPTIONS.map((option) => (
                 <SelectItem key={option.id} value={option.id}>
                   {option.label}
+                  {option.recommended ? (
+                    <span
+                      className="ml-2 text-xs text-muted-foreground"
+                      aria-hidden="true"
+                    >
+                      Recommended
+                    </span>
+                  ) : null}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/apps/web/src/lib/server/voice.test.ts
+++ b/apps/web/src/lib/server/voice.test.ts
@@ -42,6 +42,7 @@ import {
   cleanVoiceTranscript,
   createVoiceLiveSession,
   createVoicePreview,
+  VoicePreviewPermissionError,
   resolveVoiceOpenAiKey,
   resolveVoiceId,
 } from './voice';
@@ -286,5 +287,30 @@ describe('resolveVoiceId', () => {
 
     findConnection.mockResolvedValue(null);
     await expect(resolveVoiceId()).resolves.toBe('marin');
+  });
+});
+
+describe('createVoicePreview permission errors', () => {
+  it('names the missing Audio permission when a restricted key is rejected', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              message:
+                'You have insufficient permissions for this operation. Missing scopes: api.model.audio.request.',
+              type: 'invalid_request_error',
+              code: 'missing_scope',
+            },
+          }),
+          { status: 401 },
+        ),
+      ),
+    );
+
+    await expect(
+      createVoicePreview({ apiKey: 'sk-restricted', voiceId: 'marin' }),
+    ).rejects.toBeInstanceOf(VoicePreviewPermissionError);
   });
 });

--- a/apps/web/src/lib/server/voice.test.ts
+++ b/apps/web/src/lib/server/voice.test.ts
@@ -313,4 +313,32 @@ describe('createVoicePreview permission errors', () => {
       createVoicePreview({ apiKey: 'sk-restricted', voiceId: 'marin' }),
     ).rejects.toBeInstanceOf(VoicePreviewPermissionError);
   });
+
+  it('keeps the upstream error for a missing scope other than Audio', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              message:
+                'You have insufficient permissions for this operation. Missing scopes: model.request.',
+              type: 'invalid_request_error',
+              code: 'missing_scope',
+            },
+          }),
+          { status: 401 },
+        ),
+      ),
+    );
+
+    const failure = await createVoicePreview({
+      apiKey: 'sk-restricted',
+      voiceId: 'marin',
+    }).catch((error: unknown) => error);
+    expect(failure).not.toBeInstanceOf(VoicePreviewPermissionError);
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain('status 401');
+    expect((failure as Error).message).toContain('model.request');
+  });
 });

--- a/apps/web/src/lib/server/voice.ts
+++ b/apps/web/src/lib/server/voice.ts
@@ -271,11 +271,9 @@ export async function createVoicePreview(options: {
 
   if (!response.ok) {
     const body = (await response.text().catch(() => '')).slice(0, 2_000);
-    if (
-      response.status === 401 &&
-      (body.includes('"missing_scope"') ||
-        body.includes('api.model.audio.request'))
-    ) {
+    // Only the Audio model permission has a known remedy. Any other missing
+    // scope surfaces as the upstream error so the admin sees what OpenAI said.
+    if (response.status === 401 && body.includes('api.model.audio.request')) {
       throw new VoicePreviewPermissionError();
     }
     throw new Error(

--- a/apps/web/src/lib/server/voice.ts
+++ b/apps/web/src/lib/server/voice.ts
@@ -237,6 +237,19 @@ export async function createVoiceLiveSession(options: {
   return { sessionId: payload.session.id, sdp: payload.transport.sdp };
 }
 
+/**
+ * The key can open GPT-Live calls but is a restricted OpenAI key without the
+ * Audio model permission that the speech endpoint needs for previews.
+ */
+export class VoicePreviewPermissionError extends Error {
+  constructor() {
+    super(
+      'This OpenAI key cannot generate voice previews. In OpenAI, give the key the Audio model permission (api.model.audio.request) or use an unrestricted key. Voice calls work without it.',
+    );
+    this.name = 'VoicePreviewPermissionError';
+  }
+}
+
 export async function createVoicePreview(options: {
   apiKey: string;
   voiceId: OpenAiRealtimeVoiceId;
@@ -258,6 +271,13 @@ export async function createVoicePreview(options: {
 
   if (!response.ok) {
     const body = (await response.text().catch(() => '')).slice(0, 2_000);
+    if (
+      response.status === 401 &&
+      (body.includes('"missing_scope"') ||
+        body.includes('api.model.audio.request'))
+    ) {
+      throw new VoicePreviewPermissionError();
+    }
     throw new Error(
       `OpenAI voice preview request failed with status ${response.status}: ${body}`,
     );

--- a/apps/web/src/trpc/commands/voice/index.test.ts
+++ b/apps/web/src/trpc/commands/voice/index.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
 
+import { VoicePreviewPermissionError } from '@/lib/server/voice';
+
 const {
   mockResolveVoiceOpenAiKey,
   mockCreateVoiceLiveSession,
@@ -15,7 +17,11 @@ const {
   mockResolveVoiceId: vi.fn(),
 }));
 
-vi.mock('@/lib/server/voice', () => ({
+vi.mock('@/lib/server/voice', async (importOriginal) => ({
+  // The real error class so the command's instanceof check works.
+  VoicePreviewPermissionError: (
+    await importOriginal<typeof import('@/lib/server/voice')>()
+  ).VoicePreviewPermissionError,
   resolveVoiceOpenAiKey: mockResolveVoiceOpenAiKey,
   createVoiceLiveSession: mockCreateVoiceLiveSession,
   createVoicePreview: mockCreateVoicePreview,
@@ -150,6 +156,19 @@ describe('previewVoiceCommand', () => {
       voiceId: 'cedar',
     });
     expect(mockResolveVoiceOpenAiKey).not.toHaveBeenCalled();
+  });
+
+  it('tells the admin what permission the key is missing for previews', async () => {
+    mockCreateVoicePreview.mockRejectedValue(new VoicePreviewPermissionError());
+
+    const error = await previewVoiceCommand(auth, {
+      apiKey: 'sk-restricted',
+      voiceId: 'marin',
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(TRPCError);
+    expect((error as TRPCError).code).toBe('PRECONDITION_FAILED');
+    expect((error as TRPCError).message).toContain('Audio model permission');
   });
 
   it('uses the stored key when editing with a blank key', async () => {

--- a/apps/web/src/trpc/commands/voice/index.ts
+++ b/apps/web/src/trpc/commands/voice/index.ts
@@ -15,6 +15,7 @@ import { findAccessibleFastSession } from '@/lib/server/fast-sessions';
 import {
   cleanVoiceTranscript,
   createVoicePreview,
+  VoicePreviewPermissionError,
   createVoiceLiveSession,
   resolveVoiceOpenAiKey,
   resolveVoiceId,
@@ -90,6 +91,14 @@ export async function previewVoiceCommand(
   try {
     return await createVoicePreview({ apiKey, voiceId: input.voiceId });
   } catch (error) {
+    if (error instanceof VoicePreviewPermissionError) {
+      // The admin can fix this one themselves; say exactly what is missing.
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: error.message,
+        cause: error,
+      });
+    }
     console.error('[voice] Failed to create voice preview', error);
     throw new TRPCError({
       code: 'BAD_GATEWAY',

--- a/packages/types/src/__tests__/mcp-oauth.test.ts
+++ b/packages/types/src/__tests__/mcp-oauth.test.ts
@@ -318,4 +318,14 @@ describe('Voice credential-only integration', () => {
     expect(australianVoice).toBeUndefined();
     expect(DEFAULT_OPENAI_REALTIME_VOICE_ID).toBe('marin');
   });
+
+  it('lists voices alphabetically with the recommended ones marked', () => {
+    const labels = OPENAI_REALTIME_VOICE_OPTIONS.map((voice) => voice.label);
+    expect(labels).toEqual([...labels].sort((a, b) => a.localeCompare(b)));
+    expect(
+      OPENAI_REALTIME_VOICE_OPTIONS.filter((voice) => voice.recommended).map(
+        (voice) => voice.id,
+      ),
+    ).toEqual(['cedar', 'marin']);
+  });
 });

--- a/packages/types/src/mcp-oauth.ts
+++ b/packages/types/src/mcp-oauth.ts
@@ -178,18 +178,22 @@ export interface OpenAiRealtimeVoiceOption {
   recommended?: boolean;
 }
 
-/** Voice metadata documented for OpenAI Realtime sessions. */
+/**
+ * Voice metadata documented for OpenAI Realtime sessions, alphabetical for
+ * the picker. `recommended` marks OpenAI's recommended voices; the default is
+ * chosen by id below, not by position.
+ */
 export const OPENAI_REALTIME_VOICE_OPTIONS = [
   { id: 'alloy', label: 'Alloy', locale: undefined, recommended: false },
   { id: 'ash', label: 'Ash', locale: undefined, recommended: false },
   { id: 'ballad', label: 'Ballad', locale: undefined, recommended: false },
+  { id: 'cedar', label: 'Cedar', locale: undefined, recommended: true },
   { id: 'coral', label: 'Coral', locale: undefined, recommended: false },
   { id: 'echo', label: 'Echo', locale: undefined, recommended: false },
+  { id: 'marin', label: 'Marin', locale: undefined, recommended: true },
   { id: 'sage', label: 'Sage', locale: undefined, recommended: false },
   { id: 'shimmer', label: 'Shimmer', locale: undefined, recommended: false },
   { id: 'verse', label: 'Verse', locale: undefined, recommended: false },
-  { id: 'marin', label: 'Marin', locale: undefined, recommended: true },
-  { id: 'cedar', label: 'Cedar', locale: undefined, recommended: true },
 ] as const satisfies readonly OpenAiRealtimeVoiceOption[];
 
 export type OpenAiRealtimeVoiceId =
@@ -204,10 +208,11 @@ export function isOpenAiRealtimeVoiceId(
   );
 }
 
-/** Prefer a documented Australian voice, then OpenAI's first recommended voice. */
+/** Prefer a documented Australian voice, then Marin, one of OpenAI's recommended voices. */
 export const DEFAULT_OPENAI_REALTIME_VOICE_ID: OpenAiRealtimeVoiceId =
   OPENAI_REALTIME_VOICE_OPTIONS.find((option) => option.locale === 'en-AU')
     ?.id ??
+  OPENAI_REALTIME_VOICE_OPTIONS.find((option) => option.id === 'marin')?.id ??
   OPENAI_REALTIME_VOICE_OPTIONS.find((option) => option.recommended)?.id ??
   OPENAI_REALTIME_VOICE_OPTIONS[0]!.id;
 


### PR DESCRIPTION
## What changed

- When OpenAI's speech endpoint rejects a voice preview with 401 `missing_scope`, the preview command now returns a precondition error that names the missing permission: "This OpenAI key cannot generate voice previews. In OpenAI, give the key the Audio model permission (api.model.audio.request) or use an unrestricted key. Voice calls work without it." The Settings dialog shows that text under the preview button.
- Other preview failures keep the generic message and server-side log.
- Docs note that previews need the Audio model permission in addition to GPT-Live access on restricted keys.
- The voice picker is now alphabetical, with a Recommended badge on Marin and Cedar; the default stays Marin, chosen by id rather than list position.

## Why this change was made

On a deployment with a restricted voice key, every preview attempt failed with "Failed to preview voice" while calls worked, because GPT-Live and the speech endpoint are governed by different key permissions. The server log had the cause; the admin had no way to see it.

## Impact

Admins can fix the key themselves. No behavior change for keys that already have the permission.

## Verification

Voice server and command suites pass (26 tests, two new for the permission case), plus the types catalog and Integrations page suites for the ordering change; web typecheck and residual ESLint clean. The failure mode was confirmed from the deployment's web logs.

